### PR TITLE
Introduce HasSettableParent

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/model/HasSettableParent.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/HasSettableParent.java
@@ -1,0 +1,11 @@
+package io.lionweb.lioncore.java.model;
+
+import javax.annotation.Nullable;
+
+/**
+ * Certain nodes have a parent that can be set. This is typically done for consistency when adding a
+ * node into a containment.
+ */
+public interface HasSettableParent {
+  void setParent(@Nullable Node parent);
+}

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
@@ -91,6 +91,8 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
     }
     if (value == null) {
       containmentValues.remove(link.getID());
+    } else if (value instanceof ProxyNode) {
+      // Nothing to do here
     } else {
       ((DynamicNode) value).setParent((Node) this);
       containmentValues.put(link.getID(), new ArrayList(Arrays.asList(value)));

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
@@ -1,10 +1,7 @@
 package io.lionweb.lioncore.java.model.impl;
 
 import io.lionweb.lioncore.java.language.*;
-import io.lionweb.lioncore.java.model.AnnotationInstance;
-import io.lionweb.lioncore.java.model.ClassifierInstance;
-import io.lionweb.lioncore.java.model.Node;
-import io.lionweb.lioncore.java.model.ReferenceValue;
+import io.lionweb.lioncore.java.model.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -91,10 +88,8 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
     }
     if (value == null) {
       containmentValues.remove(link.getID());
-    } else if (value instanceof ProxyNode) {
-      // Nothing to do here
-    } else {
-      ((DynamicNode) value).setParent((Node) this);
+    } else if (value instanceof HasSettableParent) {
+      ((HasSettableParent) value).setParent((Node) this);
       containmentValues.put(link.getID(), new ArrayList(Arrays.asList(value)));
     }
   }
@@ -109,8 +104,8 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
 
   private void addContainment(Containment link, Node value) {
     assert link.isMultiple();
-    if (!(value instanceof ProxyNode)) {
-      ((DynamicNode) value).setParent((Node) this);
+    if (value instanceof HasSettableParent) {
+      ((HasSettableParent) value).setParent((Node) this);
     }
     if (containmentValues.containsKey(link.getID())) {
       containmentValues.get(link.getID()).add(value);
@@ -136,7 +131,9 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
     for (Map.Entry<String, List<Node>> entry : containmentValues.entrySet()) {
       if (entry.getValue().contains(node)) {
         entry.getValue().remove(node);
-        ((DynamicNode) node).setParent(null);
+        if (node instanceof HasSettableParent) {
+          ((HasSettableParent) node).setParent(null);
+        }
         return;
       }
     }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
@@ -1,6 +1,7 @@
 package io.lionweb.lioncore.java.model.impl;
 
 import io.lionweb.lioncore.java.language.*;
+import io.lionweb.lioncore.java.model.HasSettableParent;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.Partition;
 import java.util.*;
@@ -10,7 +11,8 @@ import java.util.stream.Collectors;
  * DynamicNode can be used to represent Node of any Concept. The drawback is that this class expose
  * only homogeneous-APIs (e.g., getProperty('book')) and not heterogeneous-APIs (e.g., getBook()).
  */
-public class DynamicNode extends DynamicClassifierInstance<Concept> implements Node {
+public class DynamicNode extends DynamicClassifierInstance<Concept>
+    implements Node, HasSettableParent {
   private Node parent = null;
   private Concept concept = null;
 
@@ -39,6 +41,7 @@ public class DynamicNode extends DynamicClassifierInstance<Concept> implements N
     throw new UnsupportedOperationException();
   }
 
+  @Override
   public void setParent(Node parent) {
     this.parent = parent;
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -10,8 +10,8 @@ import io.lionweb.lioncore.java.api.LocalClassifierInstanceResolver;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.AnnotationInstance;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
+import io.lionweb.lioncore.java.model.HasSettableParent;
 import io.lionweb.lioncore.java.model.Node;
-import io.lionweb.lioncore.java.model.impl.DynamicNode;
 import io.lionweb.lioncore.java.model.impl.ProxyNode;
 import io.lionweb.lioncore.java.self.LionCore;
 import io.lionweb.lioncore.java.serialization.data.*;
@@ -611,8 +611,8 @@ public class JsonSerialization {
                 // the parent explicitly
                 ProxyNode proxyParent = deserializationStatus.proxyFor(node.getParentNodeID());
                 if (proxyParent != null) {
-                  if (classifierInstance instanceof DynamicNode) {
-                    ((DynamicNode) classifierInstance).setParent(proxyParent);
+                  if (classifierInstance instanceof HasSettableParent) {
+                    ((HasSettableParent) classifierInstance).setParent(proxyParent);
                   } else {
                     throw new UnsupportedOperationException(
                         "We do not know how to set explicitly the parent of " + classifierInstance);


### PR DESCRIPTION
When adding a Node into a containment, we try to set its parent.
This is not always possible, depending on the nature of the parent (e.g., Proxy node).
For this reason, we introduce an interface to mark nodes with a settable parent.

Note that currently we are explicitly looking for instances of DynamicNode, as we knew that those had the `setParent` method.