### PR TITLE
Update specs to 2024.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id "com.diffplug.spotless" version "5.1.0"
     id "java"
-    id 'net.researchgate.release' version '3.0.2'
-    id("com.vanniktech.maven.publish") version "0.26.0" apply false
+    alias(libs.plugins.release)
+    alias(libs.plugins.superPublish) apply(false)
 }
 
 repositories {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,12 +1,15 @@
 import com.vanniktech.maven.publish.SonatypeHost
 import java.net.URI
+import org.gradle.internal.impldep.org.junit.experimental.categories.Categories.CategoryFilter.exclude
+import org.gradle.internal.impldep.org.junit.experimental.categories.Categories.CategoryFilter.include
 
 plugins {
     id("java-library")
     id("signing")
     id("com.github.johnrengelman.shadow") version "7.1.1"
-    id("com.vanniktech.maven.publish")
+    alias(libs.plugins.superPublish)
     jacoco
+    alias(libs.plugins.buildConfig)
 }
 
 repositories {
@@ -185,4 +188,17 @@ val integrationTest = tasks.create("integrationTest", Test::class.java) {
 
 tasks.jacocoTestReport {
     dependsOn(tasks.test) // tests are required to run before generating the report
+}
+
+buildConfig {
+    sourceSets.getByName("main") {
+        packageName("io.lionweb.lioncore.java")
+        buildConfigField("String", "CURRENT_SPECS_VERSION", "\"${specsVersion}\"")
+    }
+}
+
+spotless {
+    java {
+        target("src/**/*.java")
+    }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,7 +1,5 @@
 import com.vanniktech.maven.publish.SonatypeHost
 import java.net.URI
-import org.gradle.internal.impldep.org.junit.experimental.categories.Categories.CategoryFilter.exclude
-import org.gradle.internal.impldep.org.junit.experimental.categories.Categories.CategoryFilter.include
 
 plugins {
     id("java-library")

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
@@ -10,7 +10,8 @@ public class LionCoreBuiltins extends Language {
     super("LionCore_builtins");
     setID("LionCore-builtins");
     setKey("LionCore-builtins");
-    setVersion(JsonSerialization.DEFAULT_SERIALIZATION_FORMAT);
+    // TODO we should move to the current version
+    setVersion(JsonSerialization.SERIALIZATION_FORMAT_2023_1);
     PrimitiveType string = new PrimitiveType(this, "String");
     new PrimitiveType(this, "Boolean");
     new PrimitiveType(this, "Integer");

--- a/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
@@ -78,7 +78,8 @@ public class LionCore {
       INSTANCE = new Language("LionCore_M3");
       INSTANCE.setID("-id-LionCore-M3");
       INSTANCE.setKey("LionCore-M3");
-      INSTANCE.setVersion(JsonSerialization.DEFAULT_SERIALIZATION_FORMAT);
+      // TODO we should move to the current version
+      INSTANCE.setVersion(JsonSerialization.SERIALIZATION_FORMAT_2023_1);
 
       // We first instantiate all Concepts and Interfaces
       // we add features only after as the features will have references to these elements

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import io.lionweb.lioncore.java.BuildConfig;
 import io.lionweb.lioncore.java.api.ClassifierInstanceResolver;
 import io.lionweb.lioncore.java.api.CompositeClassifierInstanceResolver;
 import io.lionweb.lioncore.java.api.LocalClassifierInstanceResolver;
@@ -39,7 +40,7 @@ import javax.annotation.Nullable;
  * behavior explicitly by calling getNodeInstantiator().enableDynamicNodes().
  */
 public class JsonSerialization {
-  public static final String DEFAULT_SERIALIZATION_FORMAT = "2023.1";
+  public static final String DEFAULT_SERIALIZATION_FORMAT = BuildConfig.CURRENT_SPECS_VERSION;
 
   public static void saveLanguageToFile(Language language, File file) throws IOException {
     String content = getStandardSerialization().serializeTreesToJsonString(language);

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -41,6 +41,13 @@ import javax.annotation.Nullable;
  */
 public class JsonSerialization {
   public static final String DEFAULT_SERIALIZATION_FORMAT = BuildConfig.CURRENT_SPECS_VERSION;
+  public static final String SERIALIZATION_FORMAT_2023_1 = "2023.1";
+  public static final Set<String> SUPPORTED_FORMATS =
+      new HashSet<>(Arrays.asList(DEFAULT_SERIALIZATION_FORMAT, SERIALIZATION_FORMAT_2023_1));
+
+  public static boolean isFormatSupported(String format) {
+    return SUPPORTED_FORMATS.contains(format);
+  }
 
   public static void saveLanguageToFile(Language language, File file) throws IOException {
     String content = getStandardSerialization().serializeTreesToJsonString(language);
@@ -485,9 +492,11 @@ public class JsonSerialization {
   }
 
   private void validateSerializationBlock(SerializedChunk serializationBlock) {
-    if (!serializationBlock.getSerializationFormatVersion().equals(DEFAULT_SERIALIZATION_FORMAT)) {
+    if (!isFormatSupported(serializationBlock.getSerializationFormatVersion())) {
       throw new IllegalArgumentException(
-          "Only serializationFormatVersion = '" + DEFAULT_SERIALIZATION_FORMAT + "' is supported");
+          "Serialization format '"
+              + serializationBlock.getSerializationFormatVersion()
+              + "' is not supported");
     }
   }
 

--- a/core/src/test/java/io/lionweb/lioncore/java/self/CorrespondanceWithDocumentationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/self/CorrespondanceWithDocumentationTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 public class CorrespondanceWithDocumentationTest {
 
   private static final String SPECIFICATION_COMMIT_CONSIDERED =
-      "69ddbf4685acf1ef6d83c400570fb6c37efa4cfc";
+      "d138a4f3f6ea86e4ff27ff5cc515488aef30bd1c";
 
   @Test
   public void lioncoreIsTheSameAsInTheOrganizationRepo() throws IOException {

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -384,7 +384,7 @@ public class JsonSerializationTest extends SerializationTest {
     assertEquals(
         JsonParser.parseString(
             "{\n"
-                + "    \"serializationFormatVersion\": \"2023.1\",\n"
+                + "    \"serializationFormatVersion\": \"2024.1\",\n"
                 + "    \"languages\": [{\n"
                 + "        \"version\": \"1\",\n"
                 + "        \"key\": \"mm_key\"\n"
@@ -462,7 +462,7 @@ public class JsonSerializationTest extends SerializationTest {
     assertEquals(
         JsonParser.parseString(
             "{\n"
-                + "    \"serializationFormatVersion\": \"2023.1\",\n"
+                + "    \"serializationFormatVersion\": \"2024.1\",\n"
                 + "    \"languages\": [{\n"
                 + "        \"version\": \"1\",\n"
                 + "        \"key\": \"mm_key\"\n"
@@ -515,7 +515,7 @@ public class JsonSerializationTest extends SerializationTest {
     JsonElement je =
         JsonParser.parseString(
             "{\n"
-                + "    \"serializationFormatVersion\": \"2023.1\",\n"
+                + "    \"serializationFormatVersion\": \"2024.1\",\n"
                 + "    \"languages\": [{\n"
                 + "        \"version\": \"1\",\n"
                 + "        \"key\": \"mm_key\"\n"
@@ -589,7 +589,7 @@ public class JsonSerializationTest extends SerializationTest {
     JsonElement je =
         JsonParser.parseString(
             "{\n"
-                + "    \"serializationFormatVersion\": \"2023.1\",\n"
+                + "    \"serializationFormatVersion\": \"2024.1\",\n"
                 + "    \"languages\": [{\n"
                 + "        \"version\": \"1\",\n"
                 + "        \"key\": \"mm_key\"\n"

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
@@ -30,7 +30,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     SerializedChunk serializedChunk =
         jsonSerialization.serializeTreeToSerializationBlock(LionCore.getInstance());
 
-    assertEquals("2023.1", serializedChunk.getSerializationFormatVersion());
+    assertEquals("2024.1", serializedChunk.getSerializationFormatVersion());
 
     assertEquals(2, serializedChunk.getLanguages().size());
     Assert.assertEquals(

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfPrimitiveValuesTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfPrimitiveValuesTest.java
@@ -24,7 +24,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject expected =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -89,7 +89,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject serialized =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -161,7 +161,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject expected =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -227,7 +227,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject serialized =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -298,7 +298,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject expected =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -364,7 +364,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject serialized =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -439,7 +439,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject expected =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -508,7 +508,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject serialized =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"

--- a/core/src/test/resources/serialization/bobslibrary.json
+++ b/core/src/test/resources/serialization/bobslibrary.json
@@ -1,5 +1,5 @@
 {
-  "serializationFormatVersion": "2023.1",
+  "serializationFormatVersion": "2024.1",
   "languages": [],
   "nodes": [
     {

--- a/core/src/test/resources/serialization/foo-library.json
+++ b/core/src/test/resources/serialization/foo-library.json
@@ -1,5 +1,5 @@
 {
-  "serializationFormatVersion": "2023.1",
+  "serializationFormatVersion": "2024.1",
   "languages": [],
   "nodes": [
     {

--- a/core/src/test/resources/serialization/langeng-library.json
+++ b/core/src/test/resources/serialization/langeng-library.json
@@ -1,5 +1,5 @@
 {
-  "serializationFormatVersion": "2023.1",
+  "serializationFormatVersion": "2024.1",
   "languages": [],
   "nodes": [
     {

--- a/core/src/test/resources/serialization/library-language.json
+++ b/core/src/test/resources/serialization/library-language.json
@@ -1,5 +1,5 @@
 {
-  "serializationFormatVersion": "2023.1",
+  "serializationFormatVersion": "2024.1",
   "languages": [],
   "nodes": [
     {

--- a/core/src/test/resources/serialization/lioncore.json
+++ b/core/src/test/resources/serialization/lioncore.json
@@ -1,5 +1,5 @@
 {
-  "serializationFormatVersion": "2023.1",
+  "serializationFormatVersion": "2024.1",
   "languages": [
     {
       "key": "LionCore-M3",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=0.2.17-SNAPSHOT
-specsVersion=2023.1
+specsVersion=2024.1
 jvmVersion=1.8
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 SONATYPE_CONNECT_TIMEOUT_SECONDS=200

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[plugins]
+buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.3.5" }
+release = { id = "net.researchgate.release", version = "3.0.2" }
+superPublish = { id = "com.vanniktech.maven.publish", version = "0.28.0" }
+


### PR DESCRIPTION
Given all changes from now on will go towards 2024.1, we update the specs number.

We introduce BuildConfig to share a gradle configuration value with the Java codebase.

We also introduce version catalogs.