### PR TITLE
Add validation checks for annotations

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/language/Annotation.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Annotation.java
@@ -56,7 +56,15 @@ public class Annotation extends Classifier<Annotation> {
   }
 
   public @Nullable Classifier<?> getAnnotates() {
-    Classifier<?> annotates = this.getReferenceSingleValue("annotates");
+    return this.getReferenceSingleValue("annotates");
+  }
+
+  /**
+   * An Annotation extending another annotation should not redefine annotates. So the value is
+   * effectively inherited from the super annotation.
+   */
+  public @Nullable Classifier<?> getEffectivelyAnnotated() {
+    Classifier<?> annotates = getAnnotates();
     if (annotates == null && getExtendedAnnotation() != null) {
       return getExtendedAnnotation().getAnnotates();
     } else {

--- a/core/src/main/java/io/lionweb/lioncore/java/utils/LanguageValidator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/LanguageValidator.java
@@ -166,7 +166,9 @@ public class LanguageValidator extends Validator<Language> {
         "An annotation should specify annotates or inherit it",
         annotation);
     validationResult.checkForError(
-        annotation.getExtendedAnnotation() != null && annotation.getAnnotates() != null,
+        annotation.getExtendedAnnotation() != null
+            && annotation.getAnnotates() != null
+            && annotation.getAnnotates() != annotation.getExtendedAnnotation().getAnnotates(),
         "A sub annotation should not define annotates",
         annotation);
     validationResult.checkForError(

--- a/core/src/main/java/io/lionweb/lioncore/java/utils/LanguageValidator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/LanguageValidator.java
@@ -162,8 +162,17 @@ public class LanguageValidator extends Validator<Language> {
 
   private void checkAnnotates(Annotation annotation, ValidationResult validationResult) {
     validationResult.checkForError(
-        annotation.getAnnotates() == null,
+        annotation.getEffectivelyAnnotated() == null,
         "An annotation should specify annotates or inherit it",
+        annotation);
+    validationResult.checkForError(
+        annotation.getExtendedAnnotation() != null && annotation.getAnnotates() != null,
+        "A sub annotation should not define annotates",
+        annotation);
+    validationResult.checkForError(
+        annotation.getExtendedAnnotation() != null
+            && annotation.isMultiple() != annotation.getExtendedAnnotation().isMultiple(),
+        "A sub annotation should have the same multiple value as the super annotation",
         annotation);
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/utils/LanguageValidator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/LanguageValidator.java
@@ -169,7 +169,7 @@ public class LanguageValidator extends Validator<Language> {
         annotation.getExtendedAnnotation() != null
             && annotation.getAnnotates() != null
             && annotation.getAnnotates() != annotation.getExtendedAnnotation().getAnnotates(),
-        "A sub annotation should not define annotates",
+        "When a sub annotation specify a value for annotates it must be the same value the super annotation specifies",
         annotation);
     validationResult.checkForError(
         annotation.getExtendedAnnotation() != null

--- a/core/src/test/java/io/lionweb/lioncore/java/language/AnnotationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/language/AnnotationTest.java
@@ -121,7 +121,8 @@ public class AnnotationTest extends BaseTest {
     assertLanguageIsNotValid(language);
 
     annotation.setExtendedAnnotation(superAnnotation);
-    assertEquals(myConcept, annotation.getAnnotates());
+    assertEquals(null, annotation.getAnnotates());
+    assertEquals(myConcept, annotation.getEffectivelyAnnotated());
     assertNodeTreeIsValid(annotation);
     assertLanguageIsValid(language);
   }

--- a/core/src/test/java/io/lionweb/lioncore/java/utils/LanguageValidatorTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/utils/LanguageValidatorTest.java
@@ -266,7 +266,10 @@ public class LanguageValidatorTest {
     assertEquals(
         new HashSet<>(
             Arrays.asList(
-                new Issue(IssueSeverity.Error, "A sub annotation should not define annotates", b))),
+                new Issue(
+                    IssueSeverity.Error,
+                    "When a sub annotation specify a value for annotates it must be the same value the super annotation specifies",
+                    b))),
         l.validate().getIssues());
   }
 

--- a/core/src/test/java/io/lionweb/lioncore/java/utils/LanguageValidatorTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/utils/LanguageValidatorTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.self.LionCore;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.stream.Collectors;
 import org.junit.Test;
@@ -253,7 +254,24 @@ public class LanguageValidatorTest {
   }
 
   @Test
-  public void aSubAnnotationShouldNotDefineAnnotates() {
+  public void aSubAnnotationShouldNotDefineAnnotatesToADifferentValue() {
+    Language l = new Language("MyLanguage", "my_language_id", "my_language_key");
+    Concept c = new Concept(l, "C", "c_id", "c_key");
+    Concept c2 = new Concept(l, "C2", "c2_id", "c2_key");
+    Annotation a = new Annotation(l, "A", "branchA_id", "branchA_key");
+    a.setAnnotates(c);
+    Annotation b = new Annotation(l, "B", "branchB_id", "branchB_key");
+    b.setAnnotates(c2);
+    b.setExtendedAnnotation(a);
+    assertEquals(
+        new HashSet<>(
+            Arrays.asList(
+                new Issue(IssueSeverity.Error, "A sub annotation should not define annotates", b))),
+        l.validate().getIssues());
+  }
+
+  @Test
+  public void aSubAnnotationCanReDefineAnnotatesToTheSameValue() {
     Language l = new Language("MyLanguage", "my_language_id", "my_language_key");
     Concept c = new Concept(l, "C", "c_id", "c_key");
     Annotation a = new Annotation(l, "A", "branchA_id", "branchA_key");
@@ -261,11 +279,7 @@ public class LanguageValidatorTest {
     Annotation b = new Annotation(l, "B", "branchB_id", "branchB_key");
     b.setAnnotates(c);
     b.setExtendedAnnotation(a);
-    assertEquals(
-        new HashSet<>(
-            Arrays.asList(
-                new Issue(IssueSeverity.Error, "A sub annotation should not define annotates", b))),
-        l.validate().getIssues());
+    assertEquals(Collections.emptySet(), l.validate().getIssues());
   }
 
   @Test

--- a/core/src/test/java/io/lionweb/lioncore/java/utils/LanguageValidatorTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/utils/LanguageValidatorTest.java
@@ -251,4 +251,42 @@ public class LanguageValidatorTest {
                     branchB))),
         l.validate().getIssues());
   }
+
+  @Test
+  public void aSubAnnotationShouldNotDefineAnnotates() {
+    Language l = new Language("MyLanguage", "my_language_id", "my_language_key");
+    Concept c = new Concept(l, "C", "c_id", "c_key");
+    Annotation a = new Annotation(l, "A", "branchA_id", "branchA_key");
+    a.setAnnotates(c);
+    Annotation b = new Annotation(l, "B", "branchB_id", "branchB_key");
+    b.setAnnotates(c);
+    b.setExtendedAnnotation(a);
+    assertEquals(
+        new HashSet<>(
+            Arrays.asList(
+                new Issue(IssueSeverity.Error, "A sub annotation should not define annotates", b))),
+        l.validate().getIssues());
+  }
+
+  @Test
+  public void aSubAnnotationShouldHaveTheSameMultipleValueAsTheParent() {
+    Language l = new Language("MyLanguage", "my_language_id", "my_language_key");
+    Concept c = new Concept(l, "C", "c_id", "c_key");
+    Annotation a = new Annotation(l, "A", "branchA_id", "branchA_key");
+    a.setAnnotates(c);
+    Annotation b = new Annotation(l, "B", "branchB_id", "branchB_key");
+    b.setExtendedAnnotation(a);
+    a.setMultiple(true);
+    b.setMultiple(true);
+    assertTrue(l.validate().isSuccessful());
+    b.setMultiple(false);
+    assertEquals(
+        new HashSet<>(
+            Arrays.asList(
+                new Issue(
+                    IssueSeverity.Error,
+                    "A sub annotation should have the same multiple value as the super annotation",
+                    b))),
+        l.validate().getIssues());
+  }
 }


### PR DESCRIPTION
This PR fix the issue in #95 and introduce a few checks.

Note that w.r.t. the specification we cannot verify that a sub annotation does not define "multiple" as it is a boolean value and it has a default value. We can instead check that it has always the same value as the super annotation.

Adding @enikao for feedback