### PR TITLE
Preparing for release 2023.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The language's _nsURI_ is `http://lionweb.io/lionweb-java/emf/core/builtins/2023
 
 ## lionweb-java-2023.1-* - Version 0.2.0
 
-This is the first release based on the new coordinates, which indicate support for the specification of LionWeb released under version 2023.1.
+This is the first release based on the new artifact ids (which now include the specifications version), which indicate support for the specification of LionWeb released under version 2023.1.
 
 At this stage support for the M1 and M2 APIs is relatively complete. Support for annotations may need refinements. Some constraints may not yet been verified.
 Import and export from and to EMF is a work in progress.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ Contains im/exporters to convert models between LionCore &harr; Ecore and LionWe
 Some of LionCore's built-in elements have no direct representation in Ecore.
 This sub-project is an Eclipse project that defines an _EPackage_ `builtins` to host the equivalent elements in Ecore.
 The language's _nsURI_ is `http://lionweb.io/lionweb-java/emf/core/builtins/2023.1`.
+
+## Changelog
+
+## lionweb-java-2023.1-* - Version 0.2.0
+
+This is the first release based on the new coordinates, which indicate support for the specification of LionWeb released under version 2023.1.
+
+At this stage support for the M1 and M2 APIs is relatively complete. Support for annotations may need refinements. Some constraints may not yet been verified.
+Import and export from and to EMF is a work in progress.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -16,6 +16,9 @@ repositories {
     }
 }
 
+val jvmVersion = extra["jvmVersion"] as String
+val specsVersion = extra["specsVersion"] as String
+
 val javadocConfig by configurations.creating {
     extendsFrom(configurations.testImplementation.get())
 }
@@ -88,7 +91,7 @@ publishing {
         create<MavenPublication>("lionweb_java_core") {
             from(components.findByName("java"))
             groupId = "io.lionweb.lionweb-java"
-            artifactId = "lionweb-java-" + project.name
+            artifactId = "lionweb-java-${specsVersion}-" + project.name
             artifact(tasks.findByName("sourcesJar"))
             artifact(tasks.findByName("javadocJar"))
             suppressPomMetadataWarningsFor("cliApiElements")
@@ -137,8 +140,6 @@ publishing {
         }
     }
 }
-
-val jvmVersion = extra["jvmVersion"] as String
 
 java {
     sourceCompatibility = JavaVersion.toVersion(jvmVersion)

--- a/emf-builtins/build.gradle
+++ b/emf-builtins/build.gradle
@@ -124,7 +124,7 @@ publishing {
         lionweb_java_emf_builtins(MavenPublication) {
             from(components.findByName("java"))
             groupId = "io.lionweb.lionweb-java"
-            artifactId = "lionweb-java-" + project.name
+            artifactId = "lionweb-java-${specsVersion}" + project.name
             artifact(tasks.findByName("sourcesJar"))
             artifact(tasks.findByName("javadocJar"))
             suppressPomMetadataWarningsFor("cliApiElements")

--- a/emf/build.gradle.kts
+++ b/emf/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 }
 
 val jvmVersion = extra["jvmVersion"] as String
+val specsVersion = extra["specsVersion"] as String
 
 java {
     sourceCompatibility = JavaVersion.toVersion(jvmVersion)
@@ -83,7 +84,7 @@ publishing {
         create<MavenPublication>("lionweb_java_emf") {
             from(components.findByName("java"))
             groupId = "io.lionweb.lionweb-java"
-            artifactId = "lionweb-java-" + project.name
+            artifactId = "lionweb-java-${specsVersion}-" + project.name
             artifact(tasks.findByName("sourcesJar"))
             artifact(tasks.findByName("javadocJar"))
             suppressPomMetadataWarningsFor("cliApiElements")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
-version=0.1.7-SNAPSHOT
+version=0.2.0-SNAPSHOT
+specsVersion=2023.1
 jvmVersion=1.8
 org.gradle.jvmargs=-Dfile.encoding=UTF-8


### PR DESCRIPTION
* Adding changelog
* Adding specsVersion in artifacts names
* Moving to 0.2.0 to indicate a significant change and offer a more separate starting point for the changelog