### PR TITLE
Support Proxy Nodes and policy for external references

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     api("org.apache.commons:commons-math3:3.6.1")
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-    implementation("com.google.guava:guava:29.0-jre")
+    implementation("com.google.guava:guava:33.0.0-jre")
 
     javadocConfig(emf.ecore)
 

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
@@ -115,14 +115,15 @@ public class ProxyNode implements Node {
     return new CannotDoBecauseProxyException(this.id);
   }
 
-  /**
-   * Exception thrown when invoking most methods of a ProxyNode.
-   */
+  /** Exception thrown when invoking most methods of a ProxyNode. */
   public class CannotDoBecauseProxyException extends IllegalStateException {
     private @Nonnull String nodeID;
 
     private CannotDoBecauseProxyException(@Nonnull String nodeID) {
-      super("Replace the proxy node with a real node to perform this operation (nodeID: " + nodeID + ")");
+      super(
+          "Replace the proxy node with a real node to perform this operation (nodeID: "
+              + nodeID
+              + ")");
     }
 
     public @Nonnull String getNodeID() {

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
@@ -3,6 +3,7 @@ package io.lionweb.lioncore.java.model.impl;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.*;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -13,9 +14,10 @@ import javax.annotation.Nullable;
  */
 public class ProxyNode implements Node {
 
-  private String id;
+  private @Nonnull String id;
 
-  public ProxyNode(String id) {
+  public ProxyNode(@Nonnull String id) {
+    Objects.requireNonNull(id, "The node ID of a ProxyNode should not be null");
     this.id = id;
   }
 
@@ -72,7 +74,7 @@ public class ProxyNode implements Node {
     throw cannotDoBecauseProxy();
   }
 
-  @Nullable
+  @Nonnull
   @Override
   public String getID() {
     return id;

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
@@ -1,0 +1,116 @@
+package io.lionweb.lioncore.java.model.impl;
+
+import io.lionweb.lioncore.java.language.*;
+import io.lionweb.lioncore.java.model.*;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * This is basic an ID holder adapted as a Node. It is used as a placeholder to indicate that we
+ * know which Node should be used in a particular point, but at this time we cannot/do not want to
+ * retrieve the data necessary to properly instantiate it.
+ */
+public class ProxyNode implements Node {
+
+  private String id;
+
+  public ProxyNode(String id) {
+    this.id = id;
+  }
+
+  @Override
+  public ClassifierInstance<Concept> getParent() {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public Object getPropertyValue(Property property) {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public void setPropertyValue(Property property, Object value) {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public List<? extends Node> getChildren() {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public List<? extends Node> getChildren(Containment containment) {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public void addChild(Containment containment, Node child) {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public void removeChild(Node node) {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Nonnull
+  @Override
+  public List<Node> getReferredNodes(@Nonnull Reference reference) {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Nonnull
+  @Override
+  public List<ReferenceValue> getReferenceValues(@Nonnull Reference reference) {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public void addReferenceValue(
+      @Nonnull Reference reference, @Nullable ReferenceValue referredNode) {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Nullable
+  @Override
+  public String getID() {
+    return id;
+  }
+
+  @Override
+  public Partition getPartition() {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public Concept getConcept() {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public List<AnnotationInstance> getAnnotations() {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public Containment getContainmentFeature() {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Nonnull
+  @Override
+  public List<AnnotationInstance> getAnnotations(Annotation annotation) {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public void addAnnotation(AnnotationInstance instance) {
+    throw cannotDoBecauseProxy();
+  }
+
+  private IllegalStateException cannotDoBecauseProxy() {
+    return new IllegalStateException(
+        "Replace the proxy node with a real node to perform this operation");
+  }
+}

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
@@ -110,7 +110,21 @@ public class ProxyNode implements Node {
   }
 
   private IllegalStateException cannotDoBecauseProxy() {
-    return new IllegalStateException(
-        "Replace the proxy node with a real node to perform this operation");
+    return new CannotDoBecauseProxyException(this.id);
+  }
+
+  /**
+   * Exception thrown when invoking most methods of a ProxyNode.
+   */
+  public class CannotDoBecauseProxyException extends IllegalStateException {
+    private @Nonnull String nodeID;
+
+    private CannotDoBecauseProxyException(@Nonnull String nodeID) {
+      super("Replace the proxy node with a real node to perform this operation (nodeID: " + nodeID + ")");
+    }
+
+    public @Nonnull String getNodeID() {
+      return this.nodeID;
+    }
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
@@ -111,7 +111,7 @@ public class ProxyNode implements Node {
     throw cannotDoBecauseProxy();
   }
 
-  private IllegalStateException cannotDoBecauseProxy() {
+  private CannotDoBecauseProxyException cannotDoBecauseProxy() {
     return new CannotDoBecauseProxyException(this.id);
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/DeserializationStatus.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/DeserializationStatus.java
@@ -1,0 +1,74 @@
+package io.lionweb.lioncore.java.serialization;
+
+import io.lionweb.lioncore.java.model.impl.ProxyNode;
+import io.lionweb.lioncore.java.serialization.data.SerializedClassifierInstance;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+
+/**
+ * This class is used to track the status of the deserializationg process, and in particular sorting
+ * operations. It is also used to track the proxies created while sorting this particular set of
+ * nodes, as the proxies created in this process will need to be returned together with the sorted
+ * list of unserialized nodes.
+ */
+class DeserializationStatus {
+  List<SerializedClassifierInstance> sortedList;
+  List<SerializedClassifierInstance> nodesToSort;
+  List<ProxyNode> proxies = new ArrayList<>();
+  private JsonSerialization jsonSerialization;
+
+  DeserializationStatus(
+      JsonSerialization jsonSerialization, List<SerializedClassifierInstance> originalList) {
+    sortedList = new ArrayList<>();
+    nodesToSort = new ArrayList<>(originalList);
+    this.jsonSerialization = jsonSerialization;
+  }
+
+  void putNodesWithNullIDsInFront() {
+    // Nodes with null IDs are ambiguous but they cannot be the children of any node: they can
+    // just be parent of other nodes, so we put all of them at the start (so they end up at the
+    // end when we reverse the list)
+    nodesToSort.stream().filter(n -> n.getID() == null).forEach(n -> sortedList.add(n));
+    nodesToSort.removeAll(sortedList);
+  }
+
+  /** We place the node in the sorted list. */
+  void place(SerializedClassifierInstance node) {
+    sortedList.add(node);
+    nodesToSort.remove(node);
+  }
+
+  void reverse() {
+    Collections.reverse(sortedList);
+  }
+
+  int howManySorted() {
+    return sortedList.size();
+  }
+
+  int howManyToSort() {
+    return nodesToSort.size();
+  }
+
+  SerializedClassifierInstance getNodeToSort(int index) {
+    return nodesToSort.get(index);
+  }
+
+  Stream<SerializedClassifierInstance> streamSorted() {
+    return sortedList.stream();
+  }
+
+  ProxyNode createProxy(String nodeID) {
+    ProxyNode proxyNode = this.jsonSerialization.createProxy(nodeID);
+    proxies.add(proxyNode);
+    return proxyNode;
+  }
+
+  @Nullable
+  ProxyNode proxyFor(String nodeID) {
+    return proxies.stream().filter(n -> n.getID().equals(nodeID)).findFirst().orElse(null);
+  }
+}

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.serialization;
 
+import com.google.common.collect.Sets;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
@@ -551,12 +552,9 @@ public class JsonSerialization {
       // NodeResolver)
       Set<String> knownIDs =
           originalList.stream().map(ci -> ci.getID()).collect(Collectors.toSet());
-      Set<String> unknownParentIDs =
-          originalList.stream()
-              .map(n -> n.getParentNodeID())
-              .distinct()
-              .filter(id -> !knownIDs.contains(id))
-              .collect(Collectors.toSet());
+      Set<String> parentIDs =
+          originalList.stream().map(n -> n.getParentNodeID()).collect(Collectors.toSet());
+      Set<String> unknownParentIDs = Sets.difference(parentIDs, knownIDs);
       originalList.stream()
           .filter(ci -> unknownParentIDs.contains(ci.getParentNodeID()))
           .forEach(effectivelyRoot -> sortingResult.place(effectivelyRoot));

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -805,16 +805,19 @@ public class JsonSerialization {
                         if (entry.getReference() != null && referred == null) {
                           if (unavailableReferenceTargetPolicy
                               == UnavailableNodePolicy.NULL_REFERENCES) {
-                            throw new UnsupportedOperationException("Not yet supported");
+                            referred = null;
                           } else if (unavailableReferenceTargetPolicy
                               == UnavailableNodePolicy.PROXY_NODES) {
                             referred = sortingResult.createProxy(entry.getReference());
-                          } else {
+                          } else if (unavailableReferenceTargetPolicy
+                              == UnavailableNodePolicy.THROW_ERROR) {
                             throw new DeserializationException(
                                 "Unable to resolve reference to "
                                     + entry.getReference()
                                     + " for feature "
                                     + serializedReferenceValue.getMetaPointer());
+                          } else {
+                            throw new IllegalStateException("This should not happen");
                           }
                         }
                         ReferenceValue referenceValue =

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -446,6 +446,7 @@ public class JsonSerialization {
     }
   }
 
+  /** Create a Proxy and from now on use it to resolve instances for this node ID. */
   private ProxyNode createProxy(String nodeID) {
     if (instanceResolver.resolve(nodeID) != null) {
       throw new IllegalStateException();
@@ -455,6 +456,11 @@ public class JsonSerialization {
     return proxyNode;
   }
 
+  /**
+   * This class is used to track the sorting operation. It is also used to track the proxies created
+   * while sorting this particular set of nodes, as the proxies created in this process will need to
+   * be returned together with the sorted list of unserialized nodes.
+   */
   private class SortingResult {
     List<SerializedClassifierInstance> sortedList;
     List<SerializedClassifierInstance> nodesToSort;
@@ -470,15 +476,13 @@ public class JsonSerialization {
 
     void putNodesWithNullIDsInFront() {
       // Nodes with null IDs are ambiguous but they cannot be the children of any node: they can
-      // just
-      // be parent of other nodes, so we put all of them at the start (so they end up at the end
-      // when
-      // we reverse
-      // the list)
+      // just be parent of other nodes, so we put all of them at the start (so they end up at the
+      // end when we reverse the list)
       nodesToSort.stream().filter(n -> n.getID() == null).forEach(n -> sortedList.add(n));
       nodesToSort.removeAll(sortedList);
     }
 
+    /** We place the node in the sorted list. */
     void place(SerializedClassifierInstance node) {
       sortedList.add(node);
       nodesToSort.remove(node);
@@ -637,9 +641,8 @@ public class JsonSerialization {
               ClassifierInstance<?> classifierInstance = serializedToInstanceMap.get(node);
               if (unavailableParentPolicy == UnavailableNodePolicy.PROXY_NODES) {
                 // For real parents, the parent is not set directly, but it is set indirectly
-                // when adding the child to the parent. For proxy nodes instead we need to set the
-                // parent
-                // explicitly
+                // when adding the child to the parent. For proxy nodes instead we need to set
+                // the parent explicitly
                 ProxyNode proxyParent = sortingResult.proxyFor(node.getParentNodeID());
                 if (proxyParent != null) {
                   if (classifierInstance instanceof DynamicNode) {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -449,7 +449,10 @@ public class JsonSerialization {
   /** Create a Proxy and from now on use it to resolve instances for this node ID. */
   private ProxyNode createProxy(String nodeID) {
     if (instanceResolver.resolve(nodeID) != null) {
-      throw new IllegalStateException();
+      throw new IllegalStateException(
+          "Cannot create a Proxy for node ID "
+              + nodeID
+              + " has there is already a Classifier Instance available for such ID");
     }
     ProxyNode proxyNode = new ProxyNode(nodeID);
     instanceResolver.add(proxyNode);

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
@@ -1,0 +1,116 @@
+package io.lionweb.lioncore.java.serialization;
+
+import io.lionweb.lioncore.java.api.ClassifierInstanceResolver;
+import io.lionweb.lioncore.java.language.Classifier;
+import io.lionweb.lioncore.java.language.Containment;
+import io.lionweb.lioncore.java.language.Reference;
+import io.lionweb.lioncore.java.model.ClassifierInstance;
+import io.lionweb.lioncore.java.model.Node;
+import io.lionweb.lioncore.java.model.ReferenceValue;
+import io.lionweb.lioncore.java.serialization.data.SerializedClassifierInstance;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * This helper class take care of populating containments and references of a node, while we are
+ * deserializing it.
+ */
+class NodePopulator {
+  private JsonSerialization jsonSerialization;
+  private ClassifierInstanceResolver classifierInstanceResolver;
+  private DeserializationStatus deserializationStatus;
+
+  NodePopulator(
+      JsonSerialization jsonSerialization,
+      ClassifierInstanceResolver classifierInstanceResolver,
+      DeserializationStatus deserializationStatus) {
+    this.jsonSerialization = jsonSerialization;
+    this.classifierInstanceResolver = classifierInstanceResolver;
+    this.deserializationStatus = deserializationStatus;
+  }
+
+  void populateClassifierInstance(
+      ClassifierInstance<?> node, SerializedClassifierInstance serializedClassifierInstance) {
+    populateContainments(node, serializedClassifierInstance);
+    populateNodeReferences(node, serializedClassifierInstance);
+  }
+
+  private void populateContainments(
+      ClassifierInstance<?> node, SerializedClassifierInstance serializedClassifierInstance) {
+    Classifier<?> concept = node.getClassifier();
+    serializedClassifierInstance
+        .getContainments()
+        .forEach(
+            serializedContainmentValue -> {
+              Containment containment =
+                  concept.getContainmentByMetaPointer(serializedContainmentValue.getMetaPointer());
+              Objects.requireNonNull(
+                  containment,
+                  "Unable to resolve containment "
+                      + serializedContainmentValue.getMetaPointer()
+                      + " in concept "
+                      + concept);
+              Objects.requireNonNull(
+                  serializedContainmentValue.getValue(),
+                  "The containment value should not be null");
+              List<ClassifierInstance<?>> deserializedValue =
+                  serializedContainmentValue.getValue().stream()
+                      .map(childNodeID -> classifierInstanceResolver.strictlyResolve(childNodeID))
+                      .collect(Collectors.toList());
+              if (!Objects.equals(deserializedValue, node.getChildren(containment))) {
+                deserializedValue.forEach(child -> node.addChild(containment, (Node) child));
+              }
+            });
+  }
+
+  private void populateNodeReferences(
+      ClassifierInstance<?> node, SerializedClassifierInstance serializedClassifierInstance) {
+    Classifier<?> concept = node.getClassifier();
+    // TODO resolve references to Nodes in different models
+    serializedClassifierInstance
+        .getReferences()
+        .forEach(
+            serializedReferenceValue -> {
+              Reference reference =
+                  concept.getReferenceByMetaPointer(serializedReferenceValue.getMetaPointer());
+              if (reference == null) {
+                throw new IllegalStateException(
+                    "Unable to solve reference "
+                        + serializedReferenceValue.getMetaPointer()
+                        + ". Concept "
+                        + concept
+                        + ". SerializedNode "
+                        + serializedClassifierInstance);
+              }
+              serializedReferenceValue
+                  .getValue()
+                  .forEach(
+                      entry -> {
+                        Node referred =
+                            (Node) classifierInstanceResolver.resolve(entry.getReference());
+                        if (entry.getReference() != null && referred == null) {
+                          switch (jsonSerialization.getUnavailableReferenceTargetPolicy()) {
+                            case NULL_REFERENCES:
+                              referred = null;
+                              break;
+                            case PROXY_NODES:
+                              referred = deserializationStatus.createProxy(entry.getReference());
+                              break;
+                            case THROW_ERROR:
+                              throw new DeserializationException(
+                                  "Unable to resolve reference to "
+                                      + entry.getReference()
+                                      + " for feature "
+                                      + serializedReferenceValue.getMetaPointer());
+                            default:
+                              throw new IllegalStateException("This should not happen");
+                          }
+                        }
+                        ReferenceValue referenceValue =
+                            new ReferenceValue(referred, entry.getResolveInfo());
+                        node.addReferenceValue(reference, referenceValue);
+                      });
+            });
+  }
+}

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/UnavailableNodePolicy.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/UnavailableNodePolicy.java
@@ -5,7 +5,8 @@ package io.lionweb.lioncore.java.serialization;
  * partitions) or we will get references to nodes (for example, parents or ancestors) outside of the
  * scope of the tree extracted. This policy specifies what we do with such references.
  */
-public enum UnknownParentPolicy {
+public enum UnavailableNodePolicy {
   NULL_REFERENCES,
-  THROW_ERROR
+  THROW_ERROR,
+  PROXY_NODES
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -710,4 +710,50 @@ public class JsonSerializationTest extends SerializationTest {
         Arrays.asList(new ReferenceValue(pr0td1, "garbage-out")),
         pr1td2.getReferenceValueByName("prerequisite"));
   }
+
+  @Test
+  public void deserializeTreeWithExternalReferencesSetToNullPolicyUnavailableNodePolicy() {
+    JsonSerialization js = JsonSerialization.getStandardSerialization();
+    InputStream languageIs =
+        this.getClass().getResourceAsStream("/serialization/todosLanguage.json");
+    Language todosLanguage = (Language) js.deserializeToNodes(languageIs).get(0);
+    js.registerLanguage(todosLanguage);
+    InputStream is =
+        this.getClass().getResourceAsStream("/serialization/todosWithExternalReferences.json");
+
+    js.enableDynamicNodes();
+    js.setUnavailableParentPolicy(UnavailableNodePolicy.NULL_REFERENCES);
+    js.setUnavailableReferenceTargetPolicy(UnavailableNodePolicy.NULL_REFERENCES);
+    List<Node> nodes = js.deserializeToNodes(is);
+    assertEquals(4, nodes.size());
+
+    Node pr1td0 =
+        nodes.stream()
+            .filter(n -> n.getID().equals("synthetic_my-wonderful-partition_projects_1_todos_0"))
+            .findFirst()
+            .get();
+    assertTrue(pr1td0 instanceof DynamicNode);
+    Node pr1td1 =
+        nodes.stream()
+            .filter(n -> n.getID().equals("synthetic_my-wonderful-partition_projects_1_todos_1"))
+            .findFirst()
+            .get();
+    assertTrue(pr1td1 instanceof DynamicNode);
+    Node pr1td2 =
+        nodes.stream()
+            .filter(n -> n.getID().equals("synthetic_my-wonderful-partition_projects_1_todos_2"))
+            .findFirst()
+            .get();
+    assertTrue(pr1td1 instanceof DynamicNode);
+
+    // local reference
+    assertEquals(
+        Arrays.asList(new ReferenceValue(pr1td0, "BD")),
+        pr1td1.getReferenceValueByName("prerequisite"));
+
+    // external reference
+    assertEquals(
+        Arrays.asList(new ReferenceValue(null, "garbage-out")),
+        pr1td2.getReferenceValueByName("prerequisite"));
+  }
 }

--- a/core/src/test/resources/serialization/todosLanguage.json
+++ b/core/src/test/resources/serialization/todosLanguage.json
@@ -1,0 +1,539 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "LionCore-M3",
+      "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "starlasu_language_TodoLanguage",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Language"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-version"
+          },
+          "value": "1"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "TodoLanguage"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "TodoLanguage"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Language-entities"
+          },
+          "children": [
+            "starlasu_language_TodoLanguage_TodoAccount",
+            "starlasu_language_TodoLanguage_TodoProject",
+            "starlasu_language_TodoLanguage_Todo"
+          ]
+        }
+      ],
+      "references": [
+
+      ],
+      "annotations": [],
+      "parent": null
+    },
+    {
+      "id": "starlasu_language_TodoLanguage_TodoAccount",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "TodoLanguage_TodoAccount"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "TodoAccount"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "starlasu_language_TodoLanguage_TodoAccount_projects"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": []
+        }
+      ],
+      "annotations": [],
+      "parent": "starlasu_language_TodoLanguage"
+    },
+    {
+      "id": "starlasu_language_TodoLanguage_TodoAccount_projects",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "TodoLanguage_TodoAccount_projects"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "projects"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "TodoProject",
+              "reference": "starlasu_language_TodoLanguage_TodoProject"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "starlasu_language_TodoLanguage_TodoAccount"
+    },
+    {
+      "id": "starlasu_language_TodoLanguage_TodoProject",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "TodoLanguage_TodoProject"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "TodoProject"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "starlasu_language_TodoLanguage_TodoProject_todos"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "INamed",
+              "reference": "LionCore-builtins-INamed"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "starlasu_language_TodoLanguage"
+    },
+    {
+      "id": "starlasu_language_TodoLanguage_TodoProject_todos",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Containment"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "TodoLanguage_TodoProject_todos"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "todos"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Todo",
+              "reference": "starlasu_language_TodoLanguage_Todo"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "starlasu_language_TodoLanguage_TodoProject"
+    },
+    {
+      "id": "starlasu_language_TodoLanguage_Todo",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Concept"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-abstract"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-partition"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "TodoLanguage_Todo"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "Todo"
+        }
+      ],
+      "containments": [
+        {
+          "containment": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Classifier-features"
+          },
+          "children": [
+            "starlasu_language_TodoLanguage_Todo_description",
+            "starlasu_language_TodoLanguage_Todo_prerequisite"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-extends"
+          },
+          "targets": [
+
+          ]
+        },
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Concept-implements"
+          },
+          "targets": [
+            {
+              "resolveInfo": "INamed",
+              "reference": "LionCore-builtins-INamed"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "starlasu_language_TodoLanguage"
+    },
+    {
+      "id": "starlasu_language_TodoLanguage_Todo_description",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Property"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "TodoLanguage_Todo_description"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "description"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Property-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "String",
+              "reference": "LionCore-builtins-String"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "starlasu_language_TodoLanguage_Todo"
+    },
+    {
+      "id": "starlasu_language_TodoLanguage_Todo_prerequisite",
+      "classifier": {
+        "language": "LionCore-M3",
+        "version": "2023.1",
+        "key": "Reference"
+      },
+      "properties": [
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-multiple"
+          },
+          "value": "false"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Feature-optional"
+          },
+          "value": "true"
+        },
+        {
+          "property": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "IKeyed-key"
+          },
+          "value": "TodoLanguage_Todo_prerequisite"
+        },
+        {
+          "property": {
+            "language": "LionCore-builtins",
+            "version": "2023.1",
+            "key": "LionCore-builtins-INamed-name"
+          },
+          "value": "prerequisite"
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "reference": {
+            "language": "LionCore-M3",
+            "version": "2023.1",
+            "key": "Link-type"
+          },
+          "targets": [
+            {
+              "resolveInfo": "Todo",
+              "reference": "starlasu_language_TodoLanguage_Todo"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "parent": "starlasu_language_TodoLanguage_Todo"
+    }
+  ]
+}

--- a/core/src/test/resources/serialization/todosWithExternalReferences.json
+++ b/core/src/test/resources/serialization/todosWithExternalReferences.json
@@ -1,0 +1,177 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "TodoLanguage",
+      "version": "1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "synthetic_my-wonderful-partition_projects_1",
+      "classifier": {
+        "key": "TodoLanguage_TodoProject",
+        "version": "1",
+        "language": "TodoLanguage"
+      },
+      "parent": null,
+      "properties": [
+        {
+          "value": "My other errands list",
+          "property": {
+            "key": "LionCore-builtins-INamed-name",
+            "version": "2023.1",
+            "language": "LionCore-builtins"
+          }
+        }
+      ],
+      "containments": [
+        {
+          "children": [
+            "synthetic_my-wonderful-partition_projects_1_todos_0",
+            "synthetic_my-wonderful-partition_projects_1_todos_1",
+            "synthetic_my-wonderful-partition_projects_1_todos_2"
+          ],
+          "containment": {
+            "key": "TodoLanguage_TodoProject_todos",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        }
+      ],
+      "references": [],
+      "annotations": []
+    },
+    {
+      "id": "synthetic_my-wonderful-partition_projects_1_todos_0",
+      "classifier": {
+        "key": "TodoLanguage_Todo",
+        "version": "1",
+        "language": "TodoLanguage"
+      },
+      "parent": "synthetic_my-wonderful-partition_projects_1",
+      "properties": [
+        {
+          "value": "Buy diary",
+          "property": {
+            "key": "TodoLanguage_Todo_description",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        },
+        {
+          "value": "BD",
+          "property": {
+            "key": "LionCore-builtins-INamed-name",
+            "version": "2023.1",
+            "language": "LionCore-builtins"
+          }
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "targets": [],
+          "reference": {
+            "key": "TodoLanguage_Todo_prerequisite",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        }
+      ],
+      "annotations": []
+    },
+    {
+      "id": "synthetic_my-wonderful-partition_projects_1_todos_1",
+      "classifier": {
+        "key": "TodoLanguage_Todo",
+        "version": "1",
+        "language": "TodoLanguage"
+      },
+      "parent": "synthetic_my-wonderful-partition_projects_1",
+      "properties": [
+        {
+          "value": "Write in diary",
+          "property": {
+            "key": "TodoLanguage_Todo_description",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        },
+        {
+          "value": "WD",
+          "property": {
+            "key": "LionCore-builtins-INamed-name",
+            "version": "2023.1",
+            "language": "LionCore-builtins"
+          }
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "targets": [
+            {
+              "reference": "synthetic_my-wonderful-partition_projects_1_todos_0",
+              "resolveInfo": "BD"
+            }
+          ],
+          "reference": {
+            "key": "TodoLanguage_Todo_prerequisite",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        }
+      ],
+      "annotations": []
+    },
+    {
+      "id": "synthetic_my-wonderful-partition_projects_1_todos_2",
+      "classifier": {
+        "key": "TodoLanguage_Todo",
+        "version": "1",
+        "language": "TodoLanguage"
+      },
+      "parent": "synthetic_my-wonderful-partition_projects_1",
+      "properties": [
+        {
+          "value": "Produce more garbage",
+          "property": {
+            "key": "TodoLanguage_Todo_description",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        },
+        {
+          "value": "garbage-in",
+          "property": {
+            "key": "LionCore-builtins-INamed-name",
+            "version": "2023.1",
+            "language": "LionCore-builtins"
+          }
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "targets": [
+            {
+              "reference": "synthetic_my-wonderful-partition_projects_0_todos_1",
+              "resolveInfo": "garbage-out"
+            }
+          ],
+          "reference": {
+            "key": "TodoLanguage_Todo_prerequisite",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        }
+      ],
+      "annotations": []
+    }
+  ]
+}


### PR DESCRIPTION
In this PR we cover a problem similar to what we covered in #132 

In #132 we looked at what happens when we retrieve a partial tree (so we have references to a parent that we have not retrieved). In that case we introduced the possibility of picking a policy to specify what to do: should we throw an error? Or set the un-retrieved parent to null?

We now introduce a third possibility: generating proxy nodes.

With this PR we also introduce the possibility to set this policy not only to deal with parents that are unavailable, but also to deal with references to nodes that are not available (which is typically the case when referring to nodes outside the tree considered). When retrieving a tree we want references which are local to the tree to be resolved correctly, setting the "real node" as the referred value. For references to nodes outside the tree consider we can again specify a policy to deal with that. The three options are the same: throw error, set them to null, or use proxy nodes.