### PR TITLE
Support deserialization of partial trees

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
  * partitions) or we will get references to nodes (for example, parents or ancestors) outside of the
  * scope of the tree extracted. This policy specifies what we do with such references.
  */
-enum UnknownNodePolicy {
+enum UnknownParentPolicy {
   NULL_REFERENCES,
   THROW_ERROR
 }
@@ -110,7 +110,7 @@ public class JsonSerialization {
 
   private final LocalClassifierInstanceResolver instanceResolver;
 
-  private UnknownNodePolicy unknownNodePolicy = UnknownNodePolicy.THROW_ERROR;
+  private UnknownParentPolicy unknownParentPolicy = UnknownParentPolicy.THROW_ERROR;
 
   private JsonSerialization() {
     // prevent public access
@@ -145,13 +145,13 @@ public class JsonSerialization {
     primitiveValuesSerialization.enableDynamicNodes();
   }
 
-  public @Nonnull UnknownNodePolicy getUnknownNodePolicy() {
-    return this.unknownNodePolicy;
+  public @Nonnull UnknownParentPolicy getUnknownNodePolicy() {
+    return this.unknownParentPolicy;
   }
 
-  public void setUnknownNodePolicy(@Nonnull UnknownNodePolicy unknownNodePolicy) {
-    Objects.requireNonNull(unknownNodePolicy);
-    this.unknownNodePolicy = unknownNodePolicy;
+  public void setUnknownNodePolicy(@Nonnull UnknownParentPolicy unknownParentPolicy) {
+    Objects.requireNonNull(unknownParentPolicy);
+    this.unknownParentPolicy = unknownParentPolicy;
   }
 
   //
@@ -451,7 +451,7 @@ public class JsonSerialization {
     nodesToSort.stream().filter(n -> n.getID() == null).forEach(n -> sortedList.add(n));
     nodesToSort.removeAll(sortedList);
 
-    if (unknownNodePolicy == UnknownNodePolicy.NULL_REFERENCES) {
+    if (unknownParentPolicy == UnknownParentPolicy.NULL_REFERENCES) {
       // Let's find all the IDs of nodes present here. The nodes with parents not present here are
       // effectively treated as roots and their parent will be set to null, as we cannot retrieve
       // them

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -614,7 +614,7 @@ public class JsonSerializationTest extends SerializationTest {
     InputStream is = this.getClass().getResourceAsStream("/serialization/partialTree.json");
 
     js.enableDynamicNodes();
-    js.setUnknownNodePolicy(UnknownNodePolicy.NULL_REFERENCES);
+    js.setUnknownNodePolicy(UnknownParentPolicy.NULL_REFERENCES);
     List<Node> nodes = js.deserializeToNodes(is);
     assertEquals(4, nodes.size());
   }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -550,7 +550,8 @@ public class JsonSerializationTest extends SerializationTest {
     SerializedClassifierInstance serializedA1_1 = serializedChunk.getClassifierInstances().get(1);
     assertEquals("n1", serializedA1_1.getParentNodeID());
 
-    List<ClassifierInstance<?>> deserialized = hjs.deserializeSerializationBlock(serializedChunk);
+    List<ClassifierInstance<?>> deserialized =
+        hjs.deserializeSerializationBlock(serializedChunk, false);
     assertEquals(4, deserialized.size());
     assertInstancesAreEquals(a1_1, deserialized.get(1));
     assertEquals(deserialized.get(0), deserialized.get(1).getParent());
@@ -589,5 +590,32 @@ public class JsonSerializationTest extends SerializationTest {
                 entry ->
                     entry.getKey().equals(language.getKey())
                         && entry.getVersion().equals(language.getVersion())));
+  }
+
+  @Test(expected = DeserializationException.class)
+  public void deserializePartialTreeFailsByDefault() {
+    JsonSerialization js = JsonSerialization.getStandardSerialization();
+    InputStream languageIs =
+        this.getClass().getResourceAsStream("/serialization/propertiesLanguage.json");
+    Language propertiesLanguage = (Language) js.deserializeToNodes(languageIs).get(0);
+    js.registerLanguage(propertiesLanguage);
+    InputStream is = this.getClass().getResourceAsStream("/serialization/partialTree.json");
+
+    js.enableDynamicNodes();
+    List<Node> nodes = js.deserializeToNodes(is);
+  }
+
+  @Test
+  public void deserializePartialTreeSucceedsWithThePartialTreeFlag() {
+    JsonSerialization js = JsonSerialization.getStandardSerialization();
+    InputStream languageIs =
+        this.getClass().getResourceAsStream("/serialization/propertiesLanguage.json");
+    Language propertiesLanguage = (Language) js.deserializeToNodes(languageIs).get(0);
+    js.registerLanguage(propertiesLanguage);
+    InputStream is = this.getClass().getResourceAsStream("/serialization/partialTree.json");
+
+    js.enableDynamicNodes();
+    List<Node> nodes = js.deserializeToNodes(is, true);
+    assertEquals(4, nodes.size());
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -550,8 +550,7 @@ public class JsonSerializationTest extends SerializationTest {
     SerializedClassifierInstance serializedA1_1 = serializedChunk.getClassifierInstances().get(1);
     assertEquals("n1", serializedA1_1.getParentNodeID());
 
-    List<ClassifierInstance<?>> deserialized =
-        hjs.deserializeSerializationBlock(serializedChunk, false);
+    List<ClassifierInstance<?>> deserialized = hjs.deserializeSerializationBlock(serializedChunk);
     assertEquals(4, deserialized.size());
     assertInstancesAreEquals(a1_1, deserialized.get(1));
     assertEquals(deserialized.get(0), deserialized.get(1).getParent());
@@ -615,7 +614,8 @@ public class JsonSerializationTest extends SerializationTest {
     InputStream is = this.getClass().getResourceAsStream("/serialization/partialTree.json");
 
     js.enableDynamicNodes();
-    List<Node> nodes = js.deserializeToNodes(is, true);
+    js.setUnknownNodePolicy(UnknownNodePolicy.NULL_REFERENCES);
+    List<Node> nodes = js.deserializeToNodes(is);
     assertEquals(4, nodes.size());
   }
 }

--- a/core/src/test/resources/serialization/partialTree.json
+++ b/core/src/test/resources/serialization/partialTree.json
@@ -1,0 +1,107 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "language-properties-key",
+      "version": "1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "node-id-rand--1470532511",
+      "classifier": {
+        "key": "properties-Property-key",
+        "version": "1",
+        "language": "language-properties-key"
+      },
+      "parent": "pf1",
+      "properties": [
+        {
+          "value": "Prop2",
+          "property": {
+            "key": "LionCore-builtins-INamed-name",
+            "version": "2023.1",
+            "language": "LionCore-builtins"
+          }
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": []
+    },
+    {
+      "id": "node-id-rand-191263549",
+      "classifier": {
+        "key": "properties-Property-key",
+        "version": "1",
+        "language": "language-properties-key"
+      },
+      "parent": "pf1",
+      "properties": [
+        {
+          "value": "Prop3",
+          "property": {
+            "key": "LionCore-builtins-INamed-name",
+            "version": "2023.1",
+            "language": "LionCore-builtins"
+          }
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": []
+    },
+    {
+      "id": "pf1",
+      "classifier": {
+        "key": "properties-PropertiesFile-key",
+        "version": "1",
+        "language": "language-properties-key"
+      },
+      "parent": "pp1",
+      "properties": [],
+      "containments": [
+        {
+          "children": [
+            "prop1",
+            "node-id-rand--1470532511",
+            "node-id-rand-191263549"
+          ],
+          "containment": {
+            "key": "properties-PropertiesFile-properties-key",
+            "version": "1",
+            "language": "language-properties-key"
+          }
+        }
+      ],
+      "references": [],
+      "annotations": []
+    },
+    {
+      "id": "prop1",
+      "classifier": {
+        "key": "properties-Property-key",
+        "version": "1",
+        "language": "language-properties-key"
+      },
+      "parent": "pf1",
+      "properties": [
+        {
+          "value": "Prop1",
+          "property": {
+            "key": "LionCore-builtins-INamed-name",
+            "version": "2023.1",
+            "language": "LionCore-builtins"
+          }
+        }
+      ],
+      "containments": [],
+      "references": [],
+      "annotations": []
+    }
+  ]
+}

--- a/core/src/test/resources/serialization/propertiesLanguage.json
+++ b/core/src/test/resources/serialization/propertiesLanguage.json
@@ -1,0 +1,420 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-M3",
+      "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "language-properties-id",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "1"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "language-properties-key"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "Properties"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "properties-PropertiesPartition-id",
+            "properties-PropertiesFile-id",
+            "properties-Property-id"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-dependsOn"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
+      "id": "properties-PropertiesPartition-id",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "properties-PropertiesPartition-key"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "PropertiesPartition"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "properties-PropertiesPartition-files-id"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "language-properties-id"
+    },
+    {
+      "id": "properties-PropertiesPartition-files-id",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "properties-PropertiesPartition-files-key"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "files"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "PropertiesFile",
+              "reference": "properties-PropertiesFile-id"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "properties-PropertiesPartition-id"
+    },
+    {
+      "id": "properties-PropertiesFile-id",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "properties-PropertiesFile-key"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "PropertiesFile"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "properties-PropertiesFile-properties-id"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "language-properties-id"
+    },
+    {
+      "id": "properties-PropertiesFile-properties-id",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "properties-PropertiesFile-properties-key"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "properties"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Property",
+              "reference": "properties-Property-id"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "properties-PropertiesFile-id"
+    },
+    {
+      "id": "properties-Property-id",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "properties-Property-key"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "Property"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": []
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": []
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "INamed",
+              "reference": "LionCore-builtins-INamed"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "language-properties-id"
+    }
+  ]
+}


### PR DESCRIPTION
Until now we were expecting to receive entire trees. In other words to receive some node with a null parent and other nodes directly or indirectly connected to such roots. In this way we were able to unserialize the tree properly, setting the parents for all nodes.

However, with support for proper partitions being introduced, we may want to ask for specific root nodes (or smaller trees) and not always to get the whole partition. So we may need to be able to unserialize trees that refer to parents we did not receive. We therefore ask support for this. In that case the parents not transmitted in the chunk will be set to null. 

In the future we may want to specify some form of NodeResolver.