### PR TITLE
Minor fixes around DynamicNode and serialization

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
@@ -9,14 +9,17 @@ import javax.annotation.Nullable;
 
 public abstract class DynamicClassifierInstance<T extends Classifier<T>>
     implements ClassifierInstance<T> {
-  protected String id;
+  /** The ID should _eventually_ be not null. */
+  protected @Nullable String id;
+
   protected final Map<String, Object> propertyValues = new HashMap<>();
   protected final Map<String, List<Node>> containmentValues = new HashMap<>();
 
   protected final Map<String, List<ReferenceValue>> referenceValues = new HashMap<>();
   protected final List<AnnotationInstance> annotations = new ArrayList<>();
 
-  public void setID(String id) {
+  /** The ID can be _temporarily_ set to null, but _eventually_ it should be not null. */
+  public void setID(@Nullable String id) {
     this.id = id;
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
@@ -16,6 +16,10 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
   protected final Map<String, List<ReferenceValue>> referenceValues = new HashMap<>();
   protected final List<AnnotationInstance> annotations = new ArrayList<>();
 
+  public void setID(String id) {
+    this.id = id;
+  }
+
   @Override
   public Object getPropertyValue(@Nonnull Property property) {
     Objects.requireNonNull(property, "Property should not be null");

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
@@ -4,6 +4,8 @@ import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.HasSettableParent;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.Partition;
+
+import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -37,8 +39,17 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
   }
 
   @Override
+  @Nullable
   public Containment getContainmentFeature() {
-    throw new UnsupportedOperationException();
+    if (parent == null) {
+      return null;
+    }
+    for (Containment containment : parent.getConcept().allContainments()) {
+      if (parent.getChildren(containment).stream().anyMatch( it -> it ==this)) {
+        return containment;
+      }
+    }
+    throw new IllegalStateException("Unable to find the containment feature");
   }
 
   @Override

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
@@ -4,11 +4,10 @@ import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.HasSettableParent;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.Partition;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * DynamicNode can be used to represent Node of any Concept. The drawback is that this class expose
@@ -55,7 +54,7 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
       return null;
     }
     for (Containment containment : parent.getConcept().allContainments()) {
-      if (parent.getChildren(containment).stream().anyMatch( it -> it ==this)) {
+      if (parent.getChildren(containment).stream().anyMatch(it -> it == this)) {
         return containment;
       }
     }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
@@ -5,6 +5,7 @@ import io.lionweb.lioncore.java.model.HasSettableParent;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.Partition;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -18,8 +19,17 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
   private Node parent = null;
   private Concept concept = null;
 
-  public DynamicNode(String id, Concept concept) {
+  public DynamicNode(@Nonnull String id, @Nonnull Concept concept) {
     this.id = id;
+    this.concept = concept;
+  }
+
+  public DynamicNode() {
+    this.id = null;
+    this.concept = null;
+  }
+
+  public void setConcept(Concept concept) {
     this.concept = concept;
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -518,7 +518,7 @@ public class JsonSerialization {
           Set<String> knownIDs =
               originalList.stream().map(ci -> ci.getID()).collect(Collectors.toSet());
           Set<String> parentIDs =
-              originalList.stream().map(n -> n.getParentNodeID()).collect(Collectors.toSet());
+              originalList.stream().map(n -> n.getParentNodeID()).filter(id -> id != null).collect(Collectors.toSet());
           Set<String> unknownParentIDs = Sets.difference(parentIDs, knownIDs);
           originalList.stream()
               .filter(ci -> unknownParentIDs.contains(ci.getParentNodeID()))

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -518,7 +518,10 @@ public class JsonSerialization {
           Set<String> knownIDs =
               originalList.stream().map(ci -> ci.getID()).collect(Collectors.toSet());
           Set<String> parentIDs =
-              originalList.stream().map(n -> n.getParentNodeID()).filter(id -> id != null).collect(Collectors.toSet());
+              originalList.stream()
+                  .map(n -> n.getParentNodeID())
+                  .filter(id -> id != null)
+                  .collect(Collectors.toSet());
           Set<String> unknownParentIDs = Sets.difference(parentIDs, knownIDs);
           originalList.stream()
               .filter(ci -> unknownParentIDs.contains(ci.getParentNodeID()))


### PR DESCRIPTION
These are small changes mostly in DynamicNode.

* We permit to modify `id` and `concept` after instantiation
* We implement `getContainmentFeature`

We also solve a problem with deserializing of null parents.