### PR TITLE
Revisit node class

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/language/Annotation.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Annotation.java
@@ -120,7 +120,7 @@ public class Annotation extends Classifier<Annotation> {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LionCore.getAnnotation();
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Concept.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Concept.java
@@ -121,7 +121,7 @@ public class Concept extends Classifier<Concept> {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LionCore.getConcept();
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Containment.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Containment.java
@@ -107,7 +107,7 @@ public class Containment extends Link<Containment> {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LionCore.getContainment();
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Enumeration.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Enumeration.java
@@ -30,7 +30,7 @@ public class Enumeration extends DataType<Enumeration> implements NamespaceProvi
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LionCore.getEnumeration();
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/EnumerationLiteral.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/EnumerationLiteral.java
@@ -52,7 +52,7 @@ public class EnumerationLiteral extends M3Node<EnumerationLiteral>
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LionCore.getEnumerationLiteral();
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Interface.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Interface.java
@@ -72,7 +72,7 @@ public class Interface extends Classifier<Interface> {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LionCore.getInterface();
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Language.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Language.java
@@ -162,7 +162,7 @@ public class Language extends M3Node<Language> implements NamespaceProvider, IKe
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LionCore.getLanguage();
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/language/PrimitiveType.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/PrimitiveType.java
@@ -36,7 +36,7 @@ public class PrimitiveType extends DataType<PrimitiveType> {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LionCore.getPrimitiveType();
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
@@ -93,7 +93,7 @@ public class Property extends Feature<Property> {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LionCore.getProperty();
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Reference.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Reference.java
@@ -104,7 +104,7 @@ public class Reference extends Link<Reference> {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LionCore.getReference();
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/AnnotationInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/AnnotationInstance.java
@@ -1,7 +1,6 @@
 package io.lionweb.lioncore.java.model;
 
 import io.lionweb.lioncore.java.language.Annotation;
-import io.lionweb.lioncore.java.language.Classifier;
 
 /**
  * While an AnnotationInstance implements HasFeatureValues, it is forbidden to hold any children, as
@@ -10,7 +9,7 @@ import io.lionweb.lioncore.java.language.Classifier;
 public interface AnnotationInstance extends ClassifierInstance<Annotation> {
   Annotation getAnnotationDefinition();
 
-  default Classifier<Annotation> getClassifier() {
+  default Annotation getClassifier() {
     return getAnnotationDefinition();
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/ClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/ClassifierInstance.java
@@ -11,7 +11,7 @@ public interface ClassifierInstance<T extends Classifier<T>> extends HasFeatureV
 
   String getID();
 
-  Classifier<T> getClassifier();
+  T getClassifier();
 
   /** The immediate parent of the Node. This should be null only for root nodes. */
   ClassifierInstance<T> getParent();

--- a/core/src/main/java/io/lionweb/lioncore/java/model/HasFeatureValues.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/HasFeatureValues.java
@@ -15,11 +15,7 @@ public interface HasFeatureValues {
    */
   Object getPropertyValue(Property property);
 
-  /**
-   * If the value is not compatible with the type of the property, the exception
-   * IllegalArgumentException will be thrown. If the feature is derived, the exception
-   * IllegalArgumentException will be thrown.
-   */
+  /** If the value is not compatible with the type of the property, the exception */
   void setPropertyValue(Property property, Object value);
 
   /** This return all the Nodes directly contained into this Node. */
@@ -37,7 +33,6 @@ public interface HasFeatureValues {
    * than the exception IllegalStateException will be thrown.
    *
    * <p>If the child has not a Concept compatible with the target of the Containement, the exception
-   * IllegalArgumentException will be thrown. If the Containment feature is derived, the exception
    * IllegalArgumentException will be thrown.
    */
   void addChild(Containment containment, Node child);
@@ -46,11 +41,34 @@ public interface HasFeatureValues {
    * Remove the given child from the list of children associated with the Node, making it a dangling
    * Node. If the specified Node is not currently a child of this Node the exception
    * IllegalArgumentException will be thrown.
-   *
-   * <p>If the Containment feature is derived, the exception IllegalArgumentException will be
-   * thrown.
    */
   void removeChild(Node node);
+
+  /**
+   * Remove the child at the given index, considering the children under the given containment.
+   *
+   * <p>If there is no match the exception IllegalArgumentException will be thrown.
+   */
+  void removeChild(@Nonnull Containment containment, int index);
+
+  @Nonnull
+  List<ReferenceValue> getReferenceValues();
+
+  /**
+   * Return the Nodes referred to under any Reference link. This returns an empty list if no Node is
+   * referred by this Node.
+   *
+   * <p>The Node returned is guaranteed to be either part of this Node's Model or of Models imported
+   * by this Node's Model.
+   *
+   * <p>Please note that this will not return null values, differently from the variant taking a
+   * Reference.
+   */
+  @Nonnull
+  List<Node> getReferredNodes();
+
+  @Nonnull
+  List<ReferenceValue> getReferenceValues(@Nonnull Reference reference);
 
   /**
    * Return the Nodes referred to under the specified Reference link. This returns an empty list if
@@ -59,14 +77,11 @@ public interface HasFeatureValues {
    * <p>The Node returned is guaranteed to be either part of this Node's Model or of Models imported
    * by this Node's Model.
    *
-   * <p>Please note that it may contains null values in case of ReferenceValue with a null reference
+   * <p>Please note that it may contain null values in case of ReferenceValue with a null referred
    * field.
    */
   @Nonnull
   List<Node> getReferredNodes(@Nonnull Reference reference);
-
-  @Nonnull
-  List<ReferenceValue> getReferenceValues(@Nonnull Reference reference);
 
   /**
    * Add the Node to the list of Nodes referred to from this Node under the given Reference.
@@ -77,8 +92,21 @@ public interface HasFeatureValues {
    * Node's Model. If that is not the case the exception IllegalArgumentException will be thrown.
    *
    * <p>If the referredNode has not a Concept compatible with the target of the Reference, the
-   * exception IllegalArgumentException will be thrown. If the Reference feature is derived, the
    * exception IllegalArgumentException will be thrown.
    */
   void addReferenceValue(@Nonnull Reference reference, @Nullable ReferenceValue referredNode);
+
+  /**
+   * Remove the first reference value that is equal to the given referenceValue. Node. If there is
+   * no match the exception IllegalArgumentException will be thrown.
+   */
+  void removeReferenceValue(@Nonnull Reference reference, @Nullable ReferenceValue referenceValue);
+
+  /**
+   * Remove the reference value at the given index, considering the reference values under the given
+   * reference.
+   *
+   * <p>If there is no match the exception IllegalArgumentException will be thrown.
+   */
+  void removeReferenceValue(@Nonnull Reference reference, int index);
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/HasFeatureValues.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/HasFeatureValues.java
@@ -62,7 +62,7 @@ public interface HasFeatureValues {
    * by this Node's Model.
    *
    * <p>Please note that this will not return null values, differently from the variant taking a
-   * Reference.
+   * Reference. It may contain duplicates.
    */
   @Nonnull
   List<Node> getReferredNodes();
@@ -109,4 +109,8 @@ public interface HasFeatureValues {
    * <p>If there is no match the exception IllegalArgumentException will be thrown.
    */
   void removeReferenceValue(@Nonnull Reference reference, int index);
+
+  void setOnlyReferenceValueByName(String referenceName, @Nullable ReferenceValue value);
+
+  void setReferenceValuesByName(String referenceName, @Nonnull List<ReferenceValue> values);
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
@@ -28,12 +28,6 @@ public interface Node extends ClassifierInstance<Concept> {
   String getID();
 
   /**
-   * The Partition in which the Node is contained. A Node is contained into a Partition when it is a
-   * root node of that Node or if one of its ancestors is.
-   */
-  Partition getPartition();
-
-  /**
    * If a Node is a root node in a Model, this method returns the node itself. Otherwise it returns
    * the ancestor which is a root node. This method should return null only if the Node is not
    * inserted in a Model and it is therefore considered a dangling Node.
@@ -52,8 +46,12 @@ public interface Node extends ClassifierInstance<Concept> {
     return ancestors.get(ancestors.size() - 1);
   }
 
+  default boolean isRoot() {
+    return getParent() == null;
+  }
+
   /** The concept of which this Node is an instance. The Concept should not be abstract. */
-  Concept getConcept();
+  Concept getClassifier();
 
   /**
    * Return the Containment feature used to hold this Node within its parent. This will be null only
@@ -65,35 +63,6 @@ public interface Node extends ClassifierInstance<Concept> {
    */
   Containment getContainmentFeature();
 
-  default Object getPropertyValueByName(String propertyName) {
-    Property property = this.getConcept().getPropertyByName(propertyName);
-    if (property == null) {
-      throw new IllegalArgumentException(
-          "Concept "
-              + this.getConcept().qualifiedName()
-              + " does not contained a property named "
-              + propertyName);
-    }
-    return getPropertyValue(property);
-  }
-
-  default void setPropertyValueByName(String propertyName, Object value) {
-    Property property = this.getConcept().getPropertyByName(propertyName);
-    if (property == null) {
-      throw new IllegalArgumentException(
-          "Concept "
-              + this.getConcept().qualifiedName()
-              + " does not contained a property named "
-              + propertyName);
-    }
-    setPropertyValue(property, value);
-  }
-
-  default Object getPropertyValueByID(String propertyID) {
-    Property property = this.getConcept().getPropertyByID(propertyID);
-    return getPropertyValue(property);
-  }
-
   /**
    * Return a list containing this node and all its descendants. Does <i>not</i> include
    * annotations.
@@ -104,8 +73,41 @@ public interface Node extends ClassifierInstance<Concept> {
     return result;
   }
 
+  // Properties methods
+
+  default Object getPropertyValueByName(String propertyName) {
+    Property property = this.getClassifier().getPropertyByName(propertyName);
+    if (property == null) {
+      throw new IllegalArgumentException(
+          "Concept "
+              + this.getClassifier().qualifiedName()
+              + " does not contained a property named "
+              + propertyName);
+    }
+    return getPropertyValue(property);
+  }
+
+  default void setPropertyValueByName(String propertyName, Object value) {
+    Property property = this.getClassifier().getPropertyByName(propertyName);
+    if (property == null) {
+      throw new IllegalArgumentException(
+          "Concept "
+              + this.getClassifier().qualifiedName()
+              + " does not contained a property named "
+              + propertyName);
+    }
+    setPropertyValue(property, value);
+  }
+
+  default Object getPropertyValueByID(String propertyID) {
+    Property property = this.getClassifier().getPropertyByID(propertyID);
+    return getPropertyValue(property);
+  }
+
+  // Containments methods
+
   default List<? extends Node> getChildrenByContainmentName(String containmentName) {
-    return getChildren(getConcept().requireContainmentByName(containmentName));
+    return getChildren(getClassifier().requireContainmentByName(containmentName));
   }
 
   default @Nullable Node getOnlyChildByContainmentName(String containmentName) {
@@ -119,12 +121,14 @@ public interface Node extends ClassifierInstance<Concept> {
     }
   }
 
+  // References methods
+
   default List<ReferenceValue> getReferenceValueByName(String referenceName) {
-    Reference reference = this.getConcept().getReferenceByName(referenceName);
+    Reference reference = this.getClassifier().getReferenceByName(referenceName);
     if (reference == null) {
       throw new IllegalArgumentException(
           "Concept "
-              + this.getConcept().qualifiedName()
+              + this.getClassifier().qualifiedName()
               + " does not contained a property named "
               + referenceName);
     }
@@ -140,13 +144,5 @@ public interface Node extends ClassifierInstance<Concept> {
     } else {
       return referenceValues.get(0);
     }
-  }
-
-  default Classifier<Concept> getClassifier() {
-    return getConcept();
-  }
-
-  default boolean isRoot() {
-    return getParent() == null;
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
@@ -131,6 +131,17 @@ public interface Node extends ClassifierInstance<Concept> {
     return getReferenceValues(reference);
   }
 
+  default @Nullable ReferenceValue getOnlyReferenceValueByReferenceName(String referenceName) {
+    List<ReferenceValue> referenceValues = getReferenceValueByName(referenceName);
+    if (referenceValues.size() > 1) {
+      throw new IllegalStateException();
+    } else if (referenceValues.isEmpty()) {
+      return null;
+    } else {
+      return referenceValues.get(0);
+    }
+  }
+
   default Classifier<Concept> getClassifier() {
     return getConcept();
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/Partition.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/Partition.java
@@ -5,7 +5,8 @@ import io.lionweb.lioncore.java.language.Language;
 import java.util.List;
 
 /**
- * This represents a container of nodes.
+ * This represents a container of nodes. This idea was not retained. Partitions are now simple
+ * nodes, and this should be removed.
  *
  * @see org.eclipse.emf.ecore.resource.Resource Ecore equivalent <i>Resource</i>
  * @see <a href="https://www.jetbrains.com/help/mps/mps-project-structure.html#models">MPS
@@ -13,6 +14,7 @@ import java.util.List;
  *     <p>TODO consider if the Model should have a version too
  */
 @Experimental
+@Deprecated
 public interface Partition {
   /** Return the fully qualified name associated with the model. */
   String getName();

--- a/core/src/main/java/io/lionweb/lioncore/java/model/ReferenceValue.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/ReferenceValue.java
@@ -56,7 +56,7 @@ public class ReferenceValue {
   public String toString() {
     return "ReferenceValue{"
         + "referred="
-        + referred
+        + (referred == null ? "null" : referred.getID())
         + ", resolveInfo='"
         + resolveInfo
         + '\''

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/AbstractClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/AbstractClassifierInstance.java
@@ -4,16 +4,18 @@ import io.lionweb.lioncore.java.language.Annotation;
 import io.lionweb.lioncore.java.language.Classifier;
 import io.lionweb.lioncore.java.model.AnnotationInstance;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import io.lionweb.lioncore.java.model.Node;
+import io.lionweb.lioncore.java.model.ReferenceValue;
+import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public abstract class AbstractClassifierInstance<T extends Classifier<T>>
     implements ClassifierInstance<T> {
   protected final List<AnnotationInstance> annotations = new ArrayList<>();
+
+  // Public methods for annotations
 
   @Override
   public List<AnnotationInstance> getAnnotations() {
@@ -75,4 +77,44 @@ public abstract class AbstractClassifierInstance<T extends Classifier<T>>
       ((DynamicAnnotationInstance) instance).setAnnotated(null);
     }
   }
+
+  // Public methods for containments
+
+  @Override
+  @Nonnull
+  public List<Node> getChildren() {
+    List<Node> allChildren = new LinkedList<>();
+    getClassifier().allContainments().stream()
+        .map(c -> getChildren(c))
+        .forEach(children -> allChildren.addAll(children));
+    return allChildren;
+  }
+
+  // Public methods for references
+
+  @Nonnull
+  @Override
+  public List<ReferenceValue> getReferenceValues() {
+    List<ReferenceValue> allReferredValues = new LinkedList<>();
+    getClassifier().allReferences().stream()
+        .map(r -> getReferenceValues(r))
+        .forEach(referenceValues -> allReferredValues.addAll(referenceValues));
+    return allReferredValues;
+  }
+
+  @Nonnull
+  @Override
+  public List<Node> getReferredNodes() {
+    return getReferenceValues().stream()
+        .map(rv -> rv.getReferred())
+        .filter(n -> n != null)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void setOnlyReferenceValueByName(String referenceName, @Nullable ReferenceValue value) {}
+
+  @Override
+  public void setReferenceValuesByName(
+      String referenceName, @Nonnull List<ReferenceValue> values) {}
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
@@ -66,16 +66,6 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
   // Public methods for containments
 
   @Override
-  @Nonnull
-  public List<Node> getChildren() {
-    List<Node> allChildren = new LinkedList<>();
-    getClassifier().allContainments().stream()
-        .map(c -> getChildren(c))
-        .forEach(children -> allChildren.addAll(children));
-    return allChildren;
-  }
-
-  @Override
   public List<Node> getChildren(@Nonnull Containment containment) {
     Objects.requireNonNull(containment, "Containment should not be null");
     if (!getClassifier().allContainments().contains(containment)) {
@@ -114,28 +104,18 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
 
   @Override
   public void removeChild(@Nonnull Containment containment, int index) {
-    throw new UnsupportedOperationException();
-  }
-
-  // Public methods for references
-
-  @Nonnull
-  @Override
-  public List<ReferenceValue> getReferenceValues() {
-    List<ReferenceValue> allReferredValues = new LinkedList<>();
-    getClassifier().allReferences().stream()
-        .map(r -> getReferenceValues(r))
-        .forEach(referenceValues -> allReferredValues.addAll(referenceValues));
-    return allReferredValues;
-  }
-
-  @Nonnull
-  @Override
-  public List<Node> getReferredNodes() {
-    return getReferenceValues().stream()
-        .map(rv -> rv.getReferred())
-        .filter(n -> n != null)
-        .collect(Collectors.toList());
+    if (!getClassifier().allContainments().contains(containment)) {
+      throw new IllegalArgumentException("Containment not belonging to this concept");
+    }
+    if (containmentValues.containsKey(containment.getID())) {
+      List<Node> children = containmentValues.get(containment.getID());
+      if (children.size() > index) {
+        children.remove(index);
+      } else {
+        throw new IllegalArgumentException(
+            "Invalid index " + index + " when children are " + children.size());
+      }
+    }
   }
 
   @Nonnull
@@ -178,17 +158,17 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
       throw new IllegalArgumentException("Reference not belonging to this concept");
     }
     if (referenceValues.containsKey(reference.getID())) {
-      List<ReferenceValue> referrenceValuesOfInterest = referenceValues.get(reference.getID());
-      for (int i = 0; i < referrenceValuesOfInterest.size(); i++) {
-        ReferenceValue rv = referrenceValuesOfInterest.get(i);
+      List<ReferenceValue> referenceValuesOfInterest = referenceValues.get(reference.getID());
+      for (int i = 0; i < referenceValuesOfInterest.size(); i++) {
+        ReferenceValue rv = referenceValuesOfInterest.get(i);
         if (referenceValue == null) {
           if (rv == null) {
-            referrenceValuesOfInterest.remove(i);
+            referenceValuesOfInterest.remove(i);
             return;
           }
         } else {
           if (referenceValue.equals(rv)) {
-            referrenceValuesOfInterest.remove(i);
+            referenceValuesOfInterest.remove(i);
             return;
           }
         }
@@ -200,7 +180,21 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
 
   @Override
   public void removeReferenceValue(@Nonnull Reference reference, int index) {
-    throw new UnsupportedOperationException();
+    if (!getClassifier().allReferences().contains(reference)) {
+      throw new IllegalArgumentException("Reference not belonging to this concept");
+    }
+    if (referenceValues.containsKey(reference.getID())) {
+      List<ReferenceValue> referenceValuesOfInterest = referenceValues.get(reference.getID());
+      if (referenceValuesOfInterest.size() > index) {
+        referenceValuesOfInterest.remove(index);
+      } else {
+        throw new IllegalArgumentException(
+            "Invalid index "
+                + index
+                + " when reference values are "
+                + referenceValuesOfInterest.size());
+      }
+    }
   }
 
   // Private methods for containments

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
@@ -112,6 +112,11 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
     throw new IllegalArgumentException("The given node is not a child of this node");
   }
 
+  @Override
+  public void removeChild(@Nonnull Containment containment, int index) {
+    throw new UnsupportedOperationException();
+  }
+
   // Public methods for references
 
   @Nonnull
@@ -193,6 +198,11 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
         "The given reference value could not be found under reference " + reference.getName());
   }
 
+  @Override
+  public void removeReferenceValue(@Nonnull Reference reference, int index) {
+    throw new UnsupportedOperationException();
+  }
+
   // Private methods for containments
 
   private void addContainment(Containment link, Node value) {
@@ -241,15 +251,5 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
     } else {
       referenceValues.put(link.getID(), new ArrayList(Arrays.asList(referenceValue)));
     }
-  }
-
-  @Override
-  public void removeChild(@Nonnull Containment containment, int index) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void removeReferenceValue(@Nonnull Reference reference, int index) {
-    throw new UnsupportedOperationException();
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
@@ -3,7 +3,6 @@ package io.lionweb.lioncore.java.model.impl;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.HasSettableParent;
 import io.lionweb.lioncore.java.model.Node;
-import io.lionweb.lioncore.java.model.Partition;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -33,17 +32,12 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
   }
 
   @Override
-  public Partition getPartition() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public Node getParent() {
     return this.parent;
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return this.concept;
   }
 
@@ -53,7 +47,7 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
     if (parent == null) {
       return null;
     }
-    for (Containment containment : parent.getConcept().allContainments()) {
+    for (Containment containment : parent.getClassifier().allContainments()) {
       if (parent.getChildren(containment).stream().anyMatch(it -> it == this)) {
         return containment;
       }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
@@ -292,4 +292,32 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
       referenceValues.put(linkName, new ArrayList(Arrays.asList(value)));
     }
   }
+
+  @Override
+  public void removeChild(@Nonnull Containment containment, int index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public List<ReferenceValue> getReferenceValues() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public List<Node> getReferredNodes() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void removeReferenceValue(
+      @Nonnull Reference reference, @Nullable ReferenceValue referenceValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void removeReferenceValue(@Nonnull Reference reference, int index) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
@@ -5,7 +5,6 @@ import io.lionweb.lioncore.java.language.Containment;
 import io.lionweb.lioncore.java.language.Property;
 import io.lionweb.lioncore.java.language.Reference;
 import io.lionweb.lioncore.java.model.Node;
-import io.lionweb.lioncore.java.model.Partition;
 import io.lionweb.lioncore.java.model.ReferenceValue;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -44,11 +43,6 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
   }
 
   @Override
-  public Partition getPartition() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public Node getRoot() {
     if (getParent() == null) {
       return this;
@@ -68,7 +62,7 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
 
   @Override
   public Object getPropertyValue(Property property) {
-    if (!getConcept().allProperties().contains(property)) {
+    if (!getClassifier().allProperties().contains(property)) {
       throw new IllegalArgumentException("Property not belonging to this concept: " + property);
     }
     return propertyValues.get(property.getName());
@@ -93,7 +87,7 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
 
   @Override
   public void setPropertyValue(Property property, Object value) {
-    if (!getConcept().allProperties().contains(property)) {
+    if (!getClassifier().allProperties().contains(property)) {
       throw new IllegalArgumentException("Property not belonging to this concept");
     }
     setPropertyValue(property.getName(), value);
@@ -106,7 +100,7 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
   @Override
   public List<Node> getChildren() {
     List<Node> allChildren = new LinkedList<>();
-    getConcept().allContainments().stream()
+    getClassifier().allContainments().stream()
         .map(c -> getChildren(c))
         .forEach(children -> allChildren.addAll(children));
     return allChildren;
@@ -114,7 +108,7 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
 
   @Override
   public List<Node> getChildren(Containment containment) {
-    if (!getConcept().allContainments().contains(containment)) {
+    if (!getClassifier().allContainments().contains(containment)) {
       throw new IllegalArgumentException("Containment not belonging to this concept");
     }
     return containmentValues.getOrDefault(containment.getName(), Collections.emptyList());
@@ -146,7 +140,7 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
   @Override
   public List<ReferenceValue> getReferenceValues(@Nonnull Reference reference) {
     Objects.requireNonNull(reference, "reference should not be null");
-    if (!getConcept().allReferences().contains(reference)) {
+    if (!getClassifier().allReferences().contains(reference)) {
       throw new IllegalArgumentException("Reference not belonging to this concept");
     }
     return referenceValues.getOrDefault(reference.getName(), Collections.emptyList());
@@ -156,7 +150,7 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
   public void addReferenceValue(
       @Nonnull Reference reference, @Nullable ReferenceValue referenceValue) {
     Objects.requireNonNull(reference, "reference should not be null");
-    if (!getConcept().allReferences().contains(reference)) {
+    if (!getClassifier().allReferences().contains(reference)) {
       throw new IllegalArgumentException("Reference not belonging to this concept: " + reference);
     }
     if (reference.isMultiple()) {

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
@@ -137,4 +137,32 @@ public class ProxyNode implements Node {
   public int hashCode() {
     return Objects.hashCode(id);
   }
+
+  @Override
+  public void removeChild(@Nonnull Containment containment, int index) {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Nonnull
+  @Override
+  public List<ReferenceValue> getReferenceValues() {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Nonnull
+  @Override
+  public List<Node> getReferredNodes() {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public void removeReferenceValue(
+      @Nonnull Reference reference, @Nullable ReferenceValue referenceValue) {
+    throw cannotDoBecauseProxy();
+  }
+
+  @Override
+  public void removeReferenceValue(@Nonnull Reference reference, int index) {
+    throw cannotDoBecauseProxy();
+  }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
@@ -81,12 +81,7 @@ public class ProxyNode implements Node {
   }
 
   @Override
-  public Partition getPartition() {
-    throw cannotDoBecauseProxy();
-  }
-
-  @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     throw cannotDoBecauseProxy();
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/ProxyNode.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
  * know which Node should be used in a particular point, but at this time we cannot/do not want to
  * retrieve the data necessary to properly instantiate it.
  */
-public class ProxyNode implements Node {
+public class ProxyNode extends AbstractClassifierInstance<Concept> implements Node {
 
   private @Nonnull String id;
 
@@ -33,11 +33,6 @@ public class ProxyNode implements Node {
 
   @Override
   public void setPropertyValue(Property property, Object value) {
-    throw cannotDoBecauseProxy();
-  }
-
-  @Override
-  public List<? extends Node> getChildren() {
     throw cannotDoBecauseProxy();
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/utils/ModelComparator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/ModelComparator.java
@@ -271,15 +271,15 @@ public class ModelComparator {
     if (!Objects.equals(nodeA.getID(), nodeB.getID())) {
       comparisonResult.markDifferentIDs(context, nodeA.getID(), nodeB.getID());
     } else {
-      if (Objects.equals(nodeA.getConcept().getID(), nodeB.getConcept().getID())) {
-        Concept concept = nodeA.getConcept();
+      if (Objects.equals(nodeA.getClassifier().getID(), nodeB.getClassifier().getID())) {
+        Concept concept = nodeA.getClassifier();
         compareProperties(concept, nodeA, nodeB, comparisonResult, context);
         compareReferences(concept, nodeA, nodeB, comparisonResult, context);
         compareContainments(concept, nodeA, nodeB, comparisonResult, context);
         compareAnnotations(concept, nodeA, nodeB, comparisonResult, context);
       } else {
         comparisonResult.markDifferentConcept(
-            context, nodeA.getID(), nodeA.getConcept().getID(), nodeB.getConcept().getID());
+            context, nodeA.getID(), nodeA.getClassifier().getID(), nodeB.getClassifier().getID());
       }
     }
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/utils/NodeTreeValidator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/NodeTreeValidator.java
@@ -20,7 +20,7 @@ public class NodeTreeValidator extends Validator<Node> {
     }
     if (node.isRoot()) {
       validationResult.checkForError(
-          !node.getConcept().isPartition(),
+          !node.getClassifier().isPartition(),
           "A root node should be an instance of a Partition concept",
           node);
     }

--- a/core/src/test/java/io/lionweb/lioncore/java/language/MetaCircularityTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/language/MetaCircularityTest.java
@@ -9,32 +9,34 @@ public class MetaCircularityTest {
 
   @Test
   public void eachElementOfM3HasRightConcept() {
-    assertSame(LionCore.getConcept(), LionCore.getConcept().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getInterface().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getContainment().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getDataType().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getEnumeration().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getEnumerationLiteral().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getFeature().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getClassifier().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getLink().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getLanguage().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getLanguageEntity().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getPrimitiveType().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getProperty().getConcept());
-    assertSame(LionCore.getConcept(), LionCore.getReference().getConcept());
+    assertSame(LionCore.getConcept(), LionCore.getConcept().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getInterface().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getContainment().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getDataType().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getEnumeration().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getEnumerationLiteral().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getFeature().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getClassifier().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getLink().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getLanguage().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getLanguageEntity().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getPrimitiveType().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getProperty().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getReference().getClassifier());
+    assertSame(LionCore.getConcept(), LionCore.getAnnotation().getClassifier());
   }
 
   @Test
   public void eachElementOfM2HasRightConcept() {
-    assertSame(LionCore.getConcept(), new Concept().getConcept());
-    assertSame(LionCore.getInterface(), new Interface().getConcept());
-    assertSame(LionCore.getContainment(), new Containment().getConcept());
-    assertSame(LionCore.getEnumeration(), new Enumeration().getConcept());
-    assertSame(LionCore.getEnumerationLiteral(), new EnumerationLiteral().getConcept());
-    assertSame(LionCore.getLanguage(), new Language().getConcept());
-    assertSame(LionCore.getPrimitiveType(), new PrimitiveType().getConcept());
-    assertSame(LionCore.getProperty(), new Property().getConcept());
-    assertSame(LionCore.getReference(), new Reference().getConcept());
+    assertSame(LionCore.getConcept(), new Concept().getClassifier());
+    assertSame(LionCore.getInterface(), new Interface().getClassifier());
+    assertSame(LionCore.getContainment(), new Containment().getClassifier());
+    assertSame(LionCore.getEnumeration(), new Enumeration().getClassifier());
+    assertSame(LionCore.getEnumerationLiteral(), new EnumerationLiteral().getClassifier());
+    assertSame(LionCore.getLanguage(), new Language().getClassifier());
+    assertSame(LionCore.getPrimitiveType(), new PrimitiveType().getClassifier());
+    assertSame(LionCore.getProperty(), new Property().getClassifier());
+    assertSame(LionCore.getReference(), new Reference().getClassifier());
+    assertSame(LionCore.getAnnotation(), new Annotation().getClassifier());
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/Book.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/Book.java
@@ -17,11 +17,11 @@ public class Book extends DynamicNode {
   }
 
   public void setTitle(String title) {
-    this.setPropertyValue(getConcept().getPropertyByName("title"), title);
+    this.setPropertyValue(getClassifier().getPropertyByName("title"), title);
   }
 
   public Book setPages(int pages) {
-    this.setPropertyValue(getConcept().getPropertyByName("pages"), pages);
+    this.setPropertyValue(getClassifier().getPropertyByName("pages"), pages);
     return this;
   }
 
@@ -31,11 +31,11 @@ public class Book extends DynamicNode {
 
   public void setAuthor(Writer author) {
     this.addReferenceValue(
-        getConcept().getReferenceByName("author"), new ReferenceValue(author, author.getName()));
+        getClassifier().getReferenceByName("author"), new ReferenceValue(author, author.getName()));
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LibraryLanguage.BOOK;
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/GuideBookWriter.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/GuideBookWriter.java
@@ -8,11 +8,11 @@ public class GuideBookWriter extends Writer {
   }
 
   public void setCountries(String countries) {
-    setPropertyValue(getConcept().getPropertyByName("countries"), countries);
+    setPropertyValue(getClassifier().getPropertyByName("countries"), countries);
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LibraryLanguage.GUIDE_BOOK_WRITER;
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/Library.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/Library.java
@@ -11,15 +11,15 @@ public class Library extends DynamicNode {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LibraryLanguage.LIBRARY;
   }
 
   public void addBook(Book book) {
-    this.addChild(getConcept().getContainmentByName("books"), book);
+    this.addChild(getClassifier().getContainmentByName("books"), book);
   }
 
   public void setName(String name) {
-    this.setPropertyValue(getConcept().getPropertyByName("name"), name);
+    this.setPropertyValue(getClassifier().getPropertyByName("name"), name);
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/MyNodeWithReferences.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/MyNodeWithReferences.java
@@ -1,0 +1,45 @@
+package io.lionweb.lioncore.java.serialization;
+
+import io.lionweb.lioncore.java.language.*;
+import io.lionweb.lioncore.java.model.ReferenceValue;
+import io.lionweb.lioncore.java.model.impl.DynamicNode;
+import java.util.List;
+
+public class MyNodeWithReferences extends DynamicNode {
+  public static final Language LANGUAGE =
+      new Language().setID("mm2").setKey("mylanguage2").setName("MM2").setVersion("1");
+  public static final Concept CONCEPT =
+      new Concept()
+          .setID("concept-MyNodeWithReferences")
+          .setKey("concept-MyNodeWithReferences")
+          .setName("MyNodeWithReferences")
+          .addFeature(
+              Reference.createOptional("r1", MyNodeWithProperties.CONCEPT).setID("r1").setKey("r1"))
+          .addFeature(
+              Reference.createMultiple("r2", MyNodeWithProperties.CONCEPT).setID("r2").setKey("r2"))
+          .setParent(LANGUAGE);
+
+  static {
+    LANGUAGE.addElement(CONCEPT);
+  }
+
+  public MyNodeWithReferences(String id) {
+    super(id, CONCEPT);
+  }
+
+  public ReferenceValue getR1() {
+    return this.getOnlyReferenceValueByReferenceName("r1");
+  }
+
+  public List<ReferenceValue> getR2() {
+    return this.getReferenceValueByName("r2");
+  }
+
+  public void setP1(ReferenceValue value) {
+    this.setOnlyReferenceValueByName("r1", value);
+  }
+
+  public void setR2(List<ReferenceValue> values) {
+    this.setReferenceValuesByName("r1", values);
+  }
+}

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
@@ -124,7 +124,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     List<Node> deserializedNodes = jsonSerialization.deserializeToNodes(jsonElement);
 
     Language lioncore = (Language) deserializedNodes.get(0);
-    assertEquals(LionCore.getLanguage(), lioncore.getConcept());
+    assertEquals(LionCore.getLanguage(), lioncore.getClassifier());
     assertEquals("-id-LionCore-M3", lioncore.getID());
     assertEquals("LionCore_M3", lioncore.getName());
     assertEquals(16, lioncore.getChildren().size());
@@ -148,7 +148,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     List<Node> deserializedNodes = jsonSerialization.deserializeToNodes(jsonElement);
 
     DynamicNode lioncore = (DynamicNode) deserializedNodes.get(0);
-    assertEquals(LionCore.getLanguage(), lioncore.getConcept());
+    assertEquals(LionCore.getLanguage(), lioncore.getClassifier());
     assertEquals("-id-LionCore-M3", lioncore.getID());
     assertEquals("LionCore_M3", lioncore.getPropertyValueByName("name"));
     assertEquals(16, lioncore.getChildren().size());

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SimpleNode.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SimpleNode.java
@@ -5,7 +5,6 @@ import io.lionweb.lioncore.java.language.Property;
 import io.lionweb.lioncore.java.language.Reference;
 import io.lionweb.lioncore.java.model.AnnotationInstance;
 import io.lionweb.lioncore.java.model.Node;
-import io.lionweb.lioncore.java.model.Partition;
 import io.lionweb.lioncore.java.model.ReferenceValue;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -40,11 +39,6 @@ public abstract class SimpleNode implements Node {
   }
 
   @Override
-  public Partition getPartition() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public Node getParent() {
     return parent;
   }
@@ -76,7 +70,7 @@ public abstract class SimpleNode implements Node {
 
   @Override
   public Object getPropertyValue(Property property) {
-    if (!getConcept().allProperties().contains(property)) {
+    if (!getClassifier().allProperties().contains(property)) {
       throw new IllegalArgumentException("Property not belonging to this concept");
     }
     return concreteGetPropertyValue(property);
@@ -93,7 +87,7 @@ public abstract class SimpleNode implements Node {
 
   @Override
   public List<? extends Node> getChildren(Containment containment) {
-    if (!getConcept().allContainments().contains(containment)) {
+    if (!getClassifier().allContainments().contains(containment)) {
       throw new IllegalArgumentException("Containment not belonging to this concept");
     }
     return concreteGetChildren(containment);
@@ -122,7 +116,7 @@ public abstract class SimpleNode implements Node {
   @Nonnull
   @Override
   public List<ReferenceValue> getReferenceValues(@Nonnull Reference reference) {
-    if (!getConcept().allReferences().contains(reference)) {
+    if (!getClassifier().allReferences().contains(reference)) {
       throw new IllegalArgumentException("Reference not belonging to this concept");
     }
     return concreteGetReferenceValues(reference);
@@ -135,7 +129,7 @@ public abstract class SimpleNode implements Node {
   @Override
   public void addReferenceValue(
       @Nonnull Reference reference, @Nullable ReferenceValue referredNode) {
-    if (!getConcept().allReferences().contains(reference)) {
+    if (!getClassifier().allReferences().contains(reference)) {
       throw new IllegalArgumentException("Reference not belonging to this concept");
     }
     concreteAddReferenceValue(reference, referredNode);
@@ -154,7 +148,7 @@ public abstract class SimpleNode implements Node {
   @Override
   public List<Node> getChildren() {
     List<Node> allChildren = new LinkedList<>();
-    getConcept().allContainments().stream()
+    getClassifier().allContainments().stream()
         .map(c -> getChildren(c))
         .forEach(children -> allChildren.addAll(children));
     return allChildren;

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SimpleNode.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SimpleNode.java
@@ -1,11 +1,13 @@
 package io.lionweb.lioncore.java.serialization;
 
+import io.lionweb.lioncore.java.language.Concept;
 import io.lionweb.lioncore.java.language.Containment;
 import io.lionweb.lioncore.java.language.Property;
 import io.lionweb.lioncore.java.language.Reference;
 import io.lionweb.lioncore.java.model.AnnotationInstance;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.ReferenceValue;
+import io.lionweb.lioncore.java.model.impl.AbstractClassifierInstance;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -13,7 +15,7 @@ import java.util.Random;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public abstract class SimpleNode implements Node {
+public abstract class SimpleNode extends AbstractClassifierInstance<Concept> implements Node {
 
   private String id;
   private Node parent;

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SimpleNode.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SimpleNode.java
@@ -159,4 +159,32 @@ public abstract class SimpleNode implements Node {
         .forEach(children -> allChildren.addAll(children));
     return allChildren;
   }
+
+  @Override
+  public void removeChild(@Nonnull Containment containment, int index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public List<ReferenceValue> getReferenceValues() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public List<Node> getReferredNodes() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void removeReferenceValue(
+      @Nonnull Reference reference, @Nullable ReferenceValue referenceValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void removeReferenceValue(@Nonnull Reference reference, int index) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/Writer.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/Writer.java
@@ -20,7 +20,7 @@ public class Writer extends DynamicNode {
   }
 
   public void setName(String name) {
-    this.setPropertyValue(getConcept().getPropertyByName("name"), name);
+    this.setPropertyValue(getClassifier().getPropertyByName("name"), name);
   }
 
   public String getName() {
@@ -28,7 +28,7 @@ public class Writer extends DynamicNode {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return LibraryLanguage.WRITER;
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/refsmm/ContainerNode.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/refsmm/ContainerNode.java
@@ -27,7 +27,7 @@ public class ContainerNode extends SimpleNode {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return RefsLanguage.CONTAINER_NODE;
   }
 

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/refsmm/RefNode.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/refsmm/RefNode.java
@@ -26,7 +26,7 @@ public class RefNode extends SimpleNode {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return RefsLanguage.REF_NODE;
   }
 

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/simplemath/IntLiteral.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/simplemath/IntLiteral.java
@@ -19,7 +19,7 @@ public class IntLiteral extends SimpleNode {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return SimpleMathLanguage.INT_LITERAL;
   }
 

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/simplemath/Sum.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/simplemath/Sum.java
@@ -25,7 +25,7 @@ public class Sum extends SimpleNode {
   }
 
   @Override
-  public Concept getConcept() {
+  public Concept getClassifier() {
     return SimpleMathLanguage.SUM;
   }
 

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFModelExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFModelExporter.java
@@ -35,10 +35,13 @@ public class EMFModelExporter extends AbstractEMFExporter {
 
   /** This export the root received to a single EObject tree. */
   public EObject exportTree(Node root, ReferencesPostponer referencesPostponer) {
-    EClass eClass = (EClass) conceptsToEClassesMapping.getCorrespondingEClass(root.getConcept());
+    EClass eClass = (EClass) conceptsToEClassesMapping.getCorrespondingEClass(root.getClassifier());
     if (eClass == null) {
       throw new IllegalStateException(
-          "Cannot find EClass corresponding to " + root.getConcept().getName() + ". Node: " + root);
+          "Cannot find EClass corresponding to "
+              + root.getClassifier().getName()
+              + ". Node: "
+              + root);
     }
     EObject eObject = eClass.getEPackage().getEFactoryInstance().create(eClass);
     referencesPostponer.trackMapping(root, eObject);
@@ -122,7 +125,7 @@ public class EMFModelExporter extends AbstractEMFExporter {
             Reference reference =
                 postponedReference
                     .node
-                    .getConcept()
+                    .getClassifier()
                     .getReferenceByName(postponedReference.eReference.getName());
             List<ReferenceValue> referenceValues =
                 postponedReference.node.getReferenceValues(reference);

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFModelImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFModelImporter.java
@@ -74,7 +74,7 @@ public class EMFModelImporter extends AbstractEMFImporter<Node> {
                   EReference eReference = (EReference) eStructuralFeature;
                   if (eReference.isContainment()) {
                     Containment containment =
-                        node.getConcept().requireContainmentByName(eStructuralFeature.getName());
+                        node.getClassifier().requireContainmentByName(eStructuralFeature.getName());
                     if (eReference.isMany()) {
                       List<EObject> values = (List<EObject>) sfValue;
                       values.forEach(

--- a/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFModelImporterTest.java
+++ b/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFModelImporterTest.java
@@ -54,7 +54,7 @@ public class EMFModelImporterTest {
     assertEquals(1, nodes.size());
 
     Node result = nodes.get(0);
-    assertEquals("Result", result.getConcept().getName());
+    assertEquals("Result", result.getClassifier().getName());
 
     Node root = result.getOnlyChildByContainmentName("root");
     assertNotNull(root);
@@ -62,7 +62,7 @@ public class EMFModelImporterTest {
     Node rootPosition = root.getOnlyChildByContainmentName("position");
     assertNotNull(rootPosition);
 
-    assertEquals("Position", rootPosition.getConcept().getName());
+    assertEquals("Position", rootPosition.getClassifier().getName());
 
     Node rootPositionStart = rootPosition.getOnlyChildByContainmentName("start");
     assertEquals(1, rootPositionStart.getPropertyValueByName("line"));
@@ -73,11 +73,11 @@ public class EMFModelImporterTest {
     assertEquals(0, rootPositionEnd.getPropertyValueByName("column"));
 
     Node rootElement = root.getOnlyChildByContainmentName("elements");
-    assertEquals("KClassDeclaration", rootElement.getConcept().getName());
+    assertEquals("KClassDeclaration", rootElement.getClassifier().getName());
     assertEquals("KotlinPrinter", rootElement.getPropertyValueByName("name"));
 
     Node rootElementPrimaryConstructor =
         rootElement.getOnlyChildByContainmentName("primaryConstructor");
-    assertEquals("KPrimaryConstructor", rootElementPrimaryConstructor.getConcept().getName());
+    assertEquals("KPrimaryConstructor", rootElementPrimaryConstructor.getClassifier().getName());
   }
 }


### PR DESCRIPTION
The refactoring mostly focuses on adding utility methods for dealing with references and containments.

In doing so, some reorganization of methods within related classes (Node, DynamicClassifierInstance, AbstractClassifierInstance) emerged, also consequently to the recent introduction of AbstractClassifierInstance.

* In Node we removed `getConcept` as `getClassifier` is specialized to return a `Concept` for `Node`, so `getConcept` was redundant at this stage. This change alone is the one affecting most of the files. We could potentially keep `getConcept` and deprecating it, but given the small user base, I would just go ahead and remove it