### PR TITLE
Make deserialization stateless w.r.t. instances resolver

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
@@ -31,13 +31,17 @@ class NodePopulator {
   }
 
   void populateClassifierInstance(
-      ClassifierInstance<?> node, SerializedClassifierInstance serializedClassifierInstance) {
-    populateContainments(node, serializedClassifierInstance);
-    populateNodeReferences(node, serializedClassifierInstance);
+      ClassifierInstance<?> node,
+      SerializedClassifierInstance serializedClassifierInstance,
+      ClassifierInstanceResolver classifierInstanceResolver) {
+    populateContainments(node, serializedClassifierInstance, classifierInstanceResolver);
+    populateNodeReferences(node, serializedClassifierInstance, classifierInstanceResolver);
   }
 
   private void populateContainments(
-      ClassifierInstance<?> node, SerializedClassifierInstance serializedClassifierInstance) {
+      ClassifierInstance<?> node,
+      SerializedClassifierInstance serializedClassifierInstance,
+      ClassifierInstanceResolver classifierInstanceResolver) {
     Classifier<?> concept = node.getClassifier();
     serializedClassifierInstance
         .getContainments()
@@ -73,7 +77,9 @@ class NodePopulator {
   }
 
   private void populateNodeReferences(
-      ClassifierInstance<?> node, SerializedClassifierInstance serializedClassifierInstance) {
+      ClassifierInstance<?> node,
+      SerializedClassifierInstance serializedClassifierInstance,
+      ClassifierInstanceResolver classifierInstanceResolver) {
     Classifier<?> concept = node.getClassifier();
     // TODO resolve references to Nodes in different models
     serializedClassifierInstance


### PR DESCRIPTION
Currently the instances resolver used in serialization would "remember" all nodes that it deserializes. I think that is incorrect and it should remember them only during the serialization but it should not affect future deserializations.

Right now to avoid this problem I was reinstatiating the JsonSerialization all the time, and performing a complex setup.