### PR TITLE
Exposing SerializedJsonComparisonUtils

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -26,7 +26,7 @@ val javadocConfig by configurations.creating {
 
 dependencies {
     // Use JUnit test framework.
-    implementation(libs.junit)
+    testImplementation(libs.junit)
 
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api("org.apache.commons:commons-math3:3.6.1")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -26,7 +26,7 @@ val javadocConfig by configurations.creating {
 
 dependencies {
     // Use JUnit test framework.
-    testImplementation(libs.junit)
+    implementation(libs.junit)
 
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api("org.apache.commons:commons-math3:3.6.1")

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -694,8 +694,8 @@ public class JsonSerialization {
                       + serializedPropertyValue.getMetaPointer()
                       + " not found in classifier "
                       + classifier
-                      + ". SerializedNode: "
-                      + serializedClassifierInstance);
+                      + ". Properties: "
+                      + classifier.allProperties().stream().map(p -> MetaPointer.from(p)).collect(Collectors.toList()));
               Object deserializedValue =
                   primitiveValuesSerialization.deserialize(
                       property.getType(),

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -695,7 +695,9 @@ public class JsonSerialization {
                       + " not found in classifier "
                       + classifier
                       + ". Properties: "
-                      + classifier.allProperties().stream().map(p -> MetaPointer.from(p)).collect(Collectors.toList()));
+                      + classifier.allProperties().stream()
+                          .map(p -> MetaPointer.from(p))
+                          .collect(Collectors.toList()));
               Object deserializedValue =
                   primitiveValuesSerialization.deserialize(
                       property.getType(),

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializedJsonComparisonUtils.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializedJsonComparisonUtils.java
@@ -1,18 +1,14 @@
 package io.lionweb.lioncore.java.serialization;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
-import org.junit.Assert;
-
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.junit.Assert;
 
 public class SerializedJsonComparisonUtils {
 
@@ -98,7 +94,8 @@ public class SerializedJsonComparisonUtils {
               actual.get("classifier"));
           break;
         case "id":
-          Assert.assertEquals("(" + context + ") different id", expected.get("id"), actual.get("id"));
+          Assert.assertEquals(
+              "(" + context + ") different id", expected.get("id"), actual.get("id"));
           break;
         case "references":
           assertEquivalentUnorderedArrays(
@@ -154,7 +151,8 @@ public class SerializedJsonComparisonUtils {
         }
       }
       if (!matchFound) {
-        Assert.fail(context + " element " + i + " : no equivalent to " + expectedElement + " found");
+        Assert.fail(
+            context + " element " + i + " : no equivalent to " + expectedElement + " found");
       }
     }
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializedJsonComparisonUtils.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializedJsonComparisonUtils.java
@@ -8,7 +8,6 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.junit.Assert;
 
 public class SerializedJsonComparisonUtils {
 
@@ -23,7 +22,7 @@ public class SerializedJsonComparisonUtils {
     if (!actual.keySet().equals(keys)) {
       throw new RuntimeException("The actual object has irregular keys: " + actual.keySet());
     }
-    Assert.assertEquals(
+    assertEquals(
         "serializationFormatVersion",
         expected.get("serializationFormatVersion"),
         actual.get("serializationFormatVersion"));
@@ -52,7 +51,7 @@ public class SerializedJsonComparisonUtils {
     if (!missingIDs.isEmpty()) {
       throw new AssertionError("Missing IDs found: " + missingIDs);
     }
-    Assert.assertEquals("The number of nodes is different", expected.size(), actual.size());
+    assertEquals("The number of nodes is different", expected.size(), actual.size());
     for (String id : expectedElements.keySet()) {
       JsonObject expectedElement = expectedElements.get(id);
       JsonObject actualElement = actualElements.get(id);
@@ -84,18 +83,17 @@ public class SerializedJsonComparisonUtils {
     for (String key : actualMeaningfulKeys) {
       switch (key) {
         case "parent":
-          Assert.assertEquals(
+          assertEquals(
               "(" + context + ") different parent", expected.get("parent"), actual.get("parent"));
           break;
         case "classifier":
-          Assert.assertEquals(
+          assertEquals(
               "(" + context + ") different classifier",
               expected.get("classifier"),
               actual.get("classifier"));
           break;
         case "id":
-          Assert.assertEquals(
-              "(" + context + ") different id", expected.get("id"), actual.get("id"));
+          assertEquals("(" + context + ") different id", expected.get("id"), actual.get("id"));
           break;
         case "references":
           assertEquivalentUnorderedArrays(
@@ -151,8 +149,7 @@ public class SerializedJsonComparisonUtils {
         }
       }
       if (!matchFound) {
-        Assert.fail(
-            context + " element " + i + " : no equivalent to " + expectedElement + " found");
+        fail(context + " element " + i + " : no equivalent to " + expectedElement + " found");
       }
     }
   }
@@ -196,8 +193,18 @@ public class SerializedJsonComparisonUtils {
       throw new AssertionError("(" + context + ") Missing keys found: " + missingKeys);
     }
     for (String key : actualMeaningfulKeys) {
-      Assert.assertEquals(
+      assertEquals(
           "(" + context + ") Different values for key " + key, expected.get(key), actual.get(key));
     }
+  }
+
+  private static void assertEquals(String message, Object expected, Object actual) {
+    if (!Objects.equals(expected, actual)) {
+      throw new AssertionError(message + ": expected " + expected + " but found" + actual);
+    }
+  }
+
+  private static void fail(String message) {
+    throw new AssertionError("Comparison failed. " + message);
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializedJsonComparisonUtils.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializedJsonComparisonUtils.java
@@ -7,16 +7,18 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
+import org.junit.Assert;
+
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-class SerializedJsonComparisonUtils {
+public class SerializedJsonComparisonUtils {
 
   private SerializedJsonComparisonUtils() {}
 
-  static void assertEquivalentLionWebJson(JsonObject expected, JsonObject actual) {
+  public static void assertEquivalentLionWebJson(JsonObject expected, JsonObject actual) {
     Set<String> keys =
         new HashSet<>(Arrays.asList("serializationFormatVersion", "nodes", "languages"));
     if (!expected.keySet().equals(keys)) {
@@ -25,7 +27,7 @@ class SerializedJsonComparisonUtils {
     if (!actual.keySet().equals(keys)) {
       throw new RuntimeException("The actual object has irregular keys: " + actual.keySet());
     }
-    assertEquals(
+    Assert.assertEquals(
         "serializationFormatVersion",
         expected.get("serializationFormatVersion"),
         actual.get("serializationFormatVersion"));
@@ -54,7 +56,7 @@ class SerializedJsonComparisonUtils {
     if (!missingIDs.isEmpty()) {
       throw new AssertionError("Missing IDs found: " + missingIDs);
     }
-    assertEquals("The number of nodes is different", expected.size(), actual.size());
+    Assert.assertEquals("The number of nodes is different", expected.size(), actual.size());
     for (String id : expectedElements.keySet()) {
       JsonObject expectedElement = expectedElements.get(id);
       JsonObject actualElement = actualElements.get(id);
@@ -86,17 +88,17 @@ class SerializedJsonComparisonUtils {
     for (String key : actualMeaningfulKeys) {
       switch (key) {
         case "parent":
-          assertEquals(
+          Assert.assertEquals(
               "(" + context + ") different parent", expected.get("parent"), actual.get("parent"));
           break;
         case "classifier":
-          assertEquals(
+          Assert.assertEquals(
               "(" + context + ") different classifier",
               expected.get("classifier"),
               actual.get("classifier"));
           break;
         case "id":
-          assertEquals("(" + context + ") different id", expected.get("id"), actual.get("id"));
+          Assert.assertEquals("(" + context + ") different id", expected.get("id"), actual.get("id"));
           break;
         case "references":
           assertEquivalentUnorderedArrays(
@@ -152,7 +154,7 @@ class SerializedJsonComparisonUtils {
         }
       }
       if (!matchFound) {
-        fail(context + " element " + i + " : no equivalent to " + expectedElement + " found");
+        Assert.fail(context + " element " + i + " : no equivalent to " + expectedElement + " found");
       }
     }
   }
@@ -196,7 +198,7 @@ class SerializedJsonComparisonUtils {
       throw new AssertionError("(" + context + ") Missing keys found: " + missingKeys);
     }
     for (String key : actualMeaningfulKeys) {
-      assertEquals(
+      Assert.assertEquals(
           "(" + context + ") Different values for key " + key, expected.get(key), actual.get(key));
     }
   }


### PR DESCRIPTION
Exposing `SerializedJsonComparisonUtils` for the reason explained in https://github.com/LionWeb-io/specification/issues/283

In practice, the format currently uses lists for things for which the order is not meaningful, so to verify that two chunks are equivalent require specific logic.