### PR TITLE
Support multiple references of the same proxied node in the same chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,7 @@ Import and export from and to EMF is a work in progress.
 
 * Revise support for homogeneous APIs in Node, especially for references
 * Introduced ClassifierInstanceUtils
+
+### Version 0.2.15
+
+* Support presence of multiple references to the same proxied node during serialization

--- a/core/src/main/java/io/lionweb/lioncore/java/api/ClassifierInstanceResolver.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/api/ClassifierInstanceResolver.java
@@ -15,6 +15,10 @@ public interface ClassifierInstanceResolver {
   @Nullable
   ClassifierInstance<?> resolve(String instanceID);
 
+  default boolean canResolve(String instanceID) {
+    return resolve(instanceID) != null;
+  }
+
   @Nonnull
   default ClassifierInstance<?> strictlyResolve(String instanceID) {
     ClassifierInstance<?> partial = resolve(instanceID);

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -627,11 +627,14 @@ public class JsonSerialization {
             node -> {
               nodePopulator.populateClassifierInstance(serializedToInstanceMap.get(node), node);
               ClassifierInstance<?> classifierInstance = serializedToInstanceMap.get(node);
-              if (unavailableParentPolicy == UnavailableNodePolicy.PROXY_NODES) {
+              ClassifierInstance<?> parent =
+                  classifierInstanceResolver.resolve(node.getParentNodeID());
+              if (parent instanceof ProxyNode
+                  && unavailableParentPolicy == UnavailableNodePolicy.PROXY_NODES) {
                 // For real parents, the parent is not set directly, but it is set indirectly
                 // when adding the child to the parent. For proxy nodes instead we need to set
                 // the parent explicitly
-                ProxyNode proxyParent = deserializationStatus.proxyFor(node.getParentNodeID());
+                ProxyNode proxyParent = (ProxyNode) parent;
                 if (proxyParent != null) {
                   if (classifierInstance instanceof HasSettableParent) {
                     ((HasSettableParent) classifierInstance).setParent(proxyParent);

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
@@ -103,7 +103,7 @@ class NodePopulator {
                               referred = null;
                               break;
                             case PROXY_NODES:
-                              referred = deserializationStatus.createProxy(entry.getReference());
+                              referred = deserializationStatus.resolve(entry.getReference());
                               break;
                             case THROW_ERROR:
                               throw new DeserializationException(

--- a/core/src/test/resources/serialization/todosWithMultipleProxies.json
+++ b/core/src/test/resources/serialization/todosWithMultipleProxies.json
@@ -1,0 +1,147 @@
+{
+  "serializationFormatVersion": "2023.1",
+  "languages": [
+    {
+      "key": "TodoLanguage",
+      "version": "1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "synthetic_my-wonderful-partition_projects_1_todos_0",
+      "classifier": {
+        "key": "TodoLanguage_Todo",
+        "version": "1",
+        "language": "TodoLanguage"
+      },
+      "parent": "synthetic_my-wonderful-partition_projects_1",
+      "properties": [
+        {
+          "value": "Abc desc",
+          "property": {
+            "key": "TodoLanguage_Todo_description",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        },
+        {
+          "value": "Abc",
+          "property": {
+            "key": "LionCore-builtins-INamed-name",
+            "version": "2023.1",
+            "language": "LionCore-builtins"
+          }
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "targets": [
+            {
+              "reference": "external-1",
+              "resolveInfo": null
+            }
+          ],
+          "reference": {
+            "key": "TodoLanguage_Todo_prerequisite",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        }
+      ],
+      "annotations": []
+    },
+    {
+      "id": "synthetic_my-wonderful-partition_projects_1_todos_1",
+      "classifier": {
+        "key": "TodoLanguage_Todo",
+        "version": "1",
+        "language": "TodoLanguage"
+      },
+      "parent": "synthetic_my-wonderful-partition_projects_1",
+      "properties": [
+        {
+          "value": "Def desc",
+          "property": {
+            "key": "TodoLanguage_Todo_description",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        },
+        {
+          "value": "Def",
+          "property": {
+            "key": "LionCore-builtins-INamed-name",
+            "version": "2023.1",
+            "language": "LionCore-builtins"
+          }
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "targets": [
+            {
+              "reference": "external-1",
+              "resolveInfo": null
+            }
+          ],
+          "reference": {
+            "key": "TodoLanguage_Todo_prerequisite",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        }
+      ],
+      "annotations": []
+    },
+    {
+      "id": "synthetic_my-wonderful-partition_projects_1_todos_2",
+      "classifier": {
+        "key": "TodoLanguage_Todo",
+        "version": "1",
+        "language": "TodoLanguage"
+      },
+      "parent": "synthetic_my-wonderful-partition_projects_1",
+      "properties": [
+        {
+          "value": "Ghi desc",
+          "property": {
+            "key": "TodoLanguage_Todo_description",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        },
+        {
+          "value": "Ghi",
+          "property": {
+            "key": "LionCore-builtins-INamed-name",
+            "version": "2023.1",
+            "language": "LionCore-builtins"
+          }
+        }
+      ],
+      "containments": [],
+      "references": [
+        {
+          "targets": [
+            {
+              "reference": "external-1",
+              "resolveInfo": null
+            }
+          ],
+          "reference": {
+            "key": "TodoLanguage_Todo_prerequisite",
+            "version": "1",
+            "language": "TodoLanguage"
+          }
+        }
+      ],
+      "annotations": []
+    }
+  ]
+}


### PR DESCRIPTION
Currently if we have two or more references to the same _external_ node (i.e., a node not present in the chunk) then we attempt to create multiple instances of `ProxyNode`. The moment we try to create the second, an exception is thrown.
This PR solves this bug and adds a test to verify that.