### PR TITLE
Consider all features when determining the list of used languages

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/language/Classifier.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Classifier.java
@@ -99,6 +99,13 @@ public abstract class Classifier<T extends M3Node> extends LanguageEntity<T>
         .collect(Collectors.toList());
   }
 
+  public @Nonnull List<Link<?>> allLinks() {
+    return allFeatures().stream()
+        .filter(f -> f instanceof Link)
+        .map(f -> (Link<?>) f)
+        .collect(Collectors.toList());
+  }
+
   // TODO should this expose an immutable list to force users to use methods on this class
   //      to modify the collection?
   public @Nonnull List<Feature<?>> getFeatures() {

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
@@ -31,7 +31,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
 
     assertEquals("2023.1", serializedChunk.getSerializationFormatVersion());
 
-    assertEquals(1, serializedChunk.getLanguages().size());
+    assertEquals(2, serializedChunk.getLanguages().size());
     Assert.assertEquals(
         new UsedLanguage("LionCore-M3", "2023.1"),
         serializedChunk.getLanguages().iterator().next());


### PR DESCRIPTION
Currently we do not consider the language used by features. This means that in most cases the Builtins language is not listed among the used languages and this cause validation to fail.