### PR TITLE
Support deserializing of shallow trees

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/api/ClassifierInstanceResolver.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/api/ClassifierInstanceResolver.java
@@ -28,10 +28,6 @@ public interface ClassifierInstanceResolver {
   @Nonnull
   default ClassifierInstance<?> resolveOrProxy(String instanceID) {
     ClassifierInstance<?> partial = resolve(instanceID);
-    if (partial == null) {
-      return new ProxyNode(instanceID);
-    } else {
-      return partial;
-    }
+    return partial == null ? new ProxyNode(instanceID) : partial;
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/api/ClassifierInstanceResolver.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/api/ClassifierInstanceResolver.java
@@ -1,6 +1,7 @@
 package io.lionweb.lioncore.java.api;
 
 import io.lionweb.lioncore.java.model.ClassifierInstance;
+import io.lionweb.lioncore.java.model.impl.ProxyNode;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -19,6 +20,16 @@ public interface ClassifierInstanceResolver {
     ClassifierInstance<?> partial = resolve(instanceID);
     if (partial == null) {
       throw new UnresolvedClassifierInstanceException(instanceID);
+    } else {
+      return partial;
+    }
+  }
+
+  @Nonnull
+  default ClassifierInstance<?> resolveOrProxy(String instanceID) {
+    ClassifierInstance<?> partial = resolve(instanceID);
+    if (partial == null) {
+      return new ProxyNode(instanceID);
     } else {
       return partial;
     }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
@@ -1,6 +1,7 @@
 package io.lionweb.lioncore.java.model;
 
 import io.lionweb.lioncore.java.language.*;
+import io.lionweb.lioncore.java.model.impl.ProxyNode;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -119,7 +120,9 @@ public interface Node extends ClassifierInstance<Concept> {
     List<Node> nodes = new ArrayList<>();
     nodes.add(this);
     for (Node child : this.getChildren()) {
-      nodes.addAll(child.thisAndAllDescendants());
+      if (!(child instanceof ProxyNode)) {
+        nodes.addAll(child.thisAndAllDescendants());
+      }
     }
     return nodes;
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
@@ -107,7 +107,9 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
 
   private void addContainment(Containment link, Node value) {
     assert link.isMultiple();
-    ((DynamicNode) value).setParent((Node) this);
+    if (!(value instanceof ProxyNode)) {
+      ((DynamicNode) value).setParent((Node) this);
+    }
     if (containmentValues.containsKey(link.getID())) {
       containmentValues.get(link.getID()).add(value);
     } else {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -240,7 +240,13 @@ public class JsonSerialization {
   }
 
   public JsonElement serializeTreeToJsonElement(Node node) {
-    return serializeNodesToJsonElement(node.thisAndAllDescendants());
+    if (node instanceof ProxyNode) {
+      throw new IllegalArgumentException("Proxy nodes cannot be serialized");
+    }
+    return serializeNodesToJsonElement(
+        node.thisAndAllDescendants().stream()
+            .filter(n -> !(n instanceof ProxyNode))
+            .collect(Collectors.toList()));
   }
 
   public JsonElement serializeTreesToJsonElement(Node... roots) {
@@ -262,10 +268,14 @@ public class JsonSerialization {
                 }
               });
     }
-    return serializeNodesToJsonElement(allNodes);
+    return serializeNodesToJsonElement(
+        allNodes.stream().filter(n -> !(n instanceof ProxyNode)).collect(Collectors.toList()));
   }
 
   public JsonElement serializeNodesToJsonElement(List<Node> nodes) {
+    if (nodes.stream().anyMatch(n -> n instanceof ProxyNode)) {
+      throw new IllegalArgumentException("Proxy nodes cannot be serialized");
+    }
     SerializedChunk serializationBlock = serializeNodesToSerializationBlock(nodes);
     return new LowLevelJsonSerialization().serializeToJsonElement(serializationBlock);
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -108,6 +108,12 @@ public class JsonSerialization {
   private UnavailableNodePolicy unavailableParentPolicy = UnavailableNodePolicy.THROW_ERROR;
 
   /**
+   * This guides what we do when deserializing a sub-tree and not being able to resolve the
+   * children.
+   */
+  private UnavailableNodePolicy unavailableChildrenPolicy = UnavailableNodePolicy.THROW_ERROR;
+
+  /**
    * This guides what we do when deserializing a sub-tree and not being able to resolve a reference
    * target.
    */
@@ -155,9 +161,19 @@ public class JsonSerialization {
     return this.unavailableReferenceTargetPolicy;
   }
 
+  public @Nonnull UnavailableNodePolicy getUnavailableChildrenPolicy() {
+    return this.unavailableChildrenPolicy;
+  }
+
   public void setUnavailableParentPolicy(@Nonnull UnavailableNodePolicy unavailableParentPolicy) {
     Objects.requireNonNull(unavailableParentPolicy);
     this.unavailableParentPolicy = unavailableParentPolicy;
+  }
+
+  public void setUnavailableChildrenPolicy(
+      @Nonnull UnavailableNodePolicy unavailableChildrenPolicy) {
+    Objects.requireNonNull(unavailableChildrenPolicy);
+    this.unavailableChildrenPolicy = unavailableChildrenPolicy;
   }
 
   public void setUnavailableReferenceTargetPolicy(

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
@@ -56,7 +56,15 @@ class NodePopulator {
                   "The containment value should not be null");
               List<ClassifierInstance<?>> deserializedValue =
                   serializedContainmentValue.getValue().stream()
-                      .map(childNodeID -> classifierInstanceResolver.strictlyResolve(childNodeID))
+                      .map(
+                          childNodeID -> {
+                            if (jsonSerialization.getUnavailableChildrenPolicy()
+                                == UnavailableNodePolicy.PROXY_NODES) {
+                              return classifierInstanceResolver.resolveOrProxy(childNodeID);
+                            } else {
+                              return classifierInstanceResolver.strictlyResolve(childNodeID);
+                            }
+                          })
                       .collect(Collectors.toList());
               if (!Objects.equals(deserializedValue, node.getChildren(containment))) {
                 deserializedValue.forEach(child -> node.addChild(containment, (Node) child));

--- a/core/src/test/resources/serialization/todosWithChildrenNotProvided.json
+++ b/core/src/test/resources/serialization/todosWithChildrenNotProvided.json
@@ -1,0 +1,50 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "TodoLanguage",
+      "version": "1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "synthetic_my-wonderful-partition_projects_1",
+      "classifier": {
+        "key": "TodoLanguage_TodoProject",
+        "version": "1",
+        "language": "TodoLanguage"
+      },
+      "parent": null,
+      "properties": [
+        {
+          "value": "My other errands list",
+          "property": {
+            "key": "LionCore-builtins-INamed-name",
+            "version": "2023.1",
+            "language": "LionCore-builtins"
+          }
+        }
+      ],
+      "containments": [
+        {
+          "children": [
+            "synthetic_my-wonderful-partition_projects_1_todos_0",
+            "synthetic_my-wonderful-partition_projects_1_todos_1",
+            "synthetic_my-wonderful-partition_projects_1_todos_2"
+          ],
+          "containment": {
+            "key": "TodoLanguage_TodoProject_todos",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        }
+      ],
+      "references": [],
+      "annotations": []
+    }
+  ]
+}


### PR DESCRIPTION
When retrieving data from sources like the LionWeb Repository, we may want to retrieve a shallow tree (i.e., not all the descendants of each node considered). When doing so we need to be able to unserialize references to children which we did not receive. To handle this case we do the same thing we did for missing parents and reference targets: we let the user specify a policy. The user can decide if to get an error or get proxy nodes to represent the children for which we do not have all the data