### PR TITLE
Correct serialization/deserialization of nullable boolean values

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
@@ -26,7 +26,9 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
       throw new IllegalArgumentException("Property not belonging to this classifier");
     }
     Object storedValue = propertyValues.get(property.getID());
-    if (storedValue == null && property.getType() == LionCoreBuiltins.getBoolean() && property.isRequired()) {
+    if (storedValue == null
+        && property.getType() == LionCoreBuiltins.getBoolean()
+        && property.isRequired()) {
       return false;
     }
     return storedValue;

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
@@ -25,7 +25,11 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
     if (!getClassifier().allProperties().contains(property)) {
       throw new IllegalArgumentException("Property not belonging to this classifier");
     }
-    return propertyValues.get(property.getID());
+    Object storedValue = propertyValues.get(property.getID());
+    if (storedValue == null && property.getType() == LionCoreBuiltins.getBoolean() && property.isRequired()) {
+      return false;
+    }
+    return storedValue;
   }
 
   @Override
@@ -35,7 +39,7 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
       throw new IllegalArgumentException(
           "Property " + property + " is not belonging to classifier " + getClassifier());
     }
-    if (value == null || value == Boolean.FALSE) {
+    if ((value == null || value == Boolean.FALSE) && property.isRequired()) {
       // We remove values corresponding to default values, so that comparisons of instances of
       // DynamicNode can be
       // simplified

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -535,7 +535,9 @@ public class JsonSerialization {
                       + serializedClassifierInstance);
               Object deserializedValue =
                   primitiveValuesSerialization.deserialize(
-                      property.getType(), serializedPropertyValue.getValue());
+                      property.getType(),
+                      serializedPropertyValue.getValue(),
+                      property.isRequired());
               propertiesValues.put(property, deserializedValue);
             });
     ClassifierInstance<?> classifierInstance =

--- a/core/src/test/java/io/lionweb/lioncore/java/model/impl/DynamicNodeTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/model/impl/DynamicNodeTest.java
@@ -3,10 +3,7 @@ package io.lionweb.lioncore.java.model.impl;
 import static org.junit.Assert.*;
 
 import com.google.gson.JsonArray;
-import io.lionweb.lioncore.java.language.Annotation;
-import io.lionweb.lioncore.java.language.Concept;
-import io.lionweb.lioncore.java.language.Containment;
-import io.lionweb.lioncore.java.language.Language;
+import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.AnnotationInstance;
 import io.lionweb.lioncore.java.serialization.MyNodeWithProperties;
 import java.util.Arrays;
@@ -172,5 +169,65 @@ public class DynamicNodeTest {
     assertThrows(IllegalStateException.class, () -> n2.getRoot());
     assertThrows(IllegalStateException.class, () -> n3.getRoot());
     assertThrows(IllegalStateException.class, () -> n4.getRoot());
+  }
+
+  @Test
+  public void settingFalseNonNullableBooleanProperty() {
+    Language l = new Language("MyLanguage", "l-id", "l-key", "123");
+    Concept a = new Concept(l, "A", "a-id", "a-key");
+    a.addFeature(Property.createRequired("foo", LionCoreBuiltins.getBoolean()));
+    DynamicNode n1 = new DynamicNode("n1", a);
+
+    assertEquals(false, n1.getPropertyValueByName("foo"));
+    n1.setPropertyValueByName("foo", false);
+    assertEquals(false, n1.getPropertyValueByName("foo"));
+  }
+
+  @Test
+  public void settingTrueNonNullableBooleanProperty() {
+    Language l = new Language("MyLanguage", "l-id", "l-key", "123");
+    Concept a = new Concept(l, "A", "a-id", "a-key");
+    a.addFeature(Property.createRequired("foo", LionCoreBuiltins.getBoolean()));
+    DynamicNode n1 = new DynamicNode("n1", a);
+
+    assertEquals(false, n1.getPropertyValueByName("foo"));
+    n1.setPropertyValueByName("foo", true);
+    assertEquals(true, n1.getPropertyValueByName("foo"));
+  }
+
+  @Test
+  public void settingFalseNullableBooleanProperty() {
+    Language l = new Language("MyLanguage", "l-id", "l-key", "123");
+    Concept a = new Concept(l, "A", "a-id", "a-key");
+    a.addFeature(Property.createOptional("foo", LionCoreBuiltins.getBoolean()));
+    DynamicNode n1 = new DynamicNode("n1", a);
+
+    assertEquals(null, n1.getPropertyValueByName("foo"));
+    n1.setPropertyValueByName("foo", false);
+    assertEquals(false, n1.getPropertyValueByName("foo"));
+  }
+
+  @Test
+  public void settingNullNullableBooleanProperty() {
+    Language l = new Language("MyLanguage", "l-id", "l-key", "123");
+    Concept a = new Concept(l, "A", "a-id", "a-key");
+    a.addFeature(Property.createOptional("foo", LionCoreBuiltins.getBoolean()));
+    DynamicNode n1 = new DynamicNode("n1", a);
+
+    assertEquals(null, n1.getPropertyValueByName("foo"));
+    n1.setPropertyValueByName("foo", null);
+    assertEquals(null, n1.getPropertyValueByName("foo"));
+  }
+
+  @Test
+  public void settingTrueNullableBooleanProperty() {
+    Language l = new Language("MyLanguage", "l-id", "l-key", "123");
+    Concept a = new Concept(l, "A", "a-id", "a-key");
+    a.addFeature(Property.createOptional("foo", LionCoreBuiltins.getBoolean()));
+    DynamicNode n1 = new DynamicNode("n1", a);
+
+    assertEquals(null, n1.getPropertyValueByName("foo"));
+    n1.setPropertyValueByName("foo", true);
+    assertEquals(true, n1.getPropertyValueByName("foo"));
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/MyNodeWithProperties.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/MyNodeWithProperties.java
@@ -33,8 +33,13 @@ public class MyNodeWithProperties extends DynamicNode {
     super(id, CONCEPT);
   }
 
-  public boolean getP1() {
-    return (boolean) this.getPropertyValueByName("p1");
+  public Boolean getP1() {
+    Object value = this.getPropertyValueByName("p1");
+    if (value == null) {
+      return null;
+    } else {
+      return (Boolean) value;
+    }
   }
 
   public int getP2() {

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/MyNodeWithProperties.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/MyNodeWithProperties.java
@@ -35,11 +35,7 @@ public class MyNodeWithProperties extends DynamicNode {
 
   public Boolean getP1() {
     Object value = this.getPropertyValueByName("p1");
-    if (value == null) {
-      return null;
-    } else {
-      return (Boolean) value;
-    }
+    return value == null ? null : (Boolean) value;
   }
 
   public int getP2() {

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfPrimitiveValuesTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfPrimitiveValuesTest.java
@@ -221,6 +221,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
   @Test
   public void deserializeString() {
     MyNodeWithProperties node = new MyNodeWithProperties("n1");
+    assertEquals(null, node.getP1());
     node.setP3("qwerty");
 
     JsonObject serialized =
@@ -357,6 +358,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
   @Test
   public void deserializeInteger() {
     MyNodeWithProperties node = new MyNodeWithProperties("n1");
+    node.setP1(false);
     node.setP2(2904);
 
     JsonObject serialized =
@@ -379,7 +381,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
                     + "            \"version\": \"1\",\n"
                     + "            \"key\": \"p1\"\n"
                     + "          },\n"
-                    + "          \"value\": null\n"
+                    + "          \"value\": \"false\"\n"
                     + "        },\n"
                     + "        {\n"
                     + "          \"property\": {\n"
@@ -500,6 +502,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonArray ja = new JsonArray();
     ja.add(1);
     ja.add("foo");
+    assertEquals(null, node.getP1());
     node.setP4(ja);
 
     JsonObject serialized =


### PR DESCRIPTION
Nullable boolean values were treating null and false as interchangeable values, so that serializing and deserializing one would get back a different value.

For properties of type boolean which are _optional_ we want to distinguish _false_ and _null_, so the code has been corrected and tests have been added.