### PR TITLE
Support multiple LionWeb versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,7 @@ Import and export from and to EMF is a work in progress.
 
 * Introduce support for serialization based on ProtoBuffer and FlatBuffers
 * Introduce SerializationProvider
+
+## lionweb-java-2024.1-* - Version 0.3.0
+
+Introducing support for LionWeb 2024.1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We require Java 11 for building the project, while the artifacts published are c
 
 ```
 dependencies {
-   implementation("io.lionweb.lionweb-java:lionweb-java-2023.1-core:$lionwebVersion")
+   implementation("io.lionweb.lionweb-java:lionweb-java-2024.1-core:$lionwebVersion")
 }
 ```
 

--- a/core/src/integrationTest/java/io/lionweb/lioncore/java/testset/ALanguageTestset.java
+++ b/core/src/integrationTest/java/io/lionweb/lioncore/java/testset/ALanguageTestset.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.testset;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Language;
 import io.lionweb.lioncore.java.serialization.JsonSerialization;
 import io.lionweb.lioncore.java.serialization.SerializationProvider;
@@ -24,7 +25,8 @@ public abstract class ALanguageTestset extends ATestset {
   }
 
   protected JsonSerialization getSerialization() {
-    JsonSerialization result = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization result =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     result.registerLanguage(this.language);
     result.enableDynamicNodes();
     return result;

--- a/core/src/integrationTest/java/io/lionweb/lioncore/java/testset/ATestset.java
+++ b/core/src/integrationTest/java/io/lionweb/lioncore/java/testset/ATestset.java
@@ -2,6 +2,7 @@ package io.lionweb.lioncore.java.testset;
 
 import static org.junit.Assert.*;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Language;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.serialization.JsonSerialization;
@@ -33,7 +34,9 @@ public abstract class ATestset {
 
   protected static Language loadLanguage(Path path) {
     Node firstNode =
-        parse(path, SerializationProvider.getStandardJsonSerialization()).iterator().next();
+        parse(path, SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1))
+            .iterator()
+            .next();
     assertTrue(firstNode.getClass().toString(), firstNode instanceof Language);
     Language result = (Language) firstNode;
     LanguageValidator.ensureIsValid(result);

--- a/core/src/main/java/io/lionweb/lioncore/java/LionWebVersion.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/LionWebVersion.java
@@ -11,16 +11,16 @@ public enum LionWebVersion {
   v2023_1("2023.1"),
   v2024_1("2024.1");
   public static final LionWebVersion currentVersion = LionWebVersion.v2024_1;
-  private @Nonnull String value;
+  private @Nonnull String versionString;
 
-  LionWebVersion(@Nonnull String value) {
-    Objects.requireNonNull(value, "Value should not be null");
-    this.value = value;
+  LionWebVersion(@Nonnull String versionString) {
+    Objects.requireNonNull(versionString, "versionString should not be null");
+    this.versionString = versionString;
   }
 
   public static LionWebVersion fromValue(String serializationFormatVersion) {
     for (LionWebVersion lionWebVersion : values()) {
-      if (lionWebVersion.getValue().equals(serializationFormatVersion)) {
+      if (lionWebVersion.getVersionString().equals(serializationFormatVersion)) {
         return lionWebVersion;
       }
     }
@@ -28,7 +28,7 @@ public enum LionWebVersion {
         "Invalid serializationFormatVersion: " + serializationFormatVersion);
   }
 
-  public @Nonnull String getValue() {
-    return value;
+  public @Nonnull String getVersionString() {
+    return versionString;
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/LionWebVersion.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/LionWebVersion.java
@@ -1,12 +1,20 @@
 package io.lionweb.lioncore.java;
 
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+/**
+ * A LionWeb Version. Note that the version is used to refer to the specifications but also to the
+ * versions of LionCore and LionCore Builtins, as they should always be aligned.
+ */
 public enum LionWebVersion {
   v2023_1("2023.1"),
   v2024_1("2024.1");
   public static final LionWebVersion currentVersion = LionWebVersion.v2024_1;
-  private String value;
+  private @Nonnull String value;
 
-  LionWebVersion(String value) {
+  LionWebVersion(@Nonnull String value) {
+    Objects.requireNonNull(value, "Value should not be null");
     this.value = value;
   }
 
@@ -20,7 +28,7 @@ public enum LionWebVersion {
         "Invalid serializationFormatVersion: " + serializationFormatVersion);
   }
 
-  public String getValue() {
+  public @Nonnull String getValue() {
     return value;
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/LionWebVersion.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/LionWebVersion.java
@@ -16,7 +16,8 @@ public enum LionWebVersion {
         return lionWebVersion;
       }
     }
-    throw new IllegalArgumentException("Invalid serializationFormatVersion: " + serializationFormatVersion);
+    throw new IllegalArgumentException(
+        "Invalid serializationFormatVersion: " + serializationFormatVersion);
   }
 
   public String getValue() {

--- a/core/src/main/java/io/lionweb/lioncore/java/LionWebVersion.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/LionWebVersion.java
@@ -1,0 +1,7 @@
+package io.lionweb.lioncore.java;
+
+public enum LionWebVersion {
+  v2023_1,
+  v2024_1;
+  public static final LionWebVersion currentVersion = LionWebVersion.v2024_1;
+}

--- a/core/src/main/java/io/lionweb/lioncore/java/LionWebVersion.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/LionWebVersion.java
@@ -1,7 +1,25 @@
 package io.lionweb.lioncore.java;
 
 public enum LionWebVersion {
-  v2023_1,
-  v2024_1;
+  v2023_1("2023.1"),
+  v2024_1("2024.1");
   public static final LionWebVersion currentVersion = LionWebVersion.v2024_1;
+  private String value;
+
+  LionWebVersion(String value) {
+    this.value = value;
+  }
+
+  public static LionWebVersion fromValue(String serializationFormatVersion) {
+    for (LionWebVersion lionWebVersion : values()) {
+      if (lionWebVersion.getValue().equals(serializationFormatVersion)) {
+        return lionWebVersion;
+      }
+    }
+    throw new IllegalArgumentException("Invalid serializationFormatVersion: " + serializationFormatVersion);
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Annotation.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Annotation.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.ReferenceValue;
 import io.lionweb.lioncore.java.self.LionCore;
 import java.util.ArrayList;
@@ -25,6 +26,10 @@ import javax.annotation.Nullable;
  *     equivalent <i>NodeAttribute</i> in local MPS</a>
  */
 public class Annotation extends Classifier<Annotation> {
+
+  public Annotation(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
+  }
 
   public Annotation() {
     super();

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Annotation.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Annotation.java
@@ -126,6 +126,6 @@ public class Annotation extends Classifier<Annotation> {
 
   @Override
   public Concept getClassifier() {
-    return LionCore.getAnnotation();
+    return LionCore.getAnnotation(getLionWebVersion());
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Classifier.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Classifier.java
@@ -36,7 +36,8 @@ public abstract class Classifier<T extends M3Node> extends LanguageEntity<T>
     super(language, name, id);
   }
 
-  public Classifier(@Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
+  public Classifier(
+      @Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
     super(lionWebVersion, language, name);
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Classifier.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Classifier.java
@@ -36,6 +36,10 @@ public abstract class Classifier<T extends M3Node> extends LanguageEntity<T>
     super(language, name, id);
   }
 
+  public Classifier(@Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
+    super(lionWebVersion, language, name);
+  }
+
   public Classifier(@Nullable Language language, @Nullable String name) {
     super(language, name);
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Classifier.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Classifier.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.impl.M3Node;
 import io.lionweb.lioncore.java.serialization.data.MetaPointer;
 import java.util.*;
@@ -25,6 +26,10 @@ public abstract class Classifier<T extends M3Node> extends LanguageEntity<T>
     implements NamespaceProvider {
   public Classifier() {
     super();
+  }
+
+  public Classifier(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
   }
 
   public Classifier(@Nullable Language language, @Nullable String name, @Nonnull String id) {

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Concept.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Concept.java
@@ -54,7 +54,8 @@ public class Concept extends Classifier<Concept> {
     setPartition(false);
   }
 
-  public Concept(@Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
+  public Concept(
+      @Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
     super(lionWebVersion, language, name);
     setAbstract(false);
     setPartition(false);

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Concept.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Concept.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.ReferenceValue;
 import io.lionweb.lioncore.java.self.LionCore;
 import java.util.*;
@@ -28,6 +29,12 @@ public class Concept extends Classifier<Concept> {
 
   public Concept() {
     super();
+    setAbstract(false);
+    setPartition(false);
+  }
+
+  public Concept(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
     setAbstract(false);
     setPartition(false);
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Concept.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Concept.java
@@ -54,8 +54,20 @@ public class Concept extends Classifier<Concept> {
     setPartition(false);
   }
 
+  public Concept(@Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
+    super(lionWebVersion, language, name);
+    setAbstract(false);
+    setPartition(false);
+  }
+
   public Concept(@Nullable Language language, @Nullable String name) {
     super(language, name);
+    setAbstract(false);
+    setPartition(false);
+  }
+
+  public Concept(@Nonnull LionWebVersion lionWebVersion, @Nullable String name) {
+    super(lionWebVersion, null, name);
     setAbstract(false);
     setPartition(false);
   }
@@ -129,6 +141,6 @@ public class Concept extends Classifier<Concept> {
 
   @Override
   public Concept getClassifier() {
-    return LionCore.getConcept();
+    return LionCore.getConcept(getLionWebVersion());
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Containment.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Containment.java
@@ -65,6 +65,7 @@ public class Containment extends Link<Containment> {
 
   public static Containment createMultiple(
       @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable Classifier type) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     Containment containment = new Containment(lionWebVersion, name);
     containment.setOptional(true);
     containment.setMultiple(true);
@@ -85,6 +86,7 @@ public class Containment extends Link<Containment> {
       @Nullable String name,
       @Nullable Classifier type,
       @Nonnull String id) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     Objects.requireNonNull(id, "id should not be null");
     Containment containment = new Containment(lionWebVersion, name, id);
     containment.setOptional(true);

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Containment.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Containment.java
@@ -119,7 +119,6 @@ public class Containment extends Link<Containment> {
   }
 
   public Containment(String name, @Nullable Classifier container) {
-    // TODO verify that the container is also a NamespaceProvider
     super(name, container);
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Containment.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Containment.java
@@ -139,6 +139,6 @@ public class Containment extends Link<Containment> {
 
   @Override
   public Concept getClassifier() {
-    return LionCore.getContainment();
+    return LionCore.getContainment(getLionWebVersion());
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Containment.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Containment.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.self.LionCore;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -62,8 +63,30 @@ public class Containment extends Link<Containment> {
     return containment;
   }
 
+  public static Containment createMultiple(
+      @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable Classifier type) {
+    Containment containment = new Containment(lionWebVersion, name);
+    containment.setOptional(true);
+    containment.setMultiple(true);
+    containment.setType(type);
+    return containment;
+  }
+
   public static Containment createMultiple(@Nullable String name, @Nullable Classifier type) {
     Containment containment = new Containment(name);
+    containment.setOptional(true);
+    containment.setMultiple(true);
+    containment.setType(type);
+    return containment;
+  }
+
+  public static Containment createMultiple(
+      @Nonnull LionWebVersion lionWebVersion,
+      @Nullable String name,
+      @Nullable Classifier type,
+      @Nonnull String id) {
+    Objects.requireNonNull(id, "id should not be null");
+    Containment containment = new Containment(lionWebVersion, name, id);
     containment.setOptional(true);
     containment.setMultiple(true);
     containment.setType(type);
@@ -98,8 +121,16 @@ public class Containment extends Link<Containment> {
     super(name, container);
   }
 
+  public Containment(@Nonnull LionWebVersion lionWebVersion, String name) {
+    super(lionWebVersion, name, (Classifier) null);
+  }
+
   public Containment(String name) {
     super(name, (Classifier) null);
+  }
+
+  public Containment(@Nonnull LionWebVersion lionWebVersion, String name, @Nonnull String id) {
+    super(lionWebVersion, name, id);
   }
 
   public Containment(String name, @Nonnull String id) {

--- a/core/src/main/java/io/lionweb/lioncore/java/language/DataType.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/DataType.java
@@ -33,10 +33,10 @@ public abstract class DataType<T extends M3Node> extends LanguageEntity<T> {
     super(LionWebVersion.currentVersion, null, null, id);
   }
 
-  public DataType(@Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
+  public DataType(
+      @Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
     super(lionWebVersion, language, name);
   }
-
 
   public DataType(@Nullable Language language, @Nullable String name) {
     super(language, name);

--- a/core/src/main/java/io/lionweb/lioncore/java/language/DataType.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/DataType.java
@@ -33,6 +33,11 @@ public abstract class DataType<T extends M3Node> extends LanguageEntity<T> {
     super(LionWebVersion.currentVersion, null, null, id);
   }
 
+  public DataType(@Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
+    super(lionWebVersion, language, name);
+  }
+
+
   public DataType(@Nullable Language language, @Nullable String name) {
     super(language, name);
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/DataType.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/DataType.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.impl.M3Node;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -20,8 +21,16 @@ public abstract class DataType<T extends M3Node> extends LanguageEntity<T> {
     super();
   }
 
+  public DataType(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
+  }
+
+  public DataType(@Nonnull LionWebVersion lionWebVersion, @Nonnull String id) {
+    super(lionWebVersion, null, null, id);
+  }
+
   public DataType(@Nonnull String id) {
-    super(null, null, id);
+    super(LionWebVersion.currentVersion, null, null, id);
   }
 
   public DataType(@Nullable Language language, @Nullable String name) {

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Enumeration.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Enumeration.java
@@ -36,6 +36,6 @@ public class Enumeration extends DataType<Enumeration> implements NamespaceProvi
 
   @Override
   public Concept getClassifier() {
-    return LionCore.getEnumeration();
+    return LionCore.getEnumeration(getLionWebVersion());
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Enumeration.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Enumeration.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.self.LionCore;
 import java.util.List;
 import java.util.Objects;
@@ -7,6 +8,10 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class Enumeration extends DataType<Enumeration> implements NamespaceProvider {
+  public Enumeration(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
+  }
+
   public Enumeration() {
     super();
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/EnumerationLiteral.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/EnumerationLiteral.java
@@ -58,7 +58,7 @@ public class EnumerationLiteral extends M3Node<EnumerationLiteral>
 
   @Override
   public Concept getClassifier() {
-    return LionCore.getEnumerationLiteral();
+    return LionCore.getEnumerationLiteral(getLionWebVersion());
   }
 
   @Override

--- a/core/src/main/java/io/lionweb/lioncore/java/language/EnumerationLiteral.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/EnumerationLiteral.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.impl.M3Node;
 import io.lionweb.lioncore.java.self.LionCore;
@@ -8,6 +9,10 @@ import javax.annotation.Nullable;
 
 public class EnumerationLiteral extends M3Node<EnumerationLiteral>
     implements NamespacedEntity, IKeyed<EnumerationLiteral> {
+
+  public EnumerationLiteral(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
+  }
 
   public EnumerationLiteral() {}
 

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Feature.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Feature.java
@@ -51,17 +51,15 @@ public abstract class Feature<T extends M3Node> extends M3Node<T>
     setOptional(false);
     Objects.requireNonNull(id, "id should not be null");
     this.setID(id);
-    // TODO verify that the container is also a NamespaceProvider
     // TODO enforce uniqueness of the name within the FeauturesContainer
     setName(name);
     setParent(container);
   }
 
-  public Feature(@Nullable String name, @Nullable Classifier container, @Nonnull String id) {
+  public Feature(@Nullable String name, @Nullable Classifier<?> container, @Nonnull String id) {
     setOptional(false);
     Objects.requireNonNull(id, "id should not be null");
     this.setID(id);
-    // TODO verify that the container is also a NamespaceProvider
     // TODO enforce uniqueness of the name within the FeauturesContainer
     setName(name);
     setParent(container);
@@ -73,7 +71,6 @@ public abstract class Feature<T extends M3Node> extends M3Node<T>
       @Nullable Classifier container) {
     super(lionWebVersion);
     setOptional(false);
-    // TODO verify that the container is also a NamespaceProvider
     // TODO enforce uniqueness of the name within the FeauturesContainer
     setName(name);
     setParent(container);
@@ -81,7 +78,6 @@ public abstract class Feature<T extends M3Node> extends M3Node<T>
 
   public Feature(@Nullable String name, @Nullable Classifier container) {
     setOptional(false);
-    // TODO verify that the container is also a NamespaceProvider
     // TODO enforce uniqueness of the name within the FeauturesContainer
     setName(name);
     setParent(container);

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Feature.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Feature.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.impl.M3Node;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -21,6 +22,18 @@ public abstract class Feature<T extends M3Node> extends M3Node<T>
     implements NamespacedEntity, IKeyed<T> {
 
   public Feature() {
+    super();
+    setOptional(false);
+  }
+
+  public Feature(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
+    setOptional(false);
+  }
+
+  public Feature(
+      @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nonnull String id) {
+    this(lionWebVersion, name, null, id);
     setOptional(false);
   }
 
@@ -29,10 +42,37 @@ public abstract class Feature<T extends M3Node> extends M3Node<T>
     setOptional(false);
   }
 
+  public Feature(
+      @Nonnull LionWebVersion lionWebVersion,
+      @Nullable String name,
+      @Nullable Classifier container,
+      @Nonnull String id) {
+    super(lionWebVersion);
+    setOptional(false);
+    Objects.requireNonNull(id, "id should not be null");
+    this.setID(id);
+    // TODO verify that the container is also a NamespaceProvider
+    // TODO enforce uniqueness of the name within the FeauturesContainer
+    setName(name);
+    setParent(container);
+  }
+
   public Feature(@Nullable String name, @Nullable Classifier container, @Nonnull String id) {
     setOptional(false);
     Objects.requireNonNull(id, "id should not be null");
     this.setID(id);
+    // TODO verify that the container is also a NamespaceProvider
+    // TODO enforce uniqueness of the name within the FeauturesContainer
+    setName(name);
+    setParent(container);
+  }
+
+  public Feature(
+      @Nonnull LionWebVersion lionWebVersion,
+      @Nullable String name,
+      @Nullable Classifier container) {
+    super(lionWebVersion);
+    setOptional(false);
     // TODO verify that the container is also a NamespaceProvider
     // TODO enforce uniqueness of the name within the FeauturesContainer
     setName(name);

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Interface.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Interface.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.ReferenceValue;
 import io.lionweb.lioncore.java.self.LionCore;
 import java.util.*;
@@ -24,6 +25,10 @@ import javax.annotation.Nullable;
 public class Interface extends Classifier<Interface> {
   public Interface() {
     super();
+  }
+
+  public Interface(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
   }
 
   public Interface(@Nullable Language language, @Nullable String name, @Nonnull String id) {

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Interface.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Interface.java
@@ -48,7 +48,8 @@ public class Interface extends Classifier<Interface> {
     super(language, name);
   }
 
-  public Interface(@Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
+  public Interface(
+      @Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
     super(lionWebVersion, language, name);
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Interface.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Interface.java
@@ -48,6 +48,14 @@ public class Interface extends Classifier<Interface> {
     super(language, name);
   }
 
+  public Interface(@Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
+    super(lionWebVersion, language, name);
+  }
+
+  public Interface(@Nonnull LionWebVersion lionWebVersion, @Nullable String name) {
+    super(lionWebVersion, null, name);
+  }
+
   public Interface(@Nullable String name) {
     super(null, name);
   }
@@ -78,7 +86,7 @@ public class Interface extends Classifier<Interface> {
 
   @Override
   public Concept getClassifier() {
-    return LionCore.getInterface();
+    return LionCore.getInterface(getLionWebVersion());
   }
 
   @Nonnull

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Language.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Language.java
@@ -28,7 +28,6 @@ import javax.annotation.Nullable;
 public class Language extends M3Node<Language> implements NamespaceProvider, IKeyed<Language> {
   public Language(@Nonnull LionWebVersion lionWebVersion) {
     super(lionWebVersion);
-    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
   }
 
   public Language() {

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Language.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Language.java
@@ -26,11 +26,9 @@ import javax.annotation.Nullable;
  *     structure aspect</i> in documentation</a>
  */
 public class Language extends M3Node<Language> implements NamespaceProvider, IKeyed<Language> {
-  private LionWebVersion lionWebVersion;
-
   public Language(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
-    this.lionWebVersion = lionWebVersion;
   }
 
   public Language() {
@@ -180,7 +178,7 @@ public class Language extends M3Node<Language> implements NamespaceProvider, IKe
 
   @Override
   public Concept getClassifier() {
-    return LionCore.getLanguage();
+    return LionCore.getLanguage(getLionWebVersion());
   }
 
   @Override

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Language.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Language.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.ReferenceValue;
 import io.lionweb.lioncore.java.model.impl.M3Node;
 import io.lionweb.lioncore.java.self.LionCore;
@@ -25,9 +26,25 @@ import javax.annotation.Nullable;
  *     structure aspect</i> in documentation</a>
  */
 public class Language extends M3Node<Language> implements NamespaceProvider, IKeyed<Language> {
-  public Language() {}
+  private LionWebVersion lionWebVersion;
+
+  public Language(@Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
+    this.lionWebVersion = lionWebVersion;
+  }
+
+  public Language() {
+    this(LionWebVersion.currentVersion);
+  }
+
+  public Language(@Nonnull LionWebVersion lionWebVersion, @Nonnull String name) {
+    this(lionWebVersion);
+    Objects.requireNonNull(name, "name should not be null");
+    this.setName(name);
+  }
 
   public Language(@Nonnull String name) {
+    this(LionWebVersion.currentVersion);
     Objects.requireNonNull(name, "name should not be null");
     this.setName(name);
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LanguageEntity.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LanguageEntity.java
@@ -1,6 +1,8 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.impl.M3Node;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -18,7 +20,25 @@ import javax.annotation.Nullable;
 public abstract class LanguageEntity<T extends M3Node> extends M3Node<T>
     implements NamespacedEntity, IKeyed<T> {
 
-  public LanguageEntity() {}
+  private LionWebVersion lionWebVersion;
+
+  public LanguageEntity(@Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
+    this.lionWebVersion = lionWebVersion;
+  }
+
+  public LanguageEntity() {
+    this(LionWebVersion.currentVersion);
+  }
+
+  public LanguageEntity(
+      @Nonnull LionWebVersion lionWebVersion,
+      @Nullable Language language,
+      @Nullable String name,
+      @Nonnull String id) {
+    this(lionWebVersion, language, name);
+    this.setID(id);
+  }
 
   public LanguageEntity(@Nullable Language language, @Nullable String name, @Nonnull String id) {
     this(language, name);
@@ -26,6 +46,19 @@ public abstract class LanguageEntity<T extends M3Node> extends M3Node<T>
   }
 
   public LanguageEntity(@Nullable Language language, @Nullable String name) {
+    this();
+    // TODO enforce uniqueness of the name within the Language
+    this.setName(name);
+    if (language != null) {
+      language.addElement(this);
+    } else {
+      this.setParent(null);
+    }
+  }
+
+  public LanguageEntity(
+      @Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
+    this(lionWebVersion);
     // TODO enforce uniqueness of the name within the Language
     this.setName(name);
     if (language != null) {

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LanguageEntity.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LanguageEntity.java
@@ -20,11 +20,10 @@ import javax.annotation.Nullable;
 public abstract class LanguageEntity<T extends M3Node> extends M3Node<T>
     implements NamespacedEntity, IKeyed<T> {
 
-  private LionWebVersion lionWebVersion;
 
   public LanguageEntity(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
-    this.lionWebVersion = lionWebVersion;
   }
 
   public LanguageEntity() {

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LanguageEntity.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LanguageEntity.java
@@ -2,7 +2,6 @@ package io.lionweb.lioncore.java.language;
 
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.impl.M3Node;
-import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -22,7 +21,6 @@ public abstract class LanguageEntity<T extends M3Node> extends M3Node<T>
 
   public LanguageEntity(@Nonnull LionWebVersion lionWebVersion) {
     super(lionWebVersion);
-    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
   }
 
   public LanguageEntity() {

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LanguageEntity.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LanguageEntity.java
@@ -20,7 +20,6 @@ import javax.annotation.Nullable;
 public abstract class LanguageEntity<T extends M3Node> extends M3Node<T>
     implements NamespacedEntity, IKeyed<T> {
 
-
   public LanguageEntity(@Nonnull LionWebVersion lionWebVersion) {
     super(lionWebVersion);
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Link.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Link.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.ReferenceValue;
 import io.lionweb.lioncore.java.model.impl.M3Node;
 import javax.annotation.Nonnull;
@@ -23,9 +24,29 @@ public abstract class Link<T extends M3Node> extends Feature<T> {
     setMultiple(false);
   }
 
+  public Link(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
+    setMultiple(false);
+  }
+
+  public Link(@Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nonnull String id) {
+    // TODO verify that the container is also a NamespaceProvider
+    super(lionWebVersion, name, id);
+    setMultiple(false);
+  }
+
   public Link(@Nullable String name, @Nonnull String id) {
     // TODO verify that the container is also a NamespaceProvider
     super(name, id);
+    setMultiple(false);
+  }
+
+  public Link(
+      @Nonnull LionWebVersion lionWebVersion,
+      @Nullable String name,
+      @Nullable Classifier container) {
+    // TODO verify that the container is also a NamespaceProvider
+    super(lionWebVersion, name, container);
     setMultiple(false);
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Link.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Link.java
@@ -30,13 +30,11 @@ public abstract class Link<T extends M3Node> extends Feature<T> {
   }
 
   public Link(@Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nonnull String id) {
-    // TODO verify that the container is also a NamespaceProvider
     super(lionWebVersion, name, id);
     setMultiple(false);
   }
 
   public Link(@Nullable String name, @Nonnull String id) {
-    // TODO verify that the container is also a NamespaceProvider
     super(name, id);
     setMultiple(false);
   }
@@ -45,13 +43,11 @@ public abstract class Link<T extends M3Node> extends Feature<T> {
       @Nonnull LionWebVersion lionWebVersion,
       @Nullable String name,
       @Nullable Classifier container) {
-    // TODO verify that the container is also a NamespaceProvider
     super(lionWebVersion, name, container);
     setMultiple(false);
   }
 
   public Link(@Nullable String name, @Nullable Classifier container) {
-    // TODO verify that the container is also a NamespaceProvider
     super(name, container);
     setMultiple(false);
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
@@ -1,11 +1,9 @@
 package io.lionweb.lioncore.java.language;
 
 import io.lionweb.lioncore.java.LionWebVersion;
-import io.lionweb.lioncore.java.serialization.JsonSerialization;
-
-import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 public class LionCoreBuiltins extends Language {
   private static final Map<LionWebVersion, LionCoreBuiltins> INSTANCES = new HashMap<>();
@@ -26,7 +24,8 @@ public class LionCoreBuiltins extends Language {
     Concept node = new Concept(lionWebVersion, this, "Node").setID("LionCore-builtins-Node");
     node.setAbstract(true);
 
-    Interface iNamed = new Interface(lionWebVersion, this, "INamed").setID("LionCore-builtins-INamed");
+    Interface iNamed =
+        new Interface(lionWebVersion, this, "INamed").setID("LionCore-builtins-INamed");
     iNamed.addFeature(
         Property.createRequired(lionWebVersion, "name", string)
             .setID("LionCore-builtins-INamed-name")

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
@@ -16,7 +16,7 @@ public class LionCoreBuiltins extends Language {
     super(lionWebVersion, "LionCore_builtins");
     setID("LionCore-builtins");
     setKey("LionCore-builtins");
-    setVersion(lionWebVersion.getValue());
+    setVersion(lionWebVersion.getVersionString());
     PrimitiveType string = new PrimitiveType(lionWebVersion, this, "String");
     new PrimitiveType(lionWebVersion, this, "Boolean");
     new PrimitiveType(lionWebVersion, this, "Integer");
@@ -50,26 +50,6 @@ public class LionCoreBuiltins extends Language {
     return getInstance(LionWebVersion.currentVersion);
   }
 
-  public static PrimitiveType getString() {
-    return getInstance().getPrimitiveTypeByName("String");
-  }
-
-  public static PrimitiveType getInteger() {
-    return getInstance().getPrimitiveTypeByName("Integer");
-  }
-
-  public static PrimitiveType getBoolean() {
-    return getInstance().getPrimitiveTypeByName("Boolean");
-  }
-
-  public static Interface getINamed() {
-    return getInstance().getInterfaceByName("INamed");
-  }
-
-  public static Concept getNode() {
-    return getInstance().getConceptByName("Node");
-  }
-
   public static LionCoreBuiltins getInstance(@Nonnull LionWebVersion lionWebVersion) {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     if (!INSTANCES.containsKey(lionWebVersion)) {
@@ -78,16 +58,44 @@ public class LionCoreBuiltins extends Language {
     return INSTANCES.get(lionWebVersion);
   }
 
+  public static PrimitiveType getString() {
+    return getInstance().getPrimitiveTypeByName("String");
+  }
+
   public static PrimitiveType getString(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).getPrimitiveTypeByName("String");
+  }
+
+  public static PrimitiveType getInteger() {
+    return getInstance().getPrimitiveTypeByName("Integer");
   }
 
   public static PrimitiveType getInteger(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).getPrimitiveTypeByName("Integer");
   }
 
+  public static PrimitiveType getBoolean() {
+    return getInstance().getPrimitiveTypeByName("Boolean");
+  }
+
   public static PrimitiveType getBoolean(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).getPrimitiveTypeByName("Boolean");
+  }
+
+  public static Interface getINamed() {
+    return getInstance().getInterfaceByName("INamed");
+  }
+
+  public static Interface getINamed(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).getInterfaceByName("INamed");
+  }
+
+  public static Concept getNode() {
+    return getInstance().getConceptByName("Node");
+  }
+
+  public static Concept getNode(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).getConceptByName("Node");
   }
 
   public static PrimitiveType getJSON(@Nonnull LionWebVersion lionWebVersion) {
@@ -95,13 +103,5 @@ public class LionCoreBuiltins extends Language {
       throw new IllegalArgumentException("JSON was present only in v2023.1");
     }
     return getInstance(lionWebVersion).getPrimitiveTypeByName("JSON");
-  }
-
-  public static Interface getINamed(@Nonnull LionWebVersion lionWebVersion) {
-    return getInstance(lionWebVersion).getInterfaceByName("INamed");
-  }
-
-  public static Concept getNode(@Nonnull LionWebVersion lionWebVersion) {
-    return getInstance(lionWebVersion).getConceptByName("Node");
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
@@ -7,6 +7,8 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 
 public class LionCoreBuiltins extends Language {
+  // We may have one instance of this class per LionWeb version, and we initialize
+  // them lazily
   private static final Map<LionWebVersion, LionCoreBuiltins> INSTANCES = new HashMap<>();
 
   /** This is private to prevent instantiation and enforce the Singleton pattern. */

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
@@ -3,6 +3,7 @@ package io.lionweb.lioncore.java.language;
 import io.lionweb.lioncore.java.LionWebVersion;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 
 public class LionCoreBuiltins extends Language {
@@ -59,10 +60,6 @@ public class LionCoreBuiltins extends Language {
     return getInstance().getPrimitiveTypeByName("Boolean");
   }
 
-  public static PrimitiveType getJSON() {
-    return getInstance().getPrimitiveTypeByName("JSON");
-  }
-
   public static Interface getINamed() {
     return getInstance().getInterfaceByName("INamed");
   }
@@ -72,6 +69,7 @@ public class LionCoreBuiltins extends Language {
   }
 
   public static LionCoreBuiltins getInstance(@Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     if (!INSTANCES.containsKey(lionWebVersion)) {
       INSTANCES.put(lionWebVersion, new LionCoreBuiltins(lionWebVersion));
     }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
@@ -1,27 +1,34 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.serialization.JsonSerialization;
 
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+
 public class LionCoreBuiltins extends Language {
-  private static final LionCoreBuiltins INSTANCE = new LionCoreBuiltins();
+  private static final Map<LionWebVersion, LionCoreBuiltins> INSTANCES = new HashMap<>();
 
   /** This is private to prevent instantiation and enforce the Singleton pattern. */
-  private LionCoreBuiltins() {
-    super("LionCore_builtins");
+  private LionCoreBuiltins(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion, "LionCore_builtins");
     setID("LionCore-builtins");
     setKey("LionCore-builtins");
-    setVersion(JsonSerialization.DEFAULT_SERIALIZATION_FORMAT);
-    PrimitiveType string = new PrimitiveType(this, "String");
-    new PrimitiveType(this, "Boolean");
-    new PrimitiveType(this, "Integer");
-    new PrimitiveType(this, "JSON");
+    setVersion(lionWebVersion.getValue());
+    PrimitiveType string = new PrimitiveType(lionWebVersion, this, "String");
+    new PrimitiveType(lionWebVersion, this, "Boolean");
+    new PrimitiveType(lionWebVersion, this, "Integer");
+    if (lionWebVersion.equals(LionWebVersion.v2023_1)) {
+      new PrimitiveType(lionWebVersion, this, "JSON");
+    }
 
-    Concept node = new Concept(this, "Node").setID("LionCore-builtins-Node");
+    Concept node = new Concept(lionWebVersion, this, "Node").setID("LionCore-builtins-Node");
     node.setAbstract(true);
 
-    Interface iNamed = new Interface(this, "INamed").setID("LionCore-builtins-INamed");
+    Interface iNamed = new Interface(lionWebVersion, this, "INamed").setID("LionCore-builtins-INamed");
     iNamed.addFeature(
-        Property.createRequired("name", string)
+        Property.createRequired(lionWebVersion, "name", string)
             .setID("LionCore-builtins-INamed-name")
             .setKey("LionCore-builtins-INamed-name"));
 
@@ -38,30 +45,64 @@ public class LionCoreBuiltins extends Language {
   }
 
   public static LionCoreBuiltins getInstance() {
-    return INSTANCE;
+    return getInstance(LionWebVersion.currentVersion);
   }
 
   public static PrimitiveType getString() {
-    return INSTANCE.getPrimitiveTypeByName("String");
+    return getInstance().getPrimitiveTypeByName("String");
   }
 
   public static PrimitiveType getInteger() {
-    return INSTANCE.getPrimitiveTypeByName("Integer");
+    return getInstance().getPrimitiveTypeByName("Integer");
   }
 
   public static PrimitiveType getBoolean() {
-    return INSTANCE.getPrimitiveTypeByName("Boolean");
+    return getInstance().getPrimitiveTypeByName("Boolean");
   }
 
   public static PrimitiveType getJSON() {
-    return INSTANCE.getPrimitiveTypeByName("JSON");
+    return getInstance().getPrimitiveTypeByName("JSON");
   }
 
   public static Interface getINamed() {
-    return INSTANCE.getInterfaceByName("INamed");
+    return getInstance().getInterfaceByName("INamed");
   }
 
   public static Concept getNode() {
-    return INSTANCE.getConceptByName("Node");
+    return getInstance().getConceptByName("Node");
+  }
+
+  public static LionCoreBuiltins getInstance(@Nonnull LionWebVersion lionWebVersion) {
+    if (!INSTANCES.containsKey(lionWebVersion)) {
+      INSTANCES.put(lionWebVersion, new LionCoreBuiltins(lionWebVersion));
+    }
+    return INSTANCES.get(lionWebVersion);
+  }
+
+  public static PrimitiveType getString(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).getPrimitiveTypeByName("String");
+  }
+
+  public static PrimitiveType getInteger(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).getPrimitiveTypeByName("Integer");
+  }
+
+  public static PrimitiveType getBoolean(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).getPrimitiveTypeByName("Boolean");
+  }
+
+  public static PrimitiveType getJSON(@Nonnull LionWebVersion lionWebVersion) {
+    if (!lionWebVersion.equals(LionWebVersion.v2023_1)) {
+      throw new IllegalArgumentException("JSON was present only in v2023.1");
+    }
+    return getInstance(lionWebVersion).getPrimitiveTypeByName("JSON");
+  }
+
+  public static Interface getINamed(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).getInterfaceByName("INamed");
+  }
+
+  public static Concept getNode(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).getConceptByName("Node");
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/PrimitiveType.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/PrimitiveType.java
@@ -31,6 +31,10 @@ public class PrimitiveType extends DataType<PrimitiveType> {
     super(id);
   }
 
+  public PrimitiveType(@Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
+    super(lionWebVersion, language, name);
+  }
+
   public PrimitiveType(@Nullable Language language, @Nullable String name) {
     super(language, name);
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/PrimitiveType.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/PrimitiveType.java
@@ -31,7 +31,8 @@ public class PrimitiveType extends DataType<PrimitiveType> {
     super(id);
   }
 
-  public PrimitiveType(@Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
+  public PrimitiveType(
+      @Nonnull LionWebVersion lionWebVersion, @Nullable Language language, @Nullable String name) {
     super(lionWebVersion, language, name);
   }
 
@@ -46,6 +47,6 @@ public class PrimitiveType extends DataType<PrimitiveType> {
 
   @Override
   public Concept getClassifier() {
-    return LionCore.getPrimitiveType();
+    return LionCore.getPrimitiveType(getLionWebVersion());
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/PrimitiveType.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/PrimitiveType.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.self.LionCore;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -20,6 +21,10 @@ import javax.annotation.Nullable;
 public class PrimitiveType extends DataType<PrimitiveType> {
   public PrimitiveType() {
     super();
+  }
+
+  public PrimitiveType(@Nonnull LionWebVersion lionWebVersion, @Nonnull String id) {
+    super(lionWebVersion, id);
   }
 
   public PrimitiveType(@Nonnull String id) {

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
@@ -92,27 +92,23 @@ public class Property extends Feature<Property> {
   public Property(
       @Nonnull LionWebVersion lionWebVersion,
       @Nullable String name,
-      @Nullable Classifier container,
+      @Nullable Classifier<?> container,
       @Nonnull String id) {
-    // TODO verify that the container is also a NamespaceProvider
     super(lionWebVersion, name, container, id);
   }
 
-  public Property(@Nullable String name, @Nullable Classifier container, @Nonnull String id) {
-    // TODO verify that the container is also a NamespaceProvider
+  public Property(@Nullable String name, @Nullable Classifier<?> container, @Nonnull String id) {
     super(name, container, id);
   }
 
   public Property(
       @Nonnull LionWebVersion lionWebVersion,
       @Nullable String name,
-      @Nullable Classifier container) {
-    // TODO verify that the container is also a NamespaceProvider
+      @Nullable Classifier<?> container) {
     super(lionWebVersion, name, container);
   }
 
-  public Property(@Nullable String name, @Nullable Classifier container) {
-    // TODO verify that the container is also a NamespaceProvider
+  public Property(@Nullable String name, @Nullable Classifier<?> container) {
     super(name, container);
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
@@ -133,6 +133,6 @@ public class Property extends Feature<Property> {
 
   @Override
   public Concept getClassifier() {
-    return LionCore.getProperty();
+    return LionCore.getProperty(getLionWebVersion());
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
@@ -22,6 +22,14 @@ import javax.annotation.Nullable;
  */
 public class Property extends Feature<Property> {
 
+  public static Property createOptional(
+      @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable DataType type) {
+    Property property = new Property(lionWebVersion, name, null);
+    property.setOptional(true);
+    property.setType(type);
+    return property;
+  }
+
   public static Property createOptional(@Nullable String name, @Nullable DataType type) {
     Property property = new Property(name, null);
     property.setOptional(true);

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.ReferenceValue;
 import io.lionweb.lioncore.java.self.LionCore;
 import java.util.Objects;
@@ -28,6 +29,14 @@ public class Property extends Feature<Property> {
     return property;
   }
 
+  public static Property createRequired(
+      @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable DataType type) {
+    Property property = new Property(lionWebVersion, name, null);
+    property.setOptional(false);
+    property.setType(type);
+    return property;
+  }
+
   public static Property createRequired(@Nullable String name, @Nullable DataType type) {
     Property property = new Property(name, null);
     property.setOptional(false);
@@ -45,6 +54,19 @@ public class Property extends Feature<Property> {
   }
 
   public static Property createRequired(
+      @Nonnull LionWebVersion lionWebVersion,
+      @Nullable String name,
+      @Nullable DataType type,
+      @Nonnull String id) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
+    Objects.requireNonNull(id, "id should not be null");
+    Property property = new Property(lionWebVersion, name, null, id);
+    property.setOptional(false);
+    property.setType(type);
+    return property;
+  }
+
+  public static Property createRequired(
       @Nullable String name, @Nullable DataType type, @Nonnull String id) {
     Objects.requireNonNull(id, "id should not be null");
     Property property = new Property(name, null, id);
@@ -57,9 +79,26 @@ public class Property extends Feature<Property> {
     super();
   }
 
+  public Property(
+      @Nonnull LionWebVersion lionWebVersion,
+      @Nullable String name,
+      @Nullable Classifier container,
+      @Nonnull String id) {
+    // TODO verify that the container is also a NamespaceProvider
+    super(lionWebVersion, name, container, id);
+  }
+
   public Property(@Nullable String name, @Nullable Classifier container, @Nonnull String id) {
     // TODO verify that the container is also a NamespaceProvider
     super(name, container, id);
+  }
+
+  public Property(
+      @Nonnull LionWebVersion lionWebVersion,
+      @Nullable String name,
+      @Nullable Classifier container) {
+    // TODO verify that the container is also a NamespaceProvider
+    super(lionWebVersion, name, container);
   }
 
   public Property(@Nullable String name, @Nullable Classifier container) {

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
@@ -24,6 +24,7 @@ public class Property extends Feature<Property> {
 
   public static Property createOptional(
       @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable DataType type) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     Property property = new Property(lionWebVersion, name, null);
     property.setOptional(true);
     property.setType(type);
@@ -39,6 +40,7 @@ public class Property extends Feature<Property> {
 
   public static Property createRequired(
       @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable DataType type) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     Property property = new Property(lionWebVersion, name, null);
     property.setOptional(false);
     property.setType(type);

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Reference.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Reference.java
@@ -144,7 +144,6 @@ public class Reference extends Link<Reference> {
   }
 
   public Reference(@Nullable String name, @Nullable Classifier container) {
-    // TODO verify that the container is also a NamespaceProvider
     super(name, container);
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Reference.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Reference.java
@@ -163,6 +163,6 @@ public class Reference extends Link<Reference> {
 
   @Override
   public Concept getClassifier() {
-    return LionCore.getReference();
+    return LionCore.getReference(getLionWebVersion());
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Reference.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Reference.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.self.LionCore;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -32,6 +33,19 @@ public class Reference extends Link<Reference> {
   }
 
   public static Reference createOptional(
+      @Nonnull LionWebVersion lionWebVersion,
+      @Nullable String name,
+      @Nullable Classifier type,
+      @Nonnull String id) {
+    Objects.requireNonNull(id, "id should not be null");
+    Reference reference = new Reference(lionWebVersion, name, id);
+    reference.setOptional(true);
+    reference.setMultiple(false);
+    reference.setType(type);
+    return reference;
+  }
+
+  public static Reference createOptional(
       @Nullable String name, @Nullable Classifier type, @Nonnull String id) {
     Objects.requireNonNull(id, "id should not be null");
     Reference reference = new Reference(name, id);
@@ -50,6 +64,19 @@ public class Reference extends Link<Reference> {
   }
 
   public static Reference createRequired(
+      @Nonnull LionWebVersion lionWebVersion,
+      @Nullable String name,
+      @Nullable Classifier type,
+      @Nonnull String id) {
+    Objects.requireNonNull(id, "id should not be null");
+    Reference reference = new Reference(lionWebVersion, name, id);
+    reference.setOptional(false);
+    reference.setMultiple(false);
+    reference.setType(type);
+    return reference;
+  }
+
+  public static Reference createRequired(
       @Nullable String name, @Nullable Classifier type, @Nonnull String id) {
     Objects.requireNonNull(id, "id should not be null");
     Reference reference = new Reference(name, id);
@@ -59,8 +86,30 @@ public class Reference extends Link<Reference> {
     return reference;
   }
 
+  public static Reference createMultiple(
+      @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable Classifier type) {
+    Reference reference = new Reference(lionWebVersion, name);
+    reference.setOptional(true);
+    reference.setMultiple(true);
+    reference.setType(type);
+    return reference;
+  }
+
   public static Reference createMultiple(@Nullable String name, @Nullable Classifier type) {
     Reference reference = new Reference(name);
+    reference.setOptional(true);
+    reference.setMultiple(true);
+    reference.setType(type);
+    return reference;
+  }
+
+  public static Reference createMultiple(
+      @Nonnull LionWebVersion lionWebVersion,
+      @Nullable String name,
+      @Nullable Classifier type,
+      @Nonnull String id) {
+    Objects.requireNonNull(id, "id should not be null");
+    Reference reference = new Reference(lionWebVersion, name, id);
     reference.setOptional(true);
     reference.setMultiple(true);
     reference.setType(type);
@@ -95,8 +144,17 @@ public class Reference extends Link<Reference> {
     super(name, container);
   }
 
+  public Reference(@Nonnull LionWebVersion lionWebVersion, @Nullable String name) {
+    super(lionWebVersion, name, (Classifier) null);
+  }
+
   public Reference(@Nullable String name) {
     super(name, (Classifier) null);
+  }
+
+  public Reference(
+      @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nonnull String id) {
+    super(lionWebVersion, name, id);
   }
 
   public Reference(@Nullable String name, @Nonnull String id) {

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Reference.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Reference.java
@@ -37,6 +37,7 @@ public class Reference extends Link<Reference> {
       @Nullable String name,
       @Nullable Classifier type,
       @Nonnull String id) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     Objects.requireNonNull(id, "id should not be null");
     Reference reference = new Reference(lionWebVersion, name, id);
     reference.setOptional(true);
@@ -68,6 +69,7 @@ public class Reference extends Link<Reference> {
       @Nullable String name,
       @Nullable Classifier type,
       @Nonnull String id) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     Objects.requireNonNull(id, "id should not be null");
     Reference reference = new Reference(lionWebVersion, name, id);
     reference.setOptional(false);
@@ -88,6 +90,7 @@ public class Reference extends Link<Reference> {
 
   public static Reference createMultiple(
       @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable Classifier type) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     Reference reference = new Reference(lionWebVersion, name);
     reference.setOptional(true);
     reference.setMultiple(true);
@@ -108,6 +111,7 @@ public class Reference extends Link<Reference> {
       @Nullable String name,
       @Nullable Classifier type,
       @Nonnull String id) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     Objects.requireNonNull(id, "id should not be null");
     Reference reference = new Reference(lionWebVersion, name, id);
     reference.setOptional(true);

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
  */
 public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstance<Concept>
     implements Node {
-  private @Nonnull LionWebVersion lionWebVersion;
+  private final @Nonnull LionWebVersion lionWebVersion;
   private @Nullable String id;
   private @Nullable Node parent;
 

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
@@ -15,10 +15,13 @@ import javax.annotation.Nullable;
 /**
  * Base class to help implements Node in the language package.
  *
- * <p>Other libraries could implement Node differently, for example based on reflection. However
+ * <p>Other libraries could implement Node differently, for example based on reflection. However,
  * this is outside the scope of this library. This library should provide a solid, basic dependency
  * to be used by other implementation and it should be as reusable, basic, and unopinionated as
  * possible.
+ *
+ * <p>Each M3Node is connected to a specific version of lionWebVersion, as these elements may behave
+ * differently depending on the version of LionWeb they are representing.
  */
 public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstance<Concept>
     implements Node {

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
@@ -289,4 +289,9 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
       referenceValues.put(linkName, new ArrayList(Arrays.asList(value)));
     }
   }
+
+  @Nonnull
+  public LionWebVersion getLionWebVersion() {
+    return lionWebVersion;
+  }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.model.impl;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Concept;
 import io.lionweb.lioncore.java.language.Containment;
 import io.lionweb.lioncore.java.language.Property;
@@ -21,6 +22,7 @@ import javax.annotation.Nullable;
  */
 public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstance<Concept>
     implements Node {
+  private @Nonnull LionWebVersion lionWebVersion;
   private String id;
   private Node parent;
 
@@ -31,6 +33,14 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
   private final Map<String, Object> propertyValues = new HashMap<>();
   private final Map<String, List<Node>> containmentValues = new HashMap<>();
   private final Map<String, List<ReferenceValue>> referenceValues = new HashMap<>();
+
+  protected M3Node() {
+    this.lionWebVersion = LionWebVersion.currentVersion;
+  }
+
+  protected M3Node(@Nonnull LionWebVersion lionWebVersion) {
+    this.lionWebVersion = lionWebVersion;
+  }
 
   public T setID(String id) {
     this.id = id;

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
@@ -23,8 +23,8 @@ import javax.annotation.Nullable;
 public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstance<Concept>
     implements Node {
   private @Nonnull LionWebVersion lionWebVersion;
-  private String id;
-  private Node parent;
+  private @Nullable String id;
+  private @Nullable Node parent;
 
   // We use as keys of these maps the name of the features and not the IDs.
   // The reason why we do that, is to avoid a circular dependency as the classes for defining
@@ -39,6 +39,7 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
   }
 
   protected M3Node(@Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     this.lionWebVersion = lionWebVersion;
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
@@ -139,6 +139,7 @@ public class LionCore {
   }
 
   public static Language getInstance(@Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     if (!INSTANCES.containsKey(lionWebVersion)) {
       final Language instance = new Language(lionWebVersion, "LionCore_M3");
       instance.setID("-id-LionCore-M3");

--- a/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
@@ -75,6 +75,66 @@ public class LionCore {
     return getInstance().requireConceptByName("Reference");
   }
 
+  public static Concept getAnnotation(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("Annotation");
+  }
+
+  public static Concept getConcept(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("Concept");
+  }
+
+  public static Concept getInterface(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("Interface");
+  }
+
+  public static Concept getContainment(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("Containment");
+  }
+
+  public static Concept getDataType(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("DataType");
+  }
+
+  public static Concept getEnumeration(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("Enumeration");
+  }
+
+  public static Concept getEnumerationLiteral(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("EnumerationLiteral");
+  }
+
+  public static Concept getFeature(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("Feature");
+  }
+
+  public static Concept getClassifier(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("Classifier");
+  }
+
+  public static Concept getLink(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("Link");
+  }
+
+  public static Concept getLanguage(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("Language");
+  }
+
+  public static Concept getLanguageEntity(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("LanguageEntity");
+  }
+
+  public static Concept getPrimitiveType(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("PrimitiveType");
+  }
+
+  public static Concept getProperty(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("Property");
+  }
+
+  public static Concept getReference(@Nonnull LionWebVersion lionWebVersion) {
+    return getInstance(lionWebVersion).requireConceptByName("Reference");
+  }
+
   public static Language getInstance() {
     return getInstance(LionWebVersion.currentVersion);
   }
@@ -84,36 +144,36 @@ public class LionCore {
       final Language instance = new Language(lionWebVersion, "LionCore_M3");
       instance.setID("-id-LionCore-M3");
       instance.setKey("LionCore-M3");
-      instance.setVersion(JsonSerialization.DEFAULT_SERIALIZATION_FORMAT);
+      instance.setVersion(lionWebVersion.getValue());
 
       // We first instantiate all Concepts and Interfaces
       // we add features only after as the features will have references to these elements
-      Concept annotation = instance.addElement(new Concept("Annotation"));
-      Concept concept = instance.addElement(new Concept("Concept"));
-      Concept iface = instance.addElement(new Concept("Interface"));
-      Concept containment = instance.addElement(new Concept("Containment"));
-      Concept dataType = instance.addElement(new Concept("DataType"));
-      Concept enumeration = instance.addElement(new Concept("Enumeration"));
-      Concept enumerationLiteral = instance.addElement(new Concept("EnumerationLiteral"));
-      Concept feature = instance.addElement(new Concept("Feature"));
-      Concept classifier = instance.addElement(new Concept("Classifier"));
-      Concept link = instance.addElement(new Concept("Link"));
-      Concept language = instance.addElement(new Concept("Language"));
-      Concept languageEntity = instance.addElement(new Concept("LanguageEntity"));
-      Interface iKeyed = instance.addElement(new Interface("IKeyed"));
-      Concept primitiveType = instance.addElement(new Concept("PrimitiveType"));
-      Concept property = instance.addElement(new Concept("Property"));
-      Concept reference = instance.addElement(new Concept("Reference"));
+      Concept annotation = instance.addElement(new Concept(lionWebVersion, "Annotation"));
+      Concept concept = instance.addElement(new Concept(lionWebVersion, "Concept"));
+      Concept iface = instance.addElement(new Concept(lionWebVersion, "Interface"));
+      Concept containment = instance.addElement(new Concept(lionWebVersion, "Containment"));
+      Concept dataType = instance.addElement(new Concept(lionWebVersion, "DataType"));
+      Concept enumeration = instance.addElement(new Concept(lionWebVersion, "Enumeration"));
+      Concept enumerationLiteral = instance.addElement(new Concept(lionWebVersion, "EnumerationLiteral"));
+      Concept feature = instance.addElement(new Concept(lionWebVersion, "Feature"));
+      Concept classifier = instance.addElement(new Concept(lionWebVersion, "Classifier"));
+      Concept link = instance.addElement(new Concept(lionWebVersion, "Link"));
+      Concept language = instance.addElement(new Concept(lionWebVersion, "Language"));
+      Concept languageEntity = instance.addElement(new Concept(lionWebVersion, "LanguageEntity"));
+      Interface iKeyed = instance.addElement(new Interface(lionWebVersion, "IKeyed"));
+      Concept primitiveType = instance.addElement(new Concept(lionWebVersion, "PrimitiveType"));
+      Concept property = instance.addElement(new Concept(lionWebVersion, "Property"));
+      Concept reference = instance.addElement(new Concept(lionWebVersion, "Reference"));
 
       // Now we start adding the features to all the Concepts and Interfaces
 
       concept.setExtendedConcept(classifier);
       concept.addFeature(
           Property.createRequired(
-              lionWebVersion, "abstract", LionCoreBuiltins.getBoolean(), "-id-Concept-abstract"));
+              lionWebVersion, "abstract", LionCoreBuiltins.getBoolean(lionWebVersion), "-id-Concept-abstract"));
       concept.addFeature(
           Property.createRequired(
-              lionWebVersion, "partition", LionCoreBuiltins.getBoolean(), "-id-Concept-partition"));
+              lionWebVersion, "partition", LionCoreBuiltins.getBoolean(lionWebVersion), "-id-Concept-partition"));
       concept.addFeature(
           Reference.createOptional(lionWebVersion, "extends", concept, "-id-Concept-extends"));
       concept.addFeature(
@@ -139,7 +199,7 @@ public class LionCore {
       feature.addImplementedInterface(iKeyed);
       feature.addFeature(
           Property.createRequired(
-              lionWebVersion, "optional", LionCoreBuiltins.getBoolean(), "-id-Feature-optional"));
+              lionWebVersion, "optional", LionCoreBuiltins.getBoolean(lionWebVersion), "-id-Feature-optional"));
 
       classifier.setAbstract(true);
       classifier.setExtendedConcept(languageEntity);
@@ -151,7 +211,7 @@ public class LionCore {
       link.setExtendedConcept(feature);
       link.addFeature(
           Property.createRequired(
-              lionWebVersion, "multiple", LionCoreBuiltins.getBoolean(), "-id-Link-multiple"));
+              lionWebVersion, "multiple", LionCoreBuiltins.getBoolean(lionWebVersion), "-id-Link-multiple"));
       link.addFeature(
           Reference.createRequired(lionWebVersion, "type", classifier, "-id-Link-type"));
 
@@ -159,7 +219,7 @@ public class LionCore {
       language.addImplementedInterface(iKeyed);
       language.addFeature(
           Property.createRequired(
-              lionWebVersion, "version", LionCoreBuiltins.getString(), "-id-Language-version"));
+              lionWebVersion, "version", LionCoreBuiltins.getString(lionWebVersion), "-id-Language-version"));
       language.addFeature(
           Reference.createMultiple(lionWebVersion, "dependsOn", language)
               .setID("-id-Language-dependsOn"));
@@ -180,9 +240,9 @@ public class LionCore {
 
       reference.setExtendedConcept(link);
 
-      iKeyed.addExtendedInterface(LionCoreBuiltins.getINamed());
+      iKeyed.addExtendedInterface(LionCoreBuiltins.getINamed(lionWebVersion));
       iKeyed.addFeature(
-          Property.createRequired(lionWebVersion, "key", LionCoreBuiltins.getString())
+          Property.createRequired(lionWebVersion, "key", LionCoreBuiltins.getString(lionWebVersion))
               .setID("-id-IKeyed-key"));
 
       annotation.setExtendedConcept(classifier);

--- a/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
@@ -20,116 +20,116 @@ public class LionCore {
     return getInstance().requireConceptByName("Annotation");
   }
 
-  public static @Nonnull Concept getConcept() {
-    return getInstance().requireConceptByName("Concept");
-  }
-
-  public static @Nonnull Concept getInterface() {
-    return getInstance().requireConceptByName("Interface");
-  }
-
-  public static @Nonnull Concept getContainment() {
-    return getInstance().requireConceptByName("Containment");
-  }
-
-  public static @Nonnull Concept getDataType() {
-    return getInstance().requireConceptByName("DataType");
-  }
-
-  public static @Nonnull Concept getEnumeration() {
-    return getInstance().requireConceptByName("Enumeration");
-  }
-
-  public static @Nonnull Concept getEnumerationLiteral() {
-    return getInstance().requireConceptByName("EnumerationLiteral");
-  }
-
-  public static @Nonnull Concept getFeature() {
-    return getInstance().requireConceptByName("Feature");
-  }
-
-  public static @Nonnull Concept getClassifier() {
-    return getInstance().requireConceptByName("Classifier");
-  }
-
-  public static @Nonnull Concept getLink() {
-    return getInstance().requireConceptByName("Link");
-  }
-
-  public static @Nonnull Concept getLanguage() {
-    return getInstance().requireConceptByName("Language");
-  }
-
-  public static @Nonnull Concept getLanguageEntity() {
-    return getInstance().requireConceptByName("LanguageEntity");
-  }
-
-  public static @Nonnull Concept getPrimitiveType() {
-    return getInstance().requireConceptByName("PrimitiveType");
-  }
-
-  public static @Nonnull Concept getProperty() {
-    return getInstance().requireConceptByName("Property");
-  }
-
-  public static @Nonnull Concept getReference() {
-    return getInstance().requireConceptByName("Reference");
-  }
-
   public static @Nonnull Concept getAnnotation(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Annotation");
+  }
+
+  public static @Nonnull Concept getConcept() {
+    return getInstance().requireConceptByName("Concept");
   }
 
   public static @Nonnull Concept getConcept(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Concept");
   }
 
+  public static @Nonnull Concept getInterface() {
+    return getInstance().requireConceptByName("Interface");
+  }
+
   public static @Nonnull Concept getInterface(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Interface");
+  }
+
+  public static @Nonnull Concept getContainment() {
+    return getInstance().requireConceptByName("Containment");
   }
 
   public static @Nonnull Concept getContainment(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Containment");
   }
 
+  public static @Nonnull Concept getDataType() {
+    return getInstance().requireConceptByName("DataType");
+  }
+
   public static @Nonnull Concept getDataType(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("DataType");
+  }
+
+  public static @Nonnull Concept getEnumeration() {
+    return getInstance().requireConceptByName("Enumeration");
   }
 
   public static @Nonnull Concept getEnumeration(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Enumeration");
   }
 
+  public static @Nonnull Concept getEnumerationLiteral() {
+    return getInstance().requireConceptByName("EnumerationLiteral");
+  }
+
   public static @Nonnull Concept getEnumerationLiteral(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("EnumerationLiteral");
+  }
+
+  public static @Nonnull Concept getFeature() {
+    return getInstance().requireConceptByName("Feature");
   }
 
   public static @Nonnull Concept getFeature(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Feature");
   }
 
+  public static @Nonnull Concept getClassifier() {
+    return getInstance().requireConceptByName("Classifier");
+  }
+
   public static @Nonnull Concept getClassifier(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Classifier");
+  }
+
+  public static @Nonnull Concept getLink() {
+    return getInstance().requireConceptByName("Link");
   }
 
   public static @Nonnull Concept getLink(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Link");
   }
 
+  public static @Nonnull Concept getLanguage() {
+    return getInstance().requireConceptByName("Language");
+  }
+
   public static @Nonnull Concept getLanguage(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Language");
+  }
+
+  public static @Nonnull Concept getLanguageEntity() {
+    return getInstance().requireConceptByName("LanguageEntity");
   }
 
   public static @Nonnull Concept getLanguageEntity(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("LanguageEntity");
   }
 
+  public static @Nonnull Concept getPrimitiveType() {
+    return getInstance().requireConceptByName("PrimitiveType");
+  }
+
   public static @Nonnull Concept getPrimitiveType(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("PrimitiveType");
   }
 
+  public static @Nonnull Concept getProperty() {
+    return getInstance().requireConceptByName("Property");
+  }
+
   public static @Nonnull Concept getProperty(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Property");
+  }
+
+  public static @Nonnull Concept getReference() {
+    return getInstance().requireConceptByName("Reference");
   }
 
   public static @Nonnull Concept getReference(@Nonnull LionWebVersion lionWebVersion) {
@@ -146,7 +146,7 @@ public class LionCore {
       final Language instance = new Language(lionWebVersion, "LionCore_M3");
       instance.setID("-id-LionCore-M3");
       instance.setKey("LionCore-M3");
-      instance.setVersion(lionWebVersion.getValue());
+      instance.setVersion(lionWebVersion.getVersionString());
 
       // We first instantiate all Concepts and Interfaces
       // we add features only after as the features will have references to these elements

--- a/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
@@ -3,7 +3,6 @@ package io.lionweb.lioncore.java.self;
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.impl.M3Node;
-import io.lionweb.lioncore.java.serialization.JsonSerialization;
 import java.util.*;
 import javax.annotation.Nonnull;
 
@@ -154,7 +153,8 @@ public class LionCore {
       Concept containment = instance.addElement(new Concept(lionWebVersion, "Containment"));
       Concept dataType = instance.addElement(new Concept(lionWebVersion, "DataType"));
       Concept enumeration = instance.addElement(new Concept(lionWebVersion, "Enumeration"));
-      Concept enumerationLiteral = instance.addElement(new Concept(lionWebVersion, "EnumerationLiteral"));
+      Concept enumerationLiteral =
+          instance.addElement(new Concept(lionWebVersion, "EnumerationLiteral"));
       Concept feature = instance.addElement(new Concept(lionWebVersion, "Feature"));
       Concept classifier = instance.addElement(new Concept(lionWebVersion, "Classifier"));
       Concept link = instance.addElement(new Concept(lionWebVersion, "Link"));
@@ -170,10 +170,16 @@ public class LionCore {
       concept.setExtendedConcept(classifier);
       concept.addFeature(
           Property.createRequired(
-              lionWebVersion, "abstract", LionCoreBuiltins.getBoolean(lionWebVersion), "-id-Concept-abstract"));
+              lionWebVersion,
+              "abstract",
+              LionCoreBuiltins.getBoolean(lionWebVersion),
+              "-id-Concept-abstract"));
       concept.addFeature(
           Property.createRequired(
-              lionWebVersion, "partition", LionCoreBuiltins.getBoolean(lionWebVersion), "-id-Concept-partition"));
+              lionWebVersion,
+              "partition",
+              LionCoreBuiltins.getBoolean(lionWebVersion),
+              "-id-Concept-partition"));
       concept.addFeature(
           Reference.createOptional(lionWebVersion, "extends", concept, "-id-Concept-extends"));
       concept.addFeature(
@@ -199,7 +205,10 @@ public class LionCore {
       feature.addImplementedInterface(iKeyed);
       feature.addFeature(
           Property.createRequired(
-              lionWebVersion, "optional", LionCoreBuiltins.getBoolean(lionWebVersion), "-id-Feature-optional"));
+              lionWebVersion,
+              "optional",
+              LionCoreBuiltins.getBoolean(lionWebVersion),
+              "-id-Feature-optional"));
 
       classifier.setAbstract(true);
       classifier.setExtendedConcept(languageEntity);
@@ -211,7 +220,10 @@ public class LionCore {
       link.setExtendedConcept(feature);
       link.addFeature(
           Property.createRequired(
-              lionWebVersion, "multiple", LionCoreBuiltins.getBoolean(lionWebVersion), "-id-Link-multiple"));
+              lionWebVersion,
+              "multiple",
+              LionCoreBuiltins.getBoolean(lionWebVersion),
+              "-id-Link-multiple"));
       link.addFeature(
           Reference.createRequired(lionWebVersion, "type", classifier, "-id-Link-type"));
 
@@ -219,7 +231,10 @@ public class LionCore {
       language.addImplementedInterface(iKeyed);
       language.addFeature(
           Property.createRequired(
-              lionWebVersion, "version", LionCoreBuiltins.getString(lionWebVersion), "-id-Language-version"));
+              lionWebVersion,
+              "version",
+              LionCoreBuiltins.getString(lionWebVersion),
+              "-id-Language-version"));
       language.addFeature(
           Reference.createMultiple(lionWebVersion, "dependsOn", language)
               .setID("-id-Language-dependsOn"));

--- a/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
@@ -12,133 +12,135 @@ public class LionCore {
     // prevent instantiation of instances outside of this class
   }
 
+  // We may have one instance of this class per LionWeb version, and we initialize
+  // them lazily
   private static Map<LionWebVersion, Language> INSTANCES = new HashMap<>();
 
-  public static Concept getAnnotation() {
+  public static @Nonnull Concept getAnnotation() {
     return getInstance().requireConceptByName("Annotation");
   }
 
-  public static Concept getConcept() {
+  public static @Nonnull Concept getConcept() {
     return getInstance().requireConceptByName("Concept");
   }
 
-  public static Concept getInterface() {
+  public static @Nonnull Concept getInterface() {
     return getInstance().requireConceptByName("Interface");
   }
 
-  public static Concept getContainment() {
+  public static @Nonnull Concept getContainment() {
     return getInstance().requireConceptByName("Containment");
   }
 
-  public static Concept getDataType() {
+  public static @Nonnull Concept getDataType() {
     return getInstance().requireConceptByName("DataType");
   }
 
-  public static Concept getEnumeration() {
+  public static @Nonnull Concept getEnumeration() {
     return getInstance().requireConceptByName("Enumeration");
   }
 
-  public static Concept getEnumerationLiteral() {
+  public static @Nonnull Concept getEnumerationLiteral() {
     return getInstance().requireConceptByName("EnumerationLiteral");
   }
 
-  public static Concept getFeature() {
+  public static @Nonnull Concept getFeature() {
     return getInstance().requireConceptByName("Feature");
   }
 
-  public static Concept getClassifier() {
+  public static @Nonnull Concept getClassifier() {
     return getInstance().requireConceptByName("Classifier");
   }
 
-  public static Concept getLink() {
+  public static @Nonnull Concept getLink() {
     return getInstance().requireConceptByName("Link");
   }
 
-  public static Concept getLanguage() {
+  public static @Nonnull Concept getLanguage() {
     return getInstance().requireConceptByName("Language");
   }
 
-  public static Concept getLanguageEntity() {
+  public static @Nonnull Concept getLanguageEntity() {
     return getInstance().requireConceptByName("LanguageEntity");
   }
 
-  public static Concept getPrimitiveType() {
+  public static @Nonnull Concept getPrimitiveType() {
     return getInstance().requireConceptByName("PrimitiveType");
   }
 
-  public static Concept getProperty() {
+  public static @Nonnull Concept getProperty() {
     return getInstance().requireConceptByName("Property");
   }
 
-  public static Concept getReference() {
+  public static @Nonnull Concept getReference() {
     return getInstance().requireConceptByName("Reference");
   }
 
-  public static Concept getAnnotation(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getAnnotation(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Annotation");
   }
 
-  public static Concept getConcept(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getConcept(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Concept");
   }
 
-  public static Concept getInterface(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getInterface(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Interface");
   }
 
-  public static Concept getContainment(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getContainment(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Containment");
   }
 
-  public static Concept getDataType(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getDataType(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("DataType");
   }
 
-  public static Concept getEnumeration(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getEnumeration(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Enumeration");
   }
 
-  public static Concept getEnumerationLiteral(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getEnumerationLiteral(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("EnumerationLiteral");
   }
 
-  public static Concept getFeature(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getFeature(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Feature");
   }
 
-  public static Concept getClassifier(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getClassifier(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Classifier");
   }
 
-  public static Concept getLink(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getLink(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Link");
   }
 
-  public static Concept getLanguage(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getLanguage(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Language");
   }
 
-  public static Concept getLanguageEntity(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getLanguageEntity(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("LanguageEntity");
   }
 
-  public static Concept getPrimitiveType(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getPrimitiveType(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("PrimitiveType");
   }
 
-  public static Concept getProperty(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getProperty(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Property");
   }
 
-  public static Concept getReference(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Concept getReference(@Nonnull LionWebVersion lionWebVersion) {
     return getInstance(lionWebVersion).requireConceptByName("Reference");
   }
 
-  public static Language getInstance() {
+  public static @Nonnull Language getInstance() {
     return getInstance(LionWebVersion.currentVersion);
   }
 
-  public static Language getInstance(@Nonnull LionWebVersion lionWebVersion) {
+  public static @Nonnull Language getInstance(@Nonnull LionWebVersion lionWebVersion) {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     if (!INSTANCES.containsKey(lionWebVersion)) {
       final Language instance = new Language(lionWebVersion, "LionCore_M3");
@@ -278,7 +280,7 @@ public class LionCore {
     return INSTANCES.get(lionWebVersion);
   }
 
-  private static void checkIDs(M3Node node) {
+  private static void checkIDs(@Nonnull M3Node node) {
     if (node.getID() == null) {
       if (node instanceof NamespacedEntity) {
         NamespacedEntity namespacedEntity = (NamespacedEntity) node;

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/AbstractSerialization.java
@@ -22,12 +22,6 @@ import javax.annotation.Nullable;
  * actual Nodes and the intermediate format (SerializedChunk). The step between the SerializedChunk
  * and the actual physical formats is done in other classes.
  */
-
-// PROBABLY IT IS BEST TO HAVE DIFFERENT SERIALIZATION INSTANCES FOR EACH
-// LIONWEB VERSION
-//
-// WE CAN THEN HAVE A SORT OF FACADE THAT WILL LOOK AT THE FORMAT AND USE ONE INSTANCE OR ANOTHER
-
 public abstract class AbstractSerialization {
 
   protected ClassifierResolver classifierResolver;
@@ -54,17 +48,18 @@ public abstract class AbstractSerialization {
   protected UnavailableNodePolicy unavailableReferenceTargetPolicy =
       UnavailableNodePolicy.THROW_ERROR;
 
-  private LionWebVersion lionWebVersion;
+  private @Nonnull LionWebVersion lionWebVersion;
 
   protected AbstractSerialization() {
     this(LionWebVersion.currentVersion);
   }
 
   protected AbstractSerialization(@Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     this.lionWebVersion = lionWebVersion;
     // prevent public access
     classifierResolver = new ClassifierResolver();
-    instantiator = new Instantiator(lionWebVersion);
+    instantiator = new Instantiator();
     primitiveValuesSerialization = new PrimitiveValuesSerialization();
     instanceResolver = new LocalClassifierInstanceResolver();
   }
@@ -442,6 +437,7 @@ public abstract class AbstractSerialization {
   private List<ClassifierInstance<?>> deserializeClassifierInstances(
       @Nonnull LionWebVersion lionWebVersion,
       List<SerializedClassifierInstance> serializedClassifierInstances) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     // We want to deserialize the nodes starting from the leaves. This is useful because in certain
     // cases we may want to use the children as constructor parameters of the parent
     DeserializationStatus deserializationStatus = sortLeavesFirst(serializedClassifierInstances);
@@ -530,6 +526,7 @@ public abstract class AbstractSerialization {
       @Nonnull LionWebVersion lionWebVersion,
       SerializedClassifierInstance serializedClassifierInstance,
       Map<String, ClassifierInstance<?>> deserializedByID) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     MetaPointer serializedClassifier = serializedClassifierInstance.getClassifier();
     if (serializedClassifier == null) {
       throw new RuntimeException("No metaPointer available for " + serializedClassifierInstance);

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/AbstractSerialization.java
@@ -29,8 +29,6 @@ import javax.annotation.Nullable;
 // WE CAN THEN HAVE A SORT OF FACADE THAT WILL LOOK AT THE FORMAT AND USE ONE INSTANCE OR ANOTHER
 
 public abstract class AbstractSerialization {
-  public static final String DEFAULT_SERIALIZATION_FORMAT =
-      LionWebVersion.currentVersion.getValue();
 
   protected ClassifierResolver classifierResolver;
   protected Instantiator instantiator;

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/AbstractSerialization.java
@@ -22,6 +22,12 @@ import javax.annotation.Nullable;
  * actual Nodes and the intermediate format (SerializedChunk). The step between the SerializedChunk
  * and the actual physical formats is done in other classes.
  */
+
+PROBABLY IT IS BEST TO HAVE DIFFERENT SERIALIZATION INSTANCES FOR EACH
+LIONWEB VERSION
+
+WE CAN THEN HAVE A SORT OF FACADE THAT WILL LOOK AT THE FORMAT AND USE ONE INSTANCE OR ANOTHER
+
 public abstract class AbstractSerialization {
   public static final String DEFAULT_SERIALIZATION_FORMAT =
       LionWebVersion.currentVersion.getValue();

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/AbstractSerialization.java
@@ -24,6 +24,11 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractSerialization {
 
+  /** You should use LionWebVersion.currentVersion.getVersionString() instead. */
+  @Deprecated
+  public static final String DEFAULT_SERIALIZATION_FORMAT =
+      LionWebVersion.currentVersion.getVersionString();
+
   protected ClassifierResolver classifierResolver;
   protected Instantiator instantiator;
   protected PrimitiveValuesSerialization primitiveValuesSerialization;
@@ -48,7 +53,7 @@ public abstract class AbstractSerialization {
   protected UnavailableNodePolicy unavailableReferenceTargetPolicy =
       UnavailableNodePolicy.THROW_ERROR;
 
-  private @Nonnull LionWebVersion lionWebVersion;
+  private final @Nonnull LionWebVersion lionWebVersion;
 
   protected AbstractSerialization() {
     this(LionWebVersion.currentVersion);
@@ -153,7 +158,7 @@ public abstract class AbstractSerialization {
   public SerializedChunk serializeNodesToSerializationBlock(
       Collection<ClassifierInstance<?>> classifierInstances) {
     SerializedChunk serializedChunk = new SerializedChunk();
-    serializedChunk.setSerializationFormatVersion(lionWebVersion.getValue());
+    serializedChunk.setSerializationFormatVersion(lionWebVersion.getVersionString());
     for (ClassifierInstance<?> classifierInstance : classifierInstances) {
       Objects.requireNonNull(classifierInstance, "nodes should not contain null values");
       serializedChunk.addClassifierInstance(serializeNode(classifierInstance));
@@ -337,10 +342,12 @@ public abstract class AbstractSerialization {
     if (serializationBlock.getSerializationFormatVersion() == null) {
       throw new IllegalArgumentException("The serializationFormatVersion should not be null");
     }
-    if (!serializationBlock.getSerializationFormatVersion().equals(lionWebVersion.getValue())) {
+    if (!serializationBlock
+        .getSerializationFormatVersion()
+        .equals(lionWebVersion.getVersionString())) {
       throw new IllegalArgumentException(
           "Only serializationFormatVersion supported by this instance of Serialization is '"
-              + lionWebVersion.getValue()
+              + lionWebVersion.getVersionString()
               + "' but we found '"
               + serializationBlock.getSerializationFormatVersion()
               + "'");

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/ClassifierResolver.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/ClassifierResolver.java
@@ -21,7 +21,7 @@ public class ClassifierResolver {
   private final Map<MetaPointer, Annotation> registeredAnnotations = new HashMap<>();
 
   @Nonnull
-  public Classifier<?> resolveClassifier(@Nonnull LionWebVersion lionWebVersion, @Nonnull MetaPointer conceptMetaPointer) {
+  public Classifier<?> resolveClassifier(@Nonnull MetaPointer conceptMetaPointer) {
     if (registeredConcepts.containsKey(conceptMetaPointer)) {
       return registeredConcepts.get(conceptMetaPointer);
     } else if (registeredAnnotations.containsKey(conceptMetaPointer)) {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/ClassifierResolver.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/ClassifierResolver.java
@@ -1,6 +1,5 @@
 package io.lionweb.lioncore.java.serialization;
 
-import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Annotation;
 import io.lionweb.lioncore.java.language.Classifier;
 import io.lionweb.lioncore.java.language.Concept;

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/ClassifierResolver.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/ClassifierResolver.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.serialization;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Annotation;
 import io.lionweb.lioncore.java.language.Classifier;
 import io.lionweb.lioncore.java.language.Concept;
@@ -20,7 +21,7 @@ public class ClassifierResolver {
   private final Map<MetaPointer, Annotation> registeredAnnotations = new HashMap<>();
 
   @Nonnull
-  public Classifier<?> resolveClassifier(@Nonnull MetaPointer conceptMetaPointer) {
+  public Classifier<?> resolveClassifier(@Nonnull LionWebVersion lionWebVersion, @Nonnull MetaPointer conceptMetaPointer) {
     if (registeredConcepts.containsKey(conceptMetaPointer)) {
       return registeredConcepts.get(conceptMetaPointer);
     } else if (registeredAnnotations.containsKey(conceptMetaPointer)) {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/Instantiator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/Instantiator.java
@@ -18,9 +18,6 @@ import javax.annotation.Nonnull;
  */
 public class Instantiator {
 
-  // TODO: not sure this is needed
-  private @Nonnull LionWebVersion lionWebVersion;
-
   public interface ClassifierSpecificInstantiator<T extends ClassifierInstance<?>> {
     T instantiate(
         Classifier<?> classifier,
@@ -38,13 +35,7 @@ public class Instantiator {
                 "Unable to instantiate instance with classifier " + classifier);
           };
 
-  public Instantiator() {
-    this.lionWebVersion = LionWebVersion.currentVersion;
-  }
-
-  public Instantiator(@Nonnull LionWebVersion lionWebVersion) {
-    this.lionWebVersion = lionWebVersion;
-  }
+  public Instantiator() {}
 
   public Instantiator enableDynamicNodes() {
     defaultNodeDeserializer =

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/Instantiator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/Instantiator.java
@@ -84,45 +84,45 @@ public class Instantiator {
     return this;
   }
 
-  public void registerLionCoreCustomDeserializers() {
+  public void registerLionCoreCustomDeserializers(@Nonnull LionWebVersion lionWebVersion) {
     customDeserializers.put(
-        LionCore.getLanguage().getID(),
+        LionCore.getLanguage(lionWebVersion).getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
             new Language(lionWebVersion).setID(serializedNode.getID()));
     customDeserializers.put(
-        LionCore.getConcept().getID(),
+        LionCore.getConcept(lionWebVersion).getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
             new Concept(lionWebVersion).setID(serializedNode.getID()));
     customDeserializers.put(
-        LionCore.getInterface().getID(),
+        LionCore.getInterface(lionWebVersion).getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
             new Interface(lionWebVersion).setID(serializedNode.getID()));
     customDeserializers.put(
-        LionCore.getProperty().getID(),
+        LionCore.getProperty(lionWebVersion).getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
             new Property(lionWebVersion, null, null, serializedNode.getID()));
     customDeserializers.put(
-        LionCore.getReference().getID(),
+        LionCore.getReference(lionWebVersion).getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
             new Reference(lionWebVersion, null, serializedNode.getID()));
     customDeserializers.put(
-        LionCore.getContainment().getID(),
+        LionCore.getContainment(lionWebVersion).getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
             new Containment(lionWebVersion, null, serializedNode.getID()));
     customDeserializers.put(
-        LionCore.getPrimitiveType().getID(),
+        LionCore.getPrimitiveType(lionWebVersion).getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
             new PrimitiveType(lionWebVersion, serializedNode.getID()));
     customDeserializers.put(
-        LionCore.getEnumeration().getID(),
+        LionCore.getEnumeration(lionWebVersion).getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
             new Enumeration(lionWebVersion).setID(serializedNode.getID()));
     customDeserializers.put(
-        LionCore.getEnumerationLiteral().getID(),
+        LionCore.getEnumerationLiteral(lionWebVersion).getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
             new EnumerationLiteral(lionWebVersion).setID(serializedNode.getID()));
     customDeserializers.put(
-        LionCore.getAnnotation().getID(),
+        LionCore.getAnnotation(lionWebVersion).getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
             new Annotation(lionWebVersion).setID(serializedNode.getID()));
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/Instantiator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/Instantiator.java
@@ -18,6 +18,7 @@ import javax.annotation.Nonnull;
  */
 public class Instantiator {
 
+  // TODO: not sure this is needed
   private @Nonnull LionWebVersion lionWebVersion;
 
   public interface ClassifierSpecificInstantiator<T extends ClassifierInstance<?>> {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/Instantiator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/Instantiator.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.serialization;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.model.Node;
@@ -9,12 +10,15 @@ import io.lionweb.lioncore.java.self.LionCore;
 import io.lionweb.lioncore.java.serialization.data.SerializedClassifierInstance;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 /**
  * This knows how to instantiate a Classifier Instance (either a Node or an Annotation Instance),
  * given the information provided by the deserialization mechanism.
  */
 public class Instantiator {
+
+  private @Nonnull LionWebVersion lionWebVersion;
 
   public interface ClassifierSpecificInstantiator<T extends ClassifierInstance<?>> {
     T instantiate(
@@ -32,6 +36,14 @@ public class Instantiator {
             throw new IllegalArgumentException(
                 "Unable to instantiate instance with classifier " + classifier);
           };
+
+  public Instantiator() {
+    this.lionWebVersion = LionWebVersion.currentVersion;
+  }
+
+  public Instantiator(@Nonnull LionWebVersion lionWebVersion) {
+    this.lionWebVersion = lionWebVersion;
+  }
 
   public Instantiator enableDynamicNodes() {
     defaultNodeDeserializer =
@@ -76,42 +88,42 @@ public class Instantiator {
     customDeserializers.put(
         LionCore.getLanguage().getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
-            new Language().setID(serializedNode.getID()));
+            new Language(lionWebVersion).setID(serializedNode.getID()));
     customDeserializers.put(
         LionCore.getConcept().getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
-            new Concept().setID(serializedNode.getID()));
+            new Concept(lionWebVersion).setID(serializedNode.getID()));
     customDeserializers.put(
         LionCore.getInterface().getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
-            new Interface().setID(serializedNode.getID()));
+            new Interface(lionWebVersion).setID(serializedNode.getID()));
     customDeserializers.put(
         LionCore.getProperty().getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
-            new Property(null, null, serializedNode.getID()));
+            new Property(lionWebVersion, null, null, serializedNode.getID()));
     customDeserializers.put(
         LionCore.getReference().getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
-            new Reference(null, serializedNode.getID()));
+            new Reference(lionWebVersion, null, serializedNode.getID()));
     customDeserializers.put(
         LionCore.getContainment().getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
-            new Containment(null, serializedNode.getID()));
+            new Containment(lionWebVersion, null, serializedNode.getID()));
     customDeserializers.put(
         LionCore.getPrimitiveType().getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
-            new PrimitiveType(serializedNode.getID()));
+            new PrimitiveType(lionWebVersion, serializedNode.getID()));
     customDeserializers.put(
         LionCore.getEnumeration().getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
-            new Enumeration().setID(serializedNode.getID()));
+            new Enumeration(lionWebVersion).setID(serializedNode.getID()));
     customDeserializers.put(
         LionCore.getEnumerationLiteral().getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
-            new EnumerationLiteral().setID(serializedNode.getID()));
+            new EnumerationLiteral(lionWebVersion).setID(serializedNode.getID()));
     customDeserializers.put(
         LionCore.getAnnotation().getID(),
         (concept, serializedNode, deserializedNodesByID, propertiesValues) ->
-            new Annotation().setID(serializedNode.getID()));
+            new Annotation(lionWebVersion).setID(serializedNode.getID()));
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -58,7 +58,7 @@ public class JsonSerialization extends AbstractSerialization {
    * an exception is thrown.
    */
   public Language loadLanguage(InputStream inputStream) {
-    JsonSerialization jsonSerialization = getStandardJsonSerialization();
+    JsonSerialization jsonSerialization = getStandardJsonSerialization(getLionWebVersion());
     List<Node> lNodes = jsonSerialization.deserializeToNodes(inputStream);
     List<Language> languages =
         lNodes.stream()

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -12,12 +12,11 @@ import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.impl.ProxyNode;
 import io.lionweb.lioncore.java.serialization.data.*;
 import io.lionweb.lioncore.java.utils.NetworkUtils;
-
-import javax.annotation.Nonnull;
 import java.io.*;
 import java.net.URL;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 /**
  * This class is responsible for deserializing models.

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -5,12 +5,15 @@ import static io.lionweb.lioncore.java.serialization.SerializationProvider.getSt
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.impl.ProxyNode;
 import io.lionweb.lioncore.java.serialization.data.*;
 import io.lionweb.lioncore.java.utils.NetworkUtils;
+
+import javax.annotation.Nonnull;
 import java.io.*;
 import java.net.URL;
 import java.util.*;
@@ -76,6 +79,15 @@ public class JsonSerialization extends AbstractSerialization {
   JsonSerialization() {
     // prevent public access
     super();
+  }
+
+  /**
+   * We want to protect this from access, as the default constructor would not add the lioncore and
+   * lioncore builtins support which most users may expect.
+   */
+  JsonSerialization(@Nonnull LionWebVersion lionWebVersion) {
+    // prevent public access
+    super(lionWebVersion);
   }
 
   //

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/PrimitiveValuesSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/PrimitiveValuesSerialization.java
@@ -71,6 +71,7 @@ public class PrimitiveValuesSerialization {
 
   public void registerLionBuiltinsPrimitiveSerializersAndDeserializers(
       @Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     primitiveDeserializers.put(
         LionCoreBuiltins.getBoolean(lionWebVersion).getID(),
         new PrimitiveDeserializer<Boolean>() {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/PrimitiveValuesSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/PrimitiveValuesSerialization.java
@@ -3,6 +3,7 @@ package io.lionweb.lioncore.java.serialization;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.language.Enumeration;
 import io.lionweb.lioncore.java.model.impl.EnumerationValue;
@@ -68,9 +69,9 @@ public class PrimitiveValuesSerialization {
     return this;
   }
 
-  public void registerLionBuiltinsPrimitiveSerializersAndDeserializers() {
+  public void registerLionBuiltinsPrimitiveSerializersAndDeserializers(@Nonnull LionWebVersion lionWebVersion) {
     primitiveDeserializers.put(
-        LionCoreBuiltins.getBoolean().getID(),
+        LionCoreBuiltins.getBoolean(lionWebVersion).getID(),
         new PrimitiveDeserializer<Boolean>() {
 
           @Override
@@ -86,18 +87,20 @@ public class PrimitiveValuesSerialization {
             return Boolean.parseBoolean(serializedValue);
           }
         });
-    primitiveDeserializers.put(LionCoreBuiltins.getString().getID(), s -> s);
+    primitiveDeserializers.put(LionCoreBuiltins.getString(lionWebVersion).getID(), s -> s);
+    if (lionWebVersion.equals(LionWebVersion.v2023_1)) {
+      primitiveDeserializers.put(
+              LionCoreBuiltins.getJSON(lionWebVersion).getID(),
+              (PrimitiveDeserializer<JsonElement>)
+                      serializedValue -> {
+                        if (serializedValue == null) {
+                          return null;
+                        }
+                        return JsonParser.parseString(serializedValue);
+                      });
+    }
     primitiveDeserializers.put(
-        LionCoreBuiltins.getJSON().getID(),
-        (PrimitiveDeserializer<JsonElement>)
-            serializedValue -> {
-              if (serializedValue == null) {
-                return null;
-              }
-              return JsonParser.parseString(serializedValue);
-            });
-    primitiveDeserializers.put(
-        LionCoreBuiltins.getInteger().getID(),
+        LionCoreBuiltins.getInteger(lionWebVersion).getID(),
         (PrimitiveDeserializer<Integer>)
             serializedValue -> {
               if (serializedValue == null) {
@@ -107,15 +110,17 @@ public class PrimitiveValuesSerialization {
             });
 
     primitiveSerializers.put(
-        LionCoreBuiltins.getBoolean().getID(),
+        LionCoreBuiltins.getBoolean(lionWebVersion).getID(),
         (PrimitiveSerializer<Boolean>) value -> Boolean.toString(value));
+    if (lionWebVersion.equals(LionWebVersion.v2023_1)) {
+      primitiveSerializers.put(
+              LionCoreBuiltins.getJSON(lionWebVersion).getID(),
+              (PrimitiveSerializer<JsonElement>) value -> new Gson().toJson(value));
+    }
     primitiveSerializers.put(
-        LionCoreBuiltins.getJSON().getID(),
-        (PrimitiveSerializer<JsonElement>) value -> new Gson().toJson(value));
+        LionCoreBuiltins.getString(lionWebVersion).getID(), (PrimitiveSerializer<String>) value -> value);
     primitiveSerializers.put(
-        LionCoreBuiltins.getString().getID(), (PrimitiveSerializer<String>) value -> value);
-    primitiveSerializers.put(
-        LionCoreBuiltins.getInteger().getID(),
+        LionCoreBuiltins.getInteger(lionWebVersion).getID(),
         (PrimitiveSerializer<Integer>) value -> value.toString());
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/PrimitiveValuesSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/PrimitiveValuesSerialization.java
@@ -69,7 +69,8 @@ public class PrimitiveValuesSerialization {
     return this;
   }
 
-  public void registerLionBuiltinsPrimitiveSerializersAndDeserializers(@Nonnull LionWebVersion lionWebVersion) {
+  public void registerLionBuiltinsPrimitiveSerializersAndDeserializers(
+      @Nonnull LionWebVersion lionWebVersion) {
     primitiveDeserializers.put(
         LionCoreBuiltins.getBoolean(lionWebVersion).getID(),
         new PrimitiveDeserializer<Boolean>() {
@@ -90,14 +91,14 @@ public class PrimitiveValuesSerialization {
     primitiveDeserializers.put(LionCoreBuiltins.getString(lionWebVersion).getID(), s -> s);
     if (lionWebVersion.equals(LionWebVersion.v2023_1)) {
       primitiveDeserializers.put(
-              LionCoreBuiltins.getJSON(lionWebVersion).getID(),
-              (PrimitiveDeserializer<JsonElement>)
-                      serializedValue -> {
-                        if (serializedValue == null) {
-                          return null;
-                        }
-                        return JsonParser.parseString(serializedValue);
-                      });
+          LionCoreBuiltins.getJSON(lionWebVersion).getID(),
+          (PrimitiveDeserializer<JsonElement>)
+              serializedValue -> {
+                if (serializedValue == null) {
+                  return null;
+                }
+                return JsonParser.parseString(serializedValue);
+              });
     }
     primitiveDeserializers.put(
         LionCoreBuiltins.getInteger(lionWebVersion).getID(),
@@ -114,17 +115,20 @@ public class PrimitiveValuesSerialization {
         (PrimitiveSerializer<Boolean>) value -> Boolean.toString(value));
     if (lionWebVersion.equals(LionWebVersion.v2023_1)) {
       primitiveSerializers.put(
-              LionCoreBuiltins.getJSON(lionWebVersion).getID(),
-              (PrimitiveSerializer<JsonElement>) value -> new Gson().toJson(value));
+          LionCoreBuiltins.getJSON(lionWebVersion).getID(),
+          (PrimitiveSerializer<JsonElement>) value -> new Gson().toJson(value));
     }
     primitiveSerializers.put(
-        LionCoreBuiltins.getString(lionWebVersion).getID(), (PrimitiveSerializer<String>) value -> value);
+        LionCoreBuiltins.getString(lionWebVersion).getID(),
+        (PrimitiveSerializer<String>) value -> value);
     primitiveSerializers.put(
         LionCoreBuiltins.getInteger(lionWebVersion).getID(),
         (PrimitiveSerializer<Integer>) value -> value.toString());
   }
 
-  public Object deserialize(DataType dataType, String serializedValue, boolean isRequired) {
+  public Object deserialize(
+      @Nonnull DataType dataType, String serializedValue, boolean isRequired) {
+    Objects.requireNonNull(dataType, "dataType should not be null");
     String dataTypeID = dataType.getID();
     if (primitiveDeserializers.containsKey(dataTypeID)) {
       return primitiveDeserializers.get(dataTypeID).deserialize(serializedValue, isRequired);

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationProvider.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationProvider.java
@@ -3,6 +3,7 @@ package io.lionweb.lioncore.java.serialization;
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.LionCoreBuiltins;
 import io.lionweb.lioncore.java.self.LionCore;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 
 public class SerializationProvider {
@@ -14,6 +15,7 @@ public class SerializationProvider {
 
   public static JsonSerialization getStandardJsonSerialization(
       @Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     JsonSerialization serialization = new JsonSerialization(lionWebVersion);
     standardInitialization(serialization);
     return serialization;
@@ -26,6 +28,7 @@ public class SerializationProvider {
 
   public static JsonSerialization getBasicJsonSerialization(
       @Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     return new JsonSerialization(lionWebVersion);
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationProvider.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationProvider.java
@@ -1,13 +1,20 @@
 package io.lionweb.lioncore.java.serialization;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.LionCoreBuiltins;
 import io.lionweb.lioncore.java.self.LionCore;
+
+import javax.annotation.Nonnull;
 
 public class SerializationProvider {
 
   /** This has specific support for LionCore or LionCoreBuiltins. */
   public static JsonSerialization getStandardJsonSerialization() {
-    JsonSerialization serialization = new JsonSerialization();
+    return getStandardJsonSerialization(LionWebVersion.currentVersion);
+  }
+
+  public static JsonSerialization getStandardJsonSerialization(@Nonnull LionWebVersion lionWebVersion) {
+    JsonSerialization serialization = new JsonSerialization(lionWebVersion);
     standardInitialization(serialization);
     return serialization;
   }
@@ -42,11 +49,11 @@ public class SerializationProvider {
   }
 
   protected static void standardInitialization(AbstractSerialization serialization) {
-    serialization.classifierResolver.registerLanguage(LionCore.getInstance());
-    serialization.instantiator.registerLionCoreCustomDeserializers();
+    serialization.classifierResolver.registerLanguage(LionCore.getInstance(serialization.getLionWebVersion()));
+    serialization.instantiator.registerLionCoreCustomDeserializers(serialization.getLionWebVersion());
     serialization.primitiveValuesSerialization
-        .registerLionBuiltinsPrimitiveSerializersAndDeserializers();
-    serialization.instanceResolver.addAll(LionCore.getInstance().thisAndAllDescendants());
-    serialization.instanceResolver.addAll(LionCoreBuiltins.getInstance().thisAndAllDescendants());
+        .registerLionBuiltinsPrimitiveSerializersAndDeserializers(serialization.getLionWebVersion());
+    serialization.instanceResolver.addAll(LionCore.getInstance(serialization.getLionWebVersion()).thisAndAllDescendants());
+    serialization.instanceResolver.addAll(LionCoreBuiltins.getInstance(serialization.getLionWebVersion()).thisAndAllDescendants());
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationProvider.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationProvider.java
@@ -3,7 +3,6 @@ package io.lionweb.lioncore.java.serialization;
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.LionCoreBuiltins;
 import io.lionweb.lioncore.java.self.LionCore;
-
 import javax.annotation.Nonnull;
 
 public class SerializationProvider {
@@ -13,7 +12,8 @@ public class SerializationProvider {
     return getStandardJsonSerialization(LionWebVersion.currentVersion);
   }
 
-  public static JsonSerialization getStandardJsonSerialization(@Nonnull LionWebVersion lionWebVersion) {
+  public static JsonSerialization getStandardJsonSerialization(
+      @Nonnull LionWebVersion lionWebVersion) {
     JsonSerialization serialization = new JsonSerialization(lionWebVersion);
     standardInitialization(serialization);
     return serialization;
@@ -22,6 +22,11 @@ public class SerializationProvider {
   /** This has no specific support for LionCore or LionCoreBuiltins. */
   public static JsonSerialization getBasicJsonSerialization() {
     return new JsonSerialization();
+  }
+
+  public static JsonSerialization getBasicJsonSerialization(
+      @Nonnull LionWebVersion lionWebVersion) {
+    return new JsonSerialization(lionWebVersion);
   }
 
   /** This has specific support for LionCore or LionCoreBuiltins. */
@@ -49,11 +54,16 @@ public class SerializationProvider {
   }
 
   protected static void standardInitialization(AbstractSerialization serialization) {
-    serialization.classifierResolver.registerLanguage(LionCore.getInstance(serialization.getLionWebVersion()));
-    serialization.instantiator.registerLionCoreCustomDeserializers(serialization.getLionWebVersion());
+    serialization.classifierResolver.registerLanguage(
+        LionCore.getInstance(serialization.getLionWebVersion()));
+    serialization.instantiator.registerLionCoreCustomDeserializers(
+        serialization.getLionWebVersion());
     serialization.primitiveValuesSerialization
-        .registerLionBuiltinsPrimitiveSerializersAndDeserializers(serialization.getLionWebVersion());
-    serialization.instanceResolver.addAll(LionCore.getInstance(serialization.getLionWebVersion()).thisAndAllDescendants());
-    serialization.instanceResolver.addAll(LionCoreBuiltins.getInstance(serialization.getLionWebVersion()).thisAndAllDescendants());
+        .registerLionBuiltinsPrimitiveSerializersAndDeserializers(
+            serialization.getLionWebVersion());
+    serialization.instanceResolver.addAll(
+        LionCore.getInstance(serialization.getLionWebVersion()).thisAndAllDescendants());
+    serialization.instanceResolver.addAll(
+        LionCoreBuiltins.getInstance(serialization.getLionWebVersion()).thisAndAllDescendants());
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializedJsonComparisonUtils.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializedJsonComparisonUtils.java
@@ -200,7 +200,7 @@ public class SerializedJsonComparisonUtils {
 
   private static void assertEquals(String message, Object expected, Object actual) {
     if (!Objects.equals(expected, actual)) {
-      throw new AssertionError(message + ": expected " + expected + " but found" + actual);
+      throw new AssertionError(message + ": expected " + expected + " but found " + actual);
     }
   }
 

--- a/core/src/test/java/io/lionweb/lioncore/java/language/LionCoreBuiltinsTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/language/LionCoreBuiltinsTest.java
@@ -20,17 +20,24 @@ public class LionCoreBuiltinsTest {
 
   @Test
   public void primitiveTypesHaveAgreedIDsv2023() {
-    assertEquals("LionCore-builtins-String", LionCoreBuiltins.getString(LionWebVersion.v2023_1).getID());
-    assertEquals("LionCore-builtins-Boolean", LionCoreBuiltins.getBoolean(LionWebVersion.v2023_1).getID());
-    assertEquals("LionCore-builtins-Integer", LionCoreBuiltins.getInteger(LionWebVersion.v2023_1).getID());
-    assertEquals("LionCore-builtins-JSON", LionCoreBuiltins.getJSON(LionWebVersion.v2023_1).getID());
+    assertEquals(
+        "LionCore-builtins-String", LionCoreBuiltins.getString(LionWebVersion.v2023_1).getID());
+    assertEquals(
+        "LionCore-builtins-Boolean", LionCoreBuiltins.getBoolean(LionWebVersion.v2023_1).getID());
+    assertEquals(
+        "LionCore-builtins-Integer", LionCoreBuiltins.getInteger(LionWebVersion.v2023_1).getID());
+    assertEquals(
+        "LionCore-builtins-JSON", LionCoreBuiltins.getJSON(LionWebVersion.v2023_1).getID());
   }
 
   @Test
   public void primitiveTypesHaveAgreedIDsv2024() {
-    assertEquals("LionCore-builtins-String", LionCoreBuiltins.getString(LionWebVersion.v2024_1).getID());
-    assertEquals("LionCore-builtins-Boolean", LionCoreBuiltins.getBoolean(LionWebVersion.v2024_1).getID());
-    assertEquals("LionCore-builtins-Integer", LionCoreBuiltins.getInteger(LionWebVersion.v2024_1).getID());
+    assertEquals(
+        "LionCore-builtins-String", LionCoreBuiltins.getString(LionWebVersion.v2024_1).getID());
+    assertEquals(
+        "LionCore-builtins-Boolean", LionCoreBuiltins.getBoolean(LionWebVersion.v2024_1).getID());
+    assertEquals(
+        "LionCore-builtins-Integer", LionCoreBuiltins.getInteger(LionWebVersion.v2024_1).getID());
     try {
       LionCoreBuiltins.getJSON(LionWebVersion.v2024_1);
       fail();

--- a/core/src/test/java/io/lionweb/lioncore/java/language/LionCoreBuiltinsTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/language/LionCoreBuiltinsTest.java
@@ -1,7 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.utils.LanguageValidator;
@@ -38,12 +37,8 @@ public class LionCoreBuiltinsTest {
         "LionCore-builtins-Boolean", LionCoreBuiltins.getBoolean(LionWebVersion.v2024_1).getID());
     assertEquals(
         "LionCore-builtins-Integer", LionCoreBuiltins.getInteger(LionWebVersion.v2024_1).getID());
-    try {
-      LionCoreBuiltins.getJSON(LionWebVersion.v2024_1);
-      fail();
-    } catch (IllegalArgumentException e) {
-      // expected
-    }
+    assertThrows(
+        IllegalArgumentException.class, () -> LionCoreBuiltins.getJSON(LionWebVersion.v2024_1));
   }
 
   @Test

--- a/core/src/test/java/io/lionweb/lioncore/java/language/LionCoreBuiltinsTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/language/LionCoreBuiltinsTest.java
@@ -1,7 +1,9 @@
 package io.lionweb.lioncore.java.language;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.utils.LanguageValidator;
 import io.lionweb.lioncore.java.utils.ValidationResult;
 import org.junit.Test;
@@ -17,11 +19,24 @@ public class LionCoreBuiltinsTest {
   }
 
   @Test
-  public void primitiveTypesHaveAgreedIDs() {
-    assertEquals("LionCore-builtins-String", LionCoreBuiltins.getString().getID());
-    assertEquals("LionCore-builtins-Boolean", LionCoreBuiltins.getBoolean().getID());
-    assertEquals("LionCore-builtins-Integer", LionCoreBuiltins.getInteger().getID());
-    assertEquals("LionCore-builtins-JSON", LionCoreBuiltins.getJSON().getID());
+  public void primitiveTypesHaveAgreedIDsv2023() {
+    assertEquals("LionCore-builtins-String", LionCoreBuiltins.getString(LionWebVersion.v2023_1).getID());
+    assertEquals("LionCore-builtins-Boolean", LionCoreBuiltins.getBoolean(LionWebVersion.v2023_1).getID());
+    assertEquals("LionCore-builtins-Integer", LionCoreBuiltins.getInteger(LionWebVersion.v2023_1).getID());
+    assertEquals("LionCore-builtins-JSON", LionCoreBuiltins.getJSON(LionWebVersion.v2023_1).getID());
+  }
+
+  @Test
+  public void primitiveTypesHaveAgreedIDsv2024() {
+    assertEquals("LionCore-builtins-String", LionCoreBuiltins.getString(LionWebVersion.v2024_1).getID());
+    assertEquals("LionCore-builtins-Boolean", LionCoreBuiltins.getBoolean(LionWebVersion.v2024_1).getID());
+    assertEquals("LionCore-builtins-Integer", LionCoreBuiltins.getInteger(LionWebVersion.v2024_1).getID());
+    try {
+      LionCoreBuiltins.getJSON(LionWebVersion.v2024_1);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
   }
 
   @Test

--- a/core/src/test/java/io/lionweb/lioncore/java/model/impl/DynamicNodeTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/model/impl/DynamicNodeTest.java
@@ -8,6 +8,7 @@ import io.lionweb.lioncore.java.model.AnnotationInstance;
 import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
 import io.lionweb.lioncore.java.model.ReferenceValue;
 import io.lionweb.lioncore.java.serialization.MyNodeWithProperties;
+import io.lionweb.lioncore.java.serialization.MyNodeWithProperties2023;
 import io.lionweb.lioncore.java.serialization.MyNodeWithReferences;
 import io.lionweb.lioncore.java.serialization.MyNodeWithSelfContainment;
 import java.util.Arrays;
@@ -32,12 +33,12 @@ public class DynamicNodeTest {
 
   @Test
   public void equalityPositiveCaseWithProperties() {
-    MyNodeWithProperties n1 = new MyNodeWithProperties("id1");
+    MyNodeWithProperties2023 n1 = new MyNodeWithProperties2023("id1");
     n1.setP1(true);
     n1.setP2(123);
     n1.setP3("foo");
     n1.setP4(new JsonArray());
-    MyNodeWithProperties n2 = new MyNodeWithProperties("id1");
+    MyNodeWithProperties2023 n2 = new MyNodeWithProperties2023("id1");
     n2.setP1(true);
     n2.setP2(123);
     n2.setP3("foo");
@@ -46,13 +47,13 @@ public class DynamicNodeTest {
   }
 
   @Test
-  public void equalityNegativrCaseWithProperties() {
-    MyNodeWithProperties n1 = new MyNodeWithProperties("id1");
+  public void equalityNegativeCaseWithProperties() {
+    MyNodeWithProperties2023 n1 = new MyNodeWithProperties2023("id1");
     n1.setP1(true);
     n1.setP2(123);
     n1.setP3("foo");
     n1.setP4(new JsonArray());
-    MyNodeWithProperties n2 = new MyNodeWithProperties("id1");
+    MyNodeWithProperties2023 n2 = new MyNodeWithProperties2023("id1");
     n2.setP1(true);
     n2.setP2(123);
     n2.setP3("bar");

--- a/core/src/test/java/io/lionweb/lioncore/java/self/CorrespondanceWithDocumentationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/self/CorrespondanceWithDocumentationTest.java
@@ -3,6 +3,7 @@ package io.lionweb.lioncore.java.self;
 import static io.lionweb.lioncore.java.serialization.SerializationProvider.getStandardJsonSerialization;
 import static org.junit.Assert.assertTrue;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Language;
 import io.lionweb.lioncore.java.language.LionCoreBuiltins;
 import io.lionweb.lioncore.java.model.Node;
@@ -20,7 +21,7 @@ public class CorrespondanceWithDocumentationTest {
 
   @Test
   public void lioncoreIsTheSameAsInTheOrganizationRepo() throws IOException {
-    JsonSerialization jsonSer = getStandardJsonSerialization();
+    JsonSerialization jsonSer = getStandardJsonSerialization(LionWebVersion.v2023_1);
 
     URL url =
         new URL(
@@ -31,7 +32,7 @@ public class CorrespondanceWithDocumentationTest {
 
     Language deserializedLioncore = (Language) nodes.get(0);
     ModelComparator.ComparisonResult comparison =
-        new ModelComparator().compare(deserializedLioncore, LionCore.getInstance());
+        new ModelComparator().compare(deserializedLioncore, LionCore.getInstance(LionWebVersion.v2023_1));
     System.out.println("Differences " + comparison.getDifferences().size());
     for (String difference : comparison.getDifferences()) {
       System.out.println(" - " + difference);
@@ -41,7 +42,7 @@ public class CorrespondanceWithDocumentationTest {
 
   @Test
   public void builtInIsTheSameAsInTheOrganizationRepo() throws IOException {
-    JsonSerialization jsonSer = getStandardJsonSerialization();
+    JsonSerialization jsonSer = getStandardJsonSerialization(LionWebVersion.v2023_1);
 
     URL url =
         new URL(

--- a/core/src/test/java/io/lionweb/lioncore/java/self/CorrespondanceWithDocumentationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/self/CorrespondanceWithDocumentationTest.java
@@ -32,7 +32,8 @@ public class CorrespondanceWithDocumentationTest {
 
     Language deserializedLioncore = (Language) nodes.get(0);
     ModelComparator.ComparisonResult comparison =
-        new ModelComparator().compare(deserializedLioncore, LionCore.getInstance(LionWebVersion.v2023_1));
+        new ModelComparator()
+            .compare(deserializedLioncore, LionCore.getInstance(LionWebVersion.v2023_1));
     System.out.println("Differences " + comparison.getDifferences().size());
     for (String difference : comparison.getDifferences()) {
       System.out.println(" - " + difference);
@@ -41,7 +42,7 @@ public class CorrespondanceWithDocumentationTest {
   }
 
   @Test
-  public void builtInIsTheSameAsInTheOrganizationRepo() throws IOException {
+  public void builtInIsTheSameAsInTheOrganizationRepo2023_1() throws IOException {
     JsonSerialization jsonSer = getStandardJsonSerialization(LionWebVersion.v2023_1);
 
     URL url =
@@ -53,7 +54,8 @@ public class CorrespondanceWithDocumentationTest {
 
     Language deserializedBuiltins = (Language) nodes.get(0);
     ModelComparator.ComparisonResult comparison =
-        new ModelComparator().compare(deserializedBuiltins, LionCoreBuiltins.getInstance());
+        new ModelComparator()
+            .compare(deserializedBuiltins, LionCoreBuiltins.getInstance(LionWebVersion.v2023_1));
     System.out.println("Differences " + comparison.getDifferences().size());
     for (String difference : comparison.getDifferences()) {
       System.out.println(" - " + difference);

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/FlatbuffersSerializationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/FlatbuffersSerializationTest.java
@@ -228,7 +228,7 @@ public class FlatbuffersSerializationTest extends SerializationTest {
     assertEquals(1, serializedClassifierInstance.getProperties().size());
     SerializedPropertyValue serializedName = serializedClassifierInstance.getProperties().get(0);
     assertEquals(
-        new MetaPointer("LionCore-builtins", "2023.1", "LionCore-builtins-INamed-name"),
+        new MetaPointer("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
         serializedName.getMetaPointer());
   }
 

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/JsonSerializationTest.java
@@ -4,6 +4,7 @@ import static io.lionweb.lioncore.java.serialization.SerializedJsonComparisonUti
 import static org.junit.Assert.*;
 
 import com.google.gson.*;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.api.UnresolvedClassifierInstanceException;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.*;
@@ -42,7 +43,8 @@ public class JsonSerializationTest extends SerializationTest {
     // The library MM is not using the standard primitive types but its own, so we need to specify
     // how to serialize
     // those values
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     jsonSerialization
         .getPrimitiveValuesSerialization()
         .registerSerializer(
@@ -74,7 +76,8 @@ public class JsonSerializationTest extends SerializationTest {
     // The library MM is not using the standard primitive types but its own, so we need to specify
     // how to serialize
     // those values
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     jsonSerialization
         .getPrimitiveValuesSerialization()
         .registerSerializer(
@@ -105,7 +108,8 @@ public class JsonSerializationTest extends SerializationTest {
     // The library MM is not using the standard primitive types but its own, so we need to specify
     // how to serialize
     // those values
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     jsonSerialization
         .getPrimitiveValuesSerialization()
         .registerSerializer(
@@ -132,7 +136,8 @@ public class JsonSerializationTest extends SerializationTest {
     InputStream inputStream =
         this.getClass().getResourceAsStream("/serialization/TestLang-language.json");
     JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     List<Node> deserializedNodes = jsonSerialization.deserializeToNodes(jsonElement);
 
     Enumeration testEnumeration1 =
@@ -164,7 +169,8 @@ public class JsonSerializationTest extends SerializationTest {
 
   @Test
   public void deserializeLanguageWithDependencies() {
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     Language starlasu =
         (Language)
             jsonSerialization
@@ -354,7 +360,8 @@ public class JsonSerializationTest extends SerializationTest {
 
   @Test(expected = DeserializationException.class)
   public void deserializeTreeWithoutRoot() {
-    JsonSerialization js = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization js =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     List<Node> nodes =
         js.deserializeToNodes(
             this.getClass().getResourceAsStream("/mpsMeetup-issue10/example1.json"));
@@ -384,7 +391,7 @@ public class JsonSerializationTest extends SerializationTest {
     assertEquals(
         JsonParser.parseString(
             "{\n"
-                + "    \"serializationFormatVersion\": \"2023.1\",\n"
+                + "    \"serializationFormatVersion\": \"2024.1\",\n"
                 + "    \"languages\": [{\n"
                 + "        \"version\": \"1\",\n"
                 + "        \"key\": \"mm_key\"\n"
@@ -462,7 +469,7 @@ public class JsonSerializationTest extends SerializationTest {
     assertEquals(
         JsonParser.parseString(
             "{\n"
-                + "    \"serializationFormatVersion\": \"2023.1\",\n"
+                + "    \"serializationFormatVersion\": \"2024.1\",\n"
                 + "    \"languages\": [{\n"
                 + "        \"version\": \"1\",\n"
                 + "        \"key\": \"mm_key\"\n"
@@ -515,7 +522,7 @@ public class JsonSerializationTest extends SerializationTest {
     JsonElement je =
         JsonParser.parseString(
             "{\n"
-                + "    \"serializationFormatVersion\": \"2023.1\",\n"
+                + "    \"serializationFormatVersion\": \"2024.1\",\n"
                 + "    \"languages\": [{\n"
                 + "        \"version\": \"1\",\n"
                 + "        \"key\": \"mm_key\"\n"
@@ -589,7 +596,7 @@ public class JsonSerializationTest extends SerializationTest {
     JsonElement je =
         JsonParser.parseString(
             "{\n"
-                + "    \"serializationFormatVersion\": \"2023.1\",\n"
+                + "    \"serializationFormatVersion\": \"2024.1\",\n"
                 + "    \"languages\": [{\n"
                 + "        \"version\": \"1\",\n"
                 + "        \"key\": \"mm_key\"\n"
@@ -677,7 +684,7 @@ public class JsonSerializationTest extends SerializationTest {
     assertEquals(1, serializedClassifierInstance.getProperties().size());
     SerializedPropertyValue serializedName = serializedClassifierInstance.getProperties().get(0);
     assertEquals(
-        new MetaPointer("LionCore-builtins", "2023.1", "LionCore-builtins-INamed-name"),
+        new MetaPointer("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
         serializedName.getMetaPointer());
   }
 
@@ -785,7 +792,8 @@ public class JsonSerializationTest extends SerializationTest {
 
   @Test(expected = DeserializationException.class)
   public void deserializePartialTreeFailsByDefault() {
-    JsonSerialization js = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization js =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     InputStream languageIs =
         this.getClass().getResourceAsStream("/serialization/propertiesLanguage.json");
     Language propertiesLanguage = (Language) js.deserializeToNodes(languageIs).get(0);
@@ -798,7 +806,8 @@ public class JsonSerializationTest extends SerializationTest {
 
   @Test
   public void deserializePartialTreeSucceedsWithNullReferencesUnavailableNodePolicy() {
-    JsonSerialization js = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization js =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     InputStream languageIs =
         this.getClass().getResourceAsStream("/serialization/propertiesLanguage.json");
     Language propertiesLanguage = (Language) js.deserializeToNodes(languageIs).get(0);
@@ -813,7 +822,8 @@ public class JsonSerializationTest extends SerializationTest {
 
   @Test
   public void deserializePartialTreeSucceedsWithProxyNodesUnavailableNodePolicy() {
-    JsonSerialization js = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization js =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     InputStream languageIs =
         this.getClass().getResourceAsStream("/serialization/propertiesLanguage.json");
     Language propertiesLanguage = (Language) js.deserializeToNodes(languageIs).get(0);
@@ -837,7 +847,8 @@ public class JsonSerializationTest extends SerializationTest {
 
   @Test(expected = DeserializationException.class)
   public void deserializeTreeWithExternalReferencesWithThrowErrorsUnavailableNodePolicy() {
-    JsonSerialization js = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization js =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     InputStream languageIs =
         this.getClass().getResourceAsStream("/serialization/todosLanguage.json");
     Language todosLanguage = (Language) js.deserializeToNodes(languageIs).get(0);
@@ -853,7 +864,8 @@ public class JsonSerializationTest extends SerializationTest {
 
   @Test
   public void deserializeTreeWithExternalReferencesWithProxyNodesUnavailableNodePolicy() {
-    JsonSerialization js = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization js =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     InputStream languageIs =
         this.getClass().getResourceAsStream("/serialization/todosLanguage.json");
     Language todosLanguage = (Language) js.deserializeToNodes(languageIs).get(0);
@@ -905,7 +917,8 @@ public class JsonSerializationTest extends SerializationTest {
 
   @Test
   public void deserializeTreeWithExternalReferencesSetToNullPolicyUnavailableNodePolicy() {
-    JsonSerialization js = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization js =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     InputStream languageIs =
         this.getClass().getResourceAsStream("/serialization/todosLanguage.json");
     Language todosLanguage = (Language) js.deserializeToNodes(languageIs).get(0);
@@ -951,7 +964,8 @@ public class JsonSerializationTest extends SerializationTest {
 
   @Test
   public void deserializeTreesWithChildrenNotProvided() {
-    JsonSerialization js = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization js =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     InputStream languageIs =
         this.getClass().getResourceAsStream("/serialization/todosLanguage.json");
     Language todosLanguage = (Language) js.deserializeToNodes(languageIs).get(0);
@@ -998,7 +1012,8 @@ public class JsonSerializationTest extends SerializationTest {
 
   @Test
   public void deserializeMultipleReferencesToProxiedNode() {
-    JsonSerialization js = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization js =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     InputStream languageIs =
         this.getClass().getResourceAsStream("/serialization/todosLanguage.json");
     Language todosLanguage = (Language) js.deserializeToNodes(languageIs).get(0);

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/LibraryLanguage.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/LibraryLanguage.java
@@ -2,6 +2,7 @@ package io.lionweb.lioncore.java.serialization;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Concept;
 import io.lionweb.lioncore.java.language.Language;
 import io.lionweb.lioncore.java.model.Node;
@@ -23,7 +24,8 @@ public class LibraryLanguage {
     InputStream inputStream =
         LibraryLanguage.class.getResourceAsStream("/serialization/library-language.json");
     JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     List<Node> deserializedNodes = jsonSerialization.deserializeToNodes(jsonElement);
     LIBRARY_MM =
         deserializedNodes.stream()

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/LowLevelJsonSerializationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/LowLevelJsonSerializationTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNull;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Annotation;
 import io.lionweb.lioncore.java.language.Concept;
 import io.lionweb.lioncore.java.language.Language;
@@ -41,7 +42,8 @@ public class LowLevelJsonSerializationTest extends SerializationTest {
     assertEquals(
         "LionCore_M3",
         lioncore.getPropertyValue(
-            MetaPointer.from(LionCoreBuiltins.getINamed().getPropertyByName("name"))));
+            MetaPointer.from(
+                LionCoreBuiltins.getINamed(LionWebVersion.v2023_1).getPropertyByName("name"))));
     assertEquals(16, lioncore.getChildren().size());
     assertNull(lioncore.getParentNodeID());
   }
@@ -66,11 +68,13 @@ public class LowLevelJsonSerializationTest extends SerializationTest {
     assertEquals(
         Arrays.asList(new SerializedReferenceValue.Entry("library-Writer", "Writer")),
         guidedBookWriter.getReferenceValues(
-            MetaPointer.from(LionCore.getConcept().getReferenceByName("extends"))));
+            MetaPointer.from(
+                LionCore.getConcept(LionWebVersion.v2023_1).getReferenceByName("extends"))));
     assertEquals(
         Arrays.asList("library-GuideBookWriter-countries"),
         guidedBookWriter.getContainmentValues(
-            MetaPointer.from(LionCore.getConcept().getContainmentByName("features"))));
+            MetaPointer.from(
+                LionCore.getConcept(LionWebVersion.v2023_1).getContainmentByName("features"))));
   }
 
   @Test

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/MyNodeWithProperties2023.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/MyNodeWithProperties2023.java
@@ -1,6 +1,7 @@
 package io.lionweb.lioncore.java.serialization;
 
 import com.google.gson.JsonElement;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Concept;
 import io.lionweb.lioncore.java.language.Language;
 import io.lionweb.lioncore.java.language.LionCoreBuiltins;
@@ -8,27 +9,53 @@ import io.lionweb.lioncore.java.language.Property;
 import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
 import io.lionweb.lioncore.java.model.impl.DynamicNode;
 
-public class MyNodeWithProperties extends DynamicNode {
+public class MyNodeWithProperties2023 extends DynamicNode {
   public static final Language LANGUAGE =
-      new Language().setID("mm1").setKey("mylanguage").setName("MM1").setVersion("1");
+      new Language(LionWebVersion.v2023_1)
+          .setID("mm1")
+          .setKey("mylanguage")
+          .setName("MM1")
+          .setVersion("1");
   public static final Concept CONCEPT =
-      new Concept()
+      new Concept(LionWebVersion.v2023_1)
           .setID("concept-MyNodeWithProperties")
           .setKey("concept-MyNodeWithProperties")
           .setName("MyNodeWithProperties")
           .addFeature(
-              Property.createOptional("p1", LionCoreBuiltins.getBoolean()).setID("p1").setKey("p1"))
+              Property.createOptional(
+                      LionWebVersion.v2023_1,
+                      "p1",
+                      LionCoreBuiltins.getBoolean(LionWebVersion.v2023_1))
+                  .setID("p1")
+                  .setKey("p1"))
           .addFeature(
-              Property.createOptional("p2", LionCoreBuiltins.getInteger()).setID("p2").setKey("p2"))
+              Property.createOptional(
+                      LionWebVersion.v2023_1,
+                      "p2",
+                      LionCoreBuiltins.getInteger(LionWebVersion.v2023_1))
+                  .setID("p2")
+                  .setKey("p2"))
           .addFeature(
-              Property.createOptional("p3", LionCoreBuiltins.getString()).setID("p3").setKey("p3"))
+              Property.createOptional(
+                      LionWebVersion.v2023_1,
+                      "p3",
+                      LionCoreBuiltins.getString(LionWebVersion.v2023_1))
+                  .setID("p3")
+                  .setKey("p3"))
+          .addFeature(
+              Property.createOptional(
+                      LionWebVersion.v2023_1,
+                      "p4",
+                      LionCoreBuiltins.getJSON(LionWebVersion.v2023_1))
+                  .setID("p4")
+                  .setKey("p4"))
           .setParent(LANGUAGE);
 
   static {
     LANGUAGE.addElement(CONCEPT);
   }
 
-  public MyNodeWithProperties(String id) {
+  public MyNodeWithProperties2023(String id) {
     super(id, CONCEPT);
   }
 

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/ProtobufSerializationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/ProtobufSerializationTest.java
@@ -222,7 +222,7 @@ public class ProtobufSerializationTest extends SerializationTest {
     assertEquals(1, serializedClassifierInstance.getProperties().size());
     SerializedPropertyValue serializedName = serializedClassifierInstance.getProperties().get(0);
     assertEquals(
-        new MetaPointer("LionCore-builtins", "2023.1", "LionCore-builtins-INamed-name"),
+        new MetaPointer("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
         serializedName.getMetaPointer());
   }
 

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLibraryTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLibraryTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Concept;
 import io.lionweb.lioncore.java.language.Property;
 import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
@@ -23,7 +24,8 @@ public class SerializationOfLibraryTest extends SerializationTest {
     InputStream inputStream =
         this.getClass().getResourceAsStream("/serialization/library-language.json");
     JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     List<Node> deserializedNodes = jsonSerialization.deserializeToNodes(jsonElement);
 
     Concept library = conceptByID(deserializedNodes, "library-Library");
@@ -52,7 +54,8 @@ public class SerializationOfLibraryTest extends SerializationTest {
     InputStream inputStream =
         this.getClass().getResourceAsStream("/serialization/library-language.json");
     JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     List<Node> deserializedNodes = jsonSerialization.deserializeToNodes(jsonElement);
     JsonElement reserialized =
         jsonSerialization.serializeTreeToJsonElement(deserializedNodes.get(0));
@@ -73,7 +76,8 @@ public class SerializationOfLibraryTest extends SerializationTest {
     // The library MM is not using the standard primitive types but its own, so we need to specify
     // how to serialize
     // those values
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     jsonSerialization
         .getPrimitiveValuesSerialization()
         .registerSerializer(
@@ -97,7 +101,8 @@ public class SerializationOfLibraryTest extends SerializationTest {
   public void deserializeLanguageWithDuplicateIDs() {
     InputStream inputStream =
         this.getClass().getResourceAsStream("/serialization/library-language-with-duplicate.json");
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     jsonSerialization.deserializeToNodes(inputStream);
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Language;
 import io.lionweb.lioncore.java.language.LionCoreBuiltins;
 import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
@@ -145,7 +146,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     jsonSerialization.getInstantiator().enableDynamicNodes();
     jsonSerialization
         .getPrimitiveValuesSerialization()
-        .registerLionBuiltinsPrimitiveSerializersAndDeserializers();
+        .registerLionBuiltinsPrimitiveSerializersAndDeserializers(LionWebVersion.currentVersion);
     List<Node> deserializedNodes = jsonSerialization.deserializeToNodes(jsonElement);
 
     DynamicNode lioncore = (DynamicNode) deserializedNodes.get(0);
@@ -164,7 +165,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     jsonSerialization.getClassifierResolver().registerLanguage(LionCore.getInstance());
     jsonSerialization
         .getPrimitiveValuesSerialization()
-        .registerLionBuiltinsPrimitiveSerializersAndDeserializers();
+        .registerLionBuiltinsPrimitiveSerializersAndDeserializers(LionWebVersion.currentVersion);
     jsonSerialization.deserializeToNodes(jsonElement);
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
@@ -31,11 +31,11 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     SerializedChunk serializedChunk =
         jsonSerialization.serializeTreeToSerializationBlock(LionCore.getInstance());
 
-    assertEquals("2023.1", serializedChunk.getSerializationFormatVersion());
+    assertEquals("2024.1", serializedChunk.getSerializationFormatVersion());
 
     assertEquals(2, serializedChunk.getLanguages().size());
     Assert.assertEquals(
-        new UsedLanguage("LionCore-M3", "2023.1"),
+        new UsedLanguage("LionCore-M3", "2024.1"),
         serializedChunk.getLanguages().iterator().next());
 
     SerializedClassifierInstance LionCore_M3 =
@@ -44,21 +44,21 @@ public class SerializationOfLionCoreTest extends SerializationTest {
             .findFirst()
             .get();
     assertEquals("-id-LionCore-M3", LionCore_M3.getID());
-    assertEquals(new MetaPointer("LionCore-M3", "2023.1", "Language"), LionCore_M3.getClassifier());
+    assertEquals(new MetaPointer("LionCore-M3", "2024.1", "Language"), LionCore_M3.getClassifier());
     assertEquals(
         Arrays.asList(
             new SerializedPropertyValue(
-                new MetaPointer("LionCore-M3", "2023.1", "Language-version"), "2023.1"),
+                new MetaPointer("LionCore-M3", "2024.1", "Language-version"), "2024.1"),
             new SerializedPropertyValue(
-                new MetaPointer("LionCore-M3", "2023.1", "IKeyed-key"), "LionCore-M3"),
+                new MetaPointer("LionCore-M3", "2024.1", "IKeyed-key"), "LionCore-M3"),
             new SerializedPropertyValue(
-                new MetaPointer("LionCore-builtins", "2023.1", "LionCore-builtins-INamed-name"),
+                new MetaPointer("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
                 "LionCore_M3")),
         LionCore_M3.getProperties());
     assertEquals(
         Arrays.asList(
             new SerializedContainmentValue(
-                new MetaPointer("LionCore-M3", "2023.1", "Language-entities"),
+                new MetaPointer("LionCore-M3", "2024.1", "Language-entities"),
                 Arrays.asList(
                     "-id-Annotation",
                     "-id-Concept",
@@ -80,7 +80,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     assertEquals(
         Arrays.asList(
             new SerializedReferenceValue(
-                new MetaPointer("LionCore-M3", "2023.1", "Language-dependsOn"),
+                new MetaPointer("LionCore-M3", "2024.1", "Language-dependsOn"),
                 Collections.emptyList())),
         LionCore_M3.getReferences());
 
@@ -95,8 +95,10 @@ public class SerializationOfLionCoreTest extends SerializationTest {
   public void serializeLionCoreToJSON() {
     InputStream inputStream = this.getClass().getResourceAsStream("/serialization/lioncore.json");
     JsonElement serializedElement = JsonParser.parseReader(new InputStreamReader(inputStream));
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
-    JsonElement reserialized = jsonSerialization.serializeTreeToJsonElement(LionCore.getInstance());
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
+    JsonElement reserialized =
+        jsonSerialization.serializeTreeToJsonElement(LionCore.getInstance(LionWebVersion.v2023_1));
     assertEquivalentLionWebJson(
         serializedElement.getAsJsonObject(), reserialized.getAsJsonObject());
   }
@@ -111,7 +113,8 @@ public class SerializationOfLionCoreTest extends SerializationTest {
         serializedChunk.getClassifierInstances();
 
     SerializedClassifierInstance lioncore = serializedChunk.getInstanceByID("-id-LionCore-M3");
-    assertEquals(MetaPointer.from(LionCore.getLanguage()), lioncore.getClassifier());
+    assertEquals(
+        MetaPointer.from(LionCore.getLanguage(LionWebVersion.v2023_1)), lioncore.getClassifier());
     assertEquals("-id-LionCore-M3", lioncore.getID());
     assertEquals("LionCore_M3", lioncore.getPropertyValue("LionCore-builtins-INamed-name"));
     assertEquals(16, lioncore.getChildren().size());
@@ -122,11 +125,12 @@ public class SerializationOfLionCoreTest extends SerializationTest {
   public void deserializeLionCoreToConcreteClasses() {
     InputStream inputStream = this.getClass().getResourceAsStream("/serialization/lioncore.json");
     JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     List<Node> deserializedNodes = jsonSerialization.deserializeToNodes(jsonElement);
 
     Language lioncore = (Language) deserializedNodes.get(0);
-    assertEquals(LionCore.getLanguage(), lioncore.getClassifier());
+    assertEquals(LionCore.getLanguage(LionWebVersion.v2023_1), lioncore.getClassifier());
     assertEquals("-id-LionCore-M3", lioncore.getID());
     assertEquals("LionCore_M3", lioncore.getName());
     assertEquals(16, ClassifierInstanceUtils.getChildren(lioncore).size());
@@ -137,20 +141,23 @@ public class SerializationOfLionCoreTest extends SerializationTest {
   public void deserializeLionCoreToDynamicNodes() {
     InputStream inputStream = this.getClass().getResourceAsStream("/serialization/lioncore.json");
     JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
-    JsonSerialization jsonSerialization = SerializationProvider.getBasicJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getBasicJsonSerialization(LionWebVersion.v2023_1);
     jsonSerialization.getInstanceResolver().addAll(LionCore.getInstance().thisAndAllDescendants());
     jsonSerialization
         .getInstanceResolver()
-        .addAll(LionCoreBuiltins.getInstance().thisAndAllDescendants());
-    jsonSerialization.getClassifierResolver().registerLanguage(LionCore.getInstance());
+        .addAll(LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).thisAndAllDescendants());
+    jsonSerialization
+        .getClassifierResolver()
+        .registerLanguage(LionCore.getInstance(LionWebVersion.v2023_1));
     jsonSerialization.getInstantiator().enableDynamicNodes();
     jsonSerialization
         .getPrimitiveValuesSerialization()
-        .registerLionBuiltinsPrimitiveSerializersAndDeserializers(LionWebVersion.currentVersion);
+        .registerLionBuiltinsPrimitiveSerializersAndDeserializers(LionWebVersion.v2023_1);
     List<Node> deserializedNodes = jsonSerialization.deserializeToNodes(jsonElement);
 
     DynamicNode lioncore = (DynamicNode) deserializedNodes.get(0);
-    assertEquals(LionCore.getLanguage(), lioncore.getClassifier());
+    assertEquals(LionCore.getLanguage(LionWebVersion.v2023_1), lioncore.getClassifier());
     assertEquals("-id-LionCore-M3", lioncore.getID());
     assertEquals("LionCore_M3", ClassifierInstanceUtils.getPropertyValueByName(lioncore, "name"));
     assertEquals(16, ClassifierInstanceUtils.getChildren(lioncore).size());

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfPrimitiveValuesTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfPrimitiveValuesTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.Node;
 import java.util.Arrays;
 import java.util.List;
@@ -24,7 +25,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject expected =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -56,14 +57,6 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
                     + "            \"language\": \"mylanguage\",\n"
                     + "            \"version\": \"1\",\n"
                     + "            \"key\": \"p3\"\n"
-                    + "          },\n"
-                    + "          \"value\": null\n"
-                    + "        },\n"
-                    + "        {\n"
-                    + "          \"property\": {\n"
-                    + "            \"language\": \"mylanguage\",\n"
-                    + "            \"version\": \"1\",\n"
-                    + "            \"key\": \"p4\"\n"
                     + "          },\n"
                     + "          \"value\": null\n"
                     + "        }\n"
@@ -89,7 +82,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject serialized =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -121,14 +114,6 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
                     + "            \"language\": \"mylanguage\",\n"
                     + "            \"version\": \"1\",\n"
                     + "            \"key\": \"p3\"\n"
-                    + "          },\n"
-                    + "          \"value\": null\n"
-                    + "        },\n"
-                    + "        {\n"
-                    + "          \"property\": {\n"
-                    + "            \"language\": \"mylanguage\",\n"
-                    + "            \"version\": \"1\",\n"
-                    + "            \"key\": \"p4\"\n"
                     + "          },\n"
                     + "          \"value\": null\n"
                     + "        }\n"
@@ -161,7 +146,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject expected =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -195,14 +180,6 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
                     + "            \"key\": \"p3\"\n"
                     + "          },\n"
                     + "          \"value\": \"qwerty\"\n"
-                    + "        },\n"
-                    + "        {\n"
-                    + "          \"property\": {\n"
-                    + "            \"language\": \"mylanguage\",\n"
-                    + "            \"version\": \"1\",\n"
-                    + "            \"key\": \"p4\"\n"
-                    + "          },\n"
-                    + "          \"value\": null\n"
                     + "        }\n"
                     + "      ],\n"
                     + "      \"containments\": [],\n"
@@ -227,7 +204,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject serialized =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -261,14 +238,6 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
                     + "            \"key\": \"p3\"\n"
                     + "          },\n"
                     + "          \"value\": \"qwerty\"\n"
-                    + "        },\n"
-                    + "        {\n"
-                    + "          \"property\": {\n"
-                    + "            \"language\": \"mylanguage\",\n"
-                    + "            \"version\": \"1\",\n"
-                    + "            \"key\": \"p4\"\n"
-                    + "          },\n"
-                    + "          \"value\": null\n"
                     + "        }\n"
                     + "      ],\n"
                     + "      \"containments\": [],\n"
@@ -298,7 +267,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject expected =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -332,14 +301,6 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
                     + "            \"key\": \"p3\"\n"
                     + "          },\n"
                     + "          \"value\": null\n"
-                    + "        },\n"
-                    + "        {\n"
-                    + "          \"property\": {\n"
-                    + "            \"language\": \"mylanguage\",\n"
-                    + "            \"version\": \"1\",\n"
-                    + "            \"key\": \"p4\"\n"
-                    + "          },\n"
-                    + "          \"value\": null\n"
                     + "        }\n"
                     + "      ],\n"
                     + "      \"containments\": [],\n"
@@ -364,7 +325,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
     JsonObject serialized =
         JsonParser.parseString(
                 "{\n"
-                    + "  \"serializationFormatVersion\": \"2023.1\",\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
                     + "  \"languages\": [],\n"
                     + "  \"nodes\": [\n"
                     + "    {\n"
@@ -398,14 +359,6 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
                     + "            \"key\": \"p3\"\n"
                     + "          },\n"
                     + "          \"value\": null\n"
-                    + "        },\n"
-                    + "        {\n"
-                    + "          \"property\": {\n"
-                    + "            \"language\": \"mylanguage\",\n"
-                    + "            \"version\": \"1\",\n"
-                    + "            \"key\": \"p4\"\n"
-                    + "          },\n"
-                    + "          \"value\": null\n"
                     + "        }\n"
                     + "      ],\n"
                     + "      \"containments\": [],\n"
@@ -430,7 +383,7 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
 
   @Test
   public void serializeJSON() {
-    MyNodeWithProperties node = new MyNodeWithProperties("n1");
+    MyNodeWithProperties2023 node = new MyNodeWithProperties2023("n1");
     JsonArray ja = new JsonArray();
     ja.add(1);
     ja.add("foo");
@@ -491,14 +444,15 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
                     + "  ]\n"
                     + "}")
             .getAsJsonObject();
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     JsonObject serialized = jsonSerialization.serializeNodesToJsonElement(node).getAsJsonObject();
     SerializedJsonComparisonUtils.assertEquivalentLionWebJson(expected, serialized);
   }
 
   @Test
   public void deserializeJSON() {
-    MyNodeWithProperties node = new MyNodeWithProperties("n1");
+    MyNodeWithProperties2023 node = new MyNodeWithProperties2023("n1");
     JsonArray ja = new JsonArray();
     ja.add(1);
     ja.add("foo");
@@ -560,14 +514,15 @@ public class SerializationOfPrimitiveValuesTest extends SerializationTest {
                     + "  ]\n"
                     + "}")
             .getAsJsonObject();
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
-    jsonSerialization.getClassifierResolver().registerLanguage(MyNodeWithProperties.LANGUAGE);
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
+    jsonSerialization.getClassifierResolver().registerLanguage(MyNodeWithProperties2023.LANGUAGE);
     jsonSerialization
         .getInstantiator()
         .registerCustomDeserializer(
-            MyNodeWithProperties.CONCEPT.getID(),
+            MyNodeWithProperties2023.CONCEPT.getID(),
             (concept, serializedNode, deserializedNodesByID, propertiesValue) ->
-                new MyNodeWithProperties(serializedNode.getID()));
+                new MyNodeWithProperties2023(serializedNode.getID()));
     List<Node> deserialized = jsonSerialization.deserializeToNodes(serialized);
     assertEquals(Arrays.asList(node), deserialized);
   }

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFExporter.java
@@ -23,7 +23,7 @@ public abstract class AbstractEMFExporter {
     this.conceptsToEClassesMapping = conceptsToEClassesMapping;
   }
 
-  public LionWebVersion getLionWebVersion() {
+  public @Nonnull LionWebVersion getLionWebVersion() {
     return lionWebVersion;
   }
 }

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFExporter.java
@@ -1,15 +1,30 @@
 package io.lionweb.lioncore.java.emf;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.emf.mapping.ConceptsToEClassesMapping;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
 
 public abstract class AbstractEMFExporter {
   protected final ConceptsToEClassesMapping conceptsToEClassesMapping;
+  private LionWebVersion lionWebVersion;
 
   protected AbstractEMFExporter() {
+    this(LionWebVersion.currentVersion);
+  }
+
+  protected AbstractEMFExporter(@Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
+    this.lionWebVersion = lionWebVersion;
     this.conceptsToEClassesMapping = new ConceptsToEClassesMapping();
   }
 
   public AbstractEMFExporter(ConceptsToEClassesMapping conceptsToEClassesMapping) {
     this.conceptsToEClassesMapping = conceptsToEClassesMapping;
+  }
+
+  public LionWebVersion getLionWebVersion() {
+    return lionWebVersion;
   }
 }

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFExporter.java
@@ -16,7 +16,7 @@ public abstract class AbstractEMFExporter {
   protected AbstractEMFExporter(@Nonnull LionWebVersion lionWebVersion) {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     this.lionWebVersion = lionWebVersion;
-    this.conceptsToEClassesMapping = new ConceptsToEClassesMapping();
+    this.conceptsToEClassesMapping = new ConceptsToEClassesMapping(lionWebVersion);
   }
 
   public AbstractEMFExporter(ConceptsToEClassesMapping conceptsToEClassesMapping) {

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFExporter.java
@@ -2,9 +2,8 @@ package io.lionweb.lioncore.java.emf;
 
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.emf.mapping.ConceptsToEClassesMapping;
-
-import javax.annotation.Nonnull;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 
 public abstract class AbstractEMFExporter {
   protected final ConceptsToEClassesMapping conceptsToEClassesMapping;

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFImporter.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import org.eclipse.emf.common.util.URI;
@@ -34,14 +35,14 @@ public abstract class AbstractEMFImporter<E> {
   }
 
   public AbstractEMFImporter(@Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     this.conceptsToEClassesMapping = new ConceptsToEClassesMapping(lionWebVersion);
   }
 
-  public AbstractEMFImporter(
-      @Nonnull LionWebVersion lionWebVersion, ConceptsToEClassesMapping conceptsToEClassesMapping) {
-    this.conceptsToEClassesMapping = conceptsToEClassesMapping;
-  }
-
+  /**
+   * Not that in this case the LionWeb Version used will be "embedded" in the
+   * ConceptsToEClassesMapping instance.
+   */
   public AbstractEMFImporter(ConceptsToEClassesMapping conceptsToEClassesMapping) {
     this.conceptsToEClassesMapping = conceptsToEClassesMapping;
   }

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFImporter.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import javax.annotation.Nonnull;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EcorePackage;
@@ -18,8 +19,6 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.xmi.impl.EcoreResourceFactoryImpl;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
-
-import javax.annotation.Nonnull;
 
 /**
  * Importer that given an EMF Resource imports something out of it.
@@ -38,7 +37,8 @@ public abstract class AbstractEMFImporter<E> {
     this.conceptsToEClassesMapping = new ConceptsToEClassesMapping();
   }
 
-  public AbstractEMFImporter(@Nonnull LionWebVersion lionWebVersion, ConceptsToEClassesMapping conceptsToEClassesMapping) {
+  public AbstractEMFImporter(
+      @Nonnull LionWebVersion lionWebVersion, ConceptsToEClassesMapping conceptsToEClassesMapping) {
     this.conceptsToEClassesMapping = conceptsToEClassesMapping;
   }
 

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFImporter.java
@@ -30,11 +30,11 @@ public abstract class AbstractEMFImporter<E> {
   protected final ConceptsToEClassesMapping conceptsToEClassesMapping;
 
   public AbstractEMFImporter() {
-    this.conceptsToEClassesMapping = new ConceptsToEClassesMapping();
+    this(LionWebVersion.currentVersion);
   }
 
   public AbstractEMFImporter(@Nonnull LionWebVersion lionWebVersion) {
-    this.conceptsToEClassesMapping = new ConceptsToEClassesMapping();
+    this.conceptsToEClassesMapping = new ConceptsToEClassesMapping(lionWebVersion);
   }
 
   public AbstractEMFImporter(

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFImporter.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.emf;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.emf.mapping.ConceptsToEClassesMapping;
 import io.lionweb.lioncore.java.emf.support.JSONResourceFactory;
 import java.io.File;
@@ -18,6 +19,8 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.xmi.impl.EcoreResourceFactoryImpl;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 
+import javax.annotation.Nonnull;
+
 /**
  * Importer that given an EMF Resource imports something out of it.
  *
@@ -29,6 +32,14 @@ public abstract class AbstractEMFImporter<E> {
 
   public AbstractEMFImporter() {
     this.conceptsToEClassesMapping = new ConceptsToEClassesMapping();
+  }
+
+  public AbstractEMFImporter(@Nonnull LionWebVersion lionWebVersion) {
+    this.conceptsToEClassesMapping = new ConceptsToEClassesMapping();
+  }
+
+  public AbstractEMFImporter(@Nonnull LionWebVersion lionWebVersion, ConceptsToEClassesMapping conceptsToEClassesMapping) {
+    this.conceptsToEClassesMapping = conceptsToEClassesMapping;
   }
 
   public AbstractEMFImporter(ConceptsToEClassesMapping conceptsToEClassesMapping) {

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporter.java
@@ -5,6 +5,7 @@ import io.lionweb.lioncore.java.emf.mapping.ConceptsToEClassesMapping;
 import io.lionweb.lioncore.java.emf.mapping.DataTypeMapping;
 import io.lionweb.lioncore.java.language.*;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import org.eclipse.emf.ecore.*;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -21,12 +22,14 @@ public class EMFMetamodelExporter extends AbstractEMFExporter {
 
   public EMFMetamodelExporter(@Nonnull LionWebVersion lionWebVersion) {
     super(lionWebVersion);
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     this.dataTypeMapping = new DataTypeMapping(lionWebVersion);
   }
 
   public EMFMetamodelExporter(
       @Nonnull LionWebVersion lionWebVersion, ConceptsToEClassesMapping conceptsToEClassesMapping) {
     super(conceptsToEClassesMapping);
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     this.dataTypeMapping = new DataTypeMapping(lionWebVersion);
   }
 

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporter.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.emf;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.emf.mapping.ConceptsToEClassesMapping;
 import io.lionweb.lioncore.java.emf.mapping.DataTypeMapping;
 import io.lionweb.lioncore.java.language.*;
@@ -8,13 +9,20 @@ import org.eclipse.emf.ecore.*;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
 
+import javax.annotation.Nonnull;
+
 /** Export LionWeb's metamodels into EMF's metamodels. */
 public class EMFMetamodelExporter extends AbstractEMFExporter {
 
-  private final DataTypeMapping dataTypeMapping = new DataTypeMapping();
+  private DataTypeMapping dataTypeMapping;
 
   public EMFMetamodelExporter() {
-    super();
+    this(LionWebVersion.currentVersion);
+  }
+
+  public EMFMetamodelExporter(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
+    this.dataTypeMapping = new DataTypeMapping(lionWebVersion);
   }
 
   public EMFMetamodelExporter(ConceptsToEClassesMapping conceptsToEClassesMapping) {

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporter.java
@@ -22,7 +22,6 @@ public class EMFMetamodelExporter extends AbstractEMFExporter {
 
   public EMFMetamodelExporter(@Nonnull LionWebVersion lionWebVersion) {
     super(lionWebVersion);
-    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     this.dataTypeMapping = new DataTypeMapping(lionWebVersion);
   }
 

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporter.java
@@ -5,11 +5,10 @@ import io.lionweb.lioncore.java.emf.mapping.ConceptsToEClassesMapping;
 import io.lionweb.lioncore.java.emf.mapping.DataTypeMapping;
 import io.lionweb.lioncore.java.language.*;
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.eclipse.emf.ecore.*;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
-
-import javax.annotation.Nonnull;
 
 /** Export LionWeb's metamodels into EMF's metamodels. */
 public class EMFMetamodelExporter extends AbstractEMFExporter {

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporter.java
@@ -24,8 +24,10 @@ public class EMFMetamodelExporter extends AbstractEMFExporter {
     this.dataTypeMapping = new DataTypeMapping(lionWebVersion);
   }
 
-  public EMFMetamodelExporter(ConceptsToEClassesMapping conceptsToEClassesMapping) {
+  public EMFMetamodelExporter(
+      @Nonnull LionWebVersion lionWebVersion, ConceptsToEClassesMapping conceptsToEClassesMapping) {
     super(conceptsToEClassesMapping);
+    this.dataTypeMapping = new DataTypeMapping(lionWebVersion);
   }
 
   /** This export all the languages received to a single Resource. */

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
@@ -24,14 +24,9 @@ public class EMFMetamodelImporter extends AbstractEMFImporter<Language> {
     dataTypeMapping = new DataTypeMapping(lionWebVersion);
   }
 
-  public EMFMetamodelImporter(
-      @Nonnull LionWebVersion lionWebVersion, ConceptsToEClassesMapping conceptsToEClassesMapping) {
-    super(lionWebVersion, conceptsToEClassesMapping);
-    dataTypeMapping = new DataTypeMapping(lionWebVersion);
-  }
-
   public EMFMetamodelImporter(ConceptsToEClassesMapping conceptsToEClassesMapping) {
-    this(LionWebVersion.currentVersion, conceptsToEClassesMapping);
+    super(conceptsToEClassesMapping);
+    dataTypeMapping = new DataTypeMapping(conceptsToEClassesMapping.getLionWebVersion());
   }
 
   @Override

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
@@ -7,10 +7,9 @@ import io.lionweb.lioncore.java.language.*;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import org.eclipse.emf.ecore.*;
 import org.eclipse.emf.ecore.resource.Resource;
-
-import javax.annotation.Nonnull;
 
 /** EMF importer which produces LionWeb's Metamodels. */
 public class EMFMetamodelImporter extends AbstractEMFImporter<Language> {
@@ -25,7 +24,8 @@ public class EMFMetamodelImporter extends AbstractEMFImporter<Language> {
     dataTypeMapping = new DataTypeMapping(lionWebVersion);
   }
 
-  public EMFMetamodelImporter(@Nonnull LionWebVersion lionWebVersion, ConceptsToEClassesMapping conceptsToEClassesMapping) {
+  public EMFMetamodelImporter(
+      @Nonnull LionWebVersion lionWebVersion, ConceptsToEClassesMapping conceptsToEClassesMapping) {
     super(lionWebVersion, conceptsToEClassesMapping);
     dataTypeMapping = new DataTypeMapping(lionWebVersion);
   }

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.emf;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.emf.mapping.ConceptsToEClassesMapping;
 import io.lionweb.lioncore.java.emf.mapping.DataTypeMapping;
 import io.lionweb.lioncore.java.language.*;
@@ -9,16 +10,28 @@ import java.util.Objects;
 import org.eclipse.emf.ecore.*;
 import org.eclipse.emf.ecore.resource.Resource;
 
+import javax.annotation.Nonnull;
+
 /** EMF importer which produces LionWeb's Metamodels. */
 public class EMFMetamodelImporter extends AbstractEMFImporter<Language> {
-  private final DataTypeMapping dataTypeMapping = new DataTypeMapping();
+  private @Nonnull DataTypeMapping dataTypeMapping;
 
   public EMFMetamodelImporter() {
+    this(LionWebVersion.currentVersion);
+  }
+
+  public EMFMetamodelImporter(@Nonnull LionWebVersion lionWebVersion) {
     super();
+    dataTypeMapping = new DataTypeMapping(lionWebVersion);
+  }
+
+  public EMFMetamodelImporter(@Nonnull LionWebVersion lionWebVersion, ConceptsToEClassesMapping conceptsToEClassesMapping) {
+    super(lionWebVersion, conceptsToEClassesMapping);
+    dataTypeMapping = new DataTypeMapping(lionWebVersion);
   }
 
   public EMFMetamodelImporter(ConceptsToEClassesMapping conceptsToEClassesMapping) {
-    super(conceptsToEClassesMapping);
+    this(LionWebVersion.currentVersion, conceptsToEClassesMapping);
   }
 
   @Override

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFModelExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFModelExporter.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.emf;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.emf.mapping.ConceptsToEClassesMapping;
 import io.lionweb.lioncore.java.language.Reference;
 import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
@@ -11,10 +12,16 @@ import org.eclipse.emf.ecore.*;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
 
+import javax.annotation.Nonnull;
+
 public class EMFModelExporter extends AbstractEMFExporter {
 
   public EMFModelExporter() {
     super();
+  }
+
+  public EMFModelExporter(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
   }
 
   public EMFModelExporter(ConceptsToEClassesMapping conceptsToEClassesMapping) {

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFModelExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFModelExporter.java
@@ -8,11 +8,10 @@ import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.ReferenceValue;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.eclipse.emf.ecore.*;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
-
-import javax.annotation.Nonnull;
 
 public class EMFModelExporter extends AbstractEMFExporter {
 

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFModelImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFModelImporter.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.emf;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.emf.mapping.ConceptsToEClassesMapping;
 import io.lionweb.lioncore.java.emf.support.NodeInstantiator;
 import io.lionweb.lioncore.java.language.*;
@@ -9,6 +10,8 @@ import java.util.*;
 import org.eclipse.emf.ecore.*;
 import org.eclipse.emf.ecore.resource.Resource;
 
+import javax.annotation.Nonnull;
+
 /** Importer which produces LionWeb's Nodes. */
 public class EMFModelImporter extends AbstractEMFImporter<Node> {
   private final NodeInstantiator nodeInstantiator;
@@ -17,6 +20,12 @@ public class EMFModelImporter extends AbstractEMFImporter<Node> {
     super();
     nodeInstantiator = new NodeInstantiator();
   }
+
+  public EMFModelImporter(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
+    nodeInstantiator = new NodeInstantiator();
+  }
+
 
   public EMFModelImporter(ConceptsToEClassesMapping conceptsToEClassesMapping) {
     super(conceptsToEClassesMapping);

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFModelImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFModelImporter.java
@@ -7,10 +7,9 @@ import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
 import io.lionweb.lioncore.java.model.Node;
 import java.util.*;
+import javax.annotation.Nonnull;
 import org.eclipse.emf.ecore.*;
 import org.eclipse.emf.ecore.resource.Resource;
-
-import javax.annotation.Nonnull;
 
 /** Importer which produces LionWeb's Nodes. */
 public class EMFModelImporter extends AbstractEMFImporter<Node> {
@@ -25,7 +24,6 @@ public class EMFModelImporter extends AbstractEMFImporter<Node> {
     super(lionWebVersion);
     nodeInstantiator = new NodeInstantiator();
   }
-
 
   public EMFModelImporter(ConceptsToEClassesMapping conceptsToEClassesMapping) {
     super(conceptsToEClassesMapping);

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/ConceptsToEClassesMapping.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/ConceptsToEClassesMapping.java
@@ -8,10 +8,9 @@ import io.lionweb.lioncore.java.language.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import org.eclipse.emf.ecore.*;
 import org.jetbrains.annotations.Nullable;
-
-import javax.annotation.Nonnull;
 
 public class ConceptsToEClassesMapping {
 
@@ -34,7 +33,8 @@ public class ConceptsToEClassesMapping {
   }
 
   /** @param prePopulateBuiltins Whether builtins should be pre-populated in this mapping. */
-  public ConceptsToEClassesMapping(@Nonnull LionWebVersion lionWebVersion,  boolean prePopulateBuiltins) {
+  public ConceptsToEClassesMapping(
+      @Nonnull LionWebVersion lionWebVersion, boolean prePopulateBuiltins) {
     this.lionWebVersion = lionWebVersion;
     if (prePopulateBuiltins) {
       prePopulateBuiltins();

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/ConceptsToEClassesMapping.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/ConceptsToEClassesMapping.java
@@ -1,6 +1,7 @@
 package io.lionweb.lioncore.java.emf.mapping;
 
 import io.lionweb.java.emf.builtins.BuiltinsPackage;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.emf.EMFMetamodelExporter;
 import io.lionweb.lioncore.java.emf.EMFMetamodelImporter;
 import io.lionweb.lioncore.java.language.*;
@@ -9,6 +10,8 @@ import java.util.Map;
 import java.util.Objects;
 import org.eclipse.emf.ecore.*;
 import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nonnull;
 
 public class ConceptsToEClassesMapping {
 
@@ -19,13 +22,20 @@ public class ConceptsToEClassesMapping {
   private final Map<Concept, EClass> conceptsToEClasses = new HashMap<>();
   private final Map<Interface, EClass> interfacesToEClasses = new HashMap<>();
 
+  private LionWebVersion lionWebVersion;
+
   /** Creates a mapping with pre-populated builtins. */
   public ConceptsToEClassesMapping() {
-    this(true);
+    this(LionWebVersion.currentVersion, true);
+  }
+
+  public ConceptsToEClassesMapping(@Nonnull LionWebVersion lionWebVersion) {
+    this(lionWebVersion, true);
   }
 
   /** @param prePopulateBuiltins Whether builtins should be pre-populated in this mapping. */
-  public ConceptsToEClassesMapping(boolean prePopulateBuiltins) {
+  public ConceptsToEClassesMapping(@Nonnull LionWebVersion lionWebVersion,  boolean prePopulateBuiltins) {
+    this.lionWebVersion = lionWebVersion;
     if (prePopulateBuiltins) {
       prePopulateBuiltins();
     }
@@ -33,7 +43,7 @@ public class ConceptsToEClassesMapping {
 
   private void processEPackage(EPackage ePackage) {
     Objects.requireNonNull(ePackage, "ePackage should not be null");
-    EMFMetamodelImporter EMFMetamodelImporter = new EMFMetamodelImporter(this);
+    EMFMetamodelImporter EMFMetamodelImporter = new EMFMetamodelImporter(lionWebVersion, this);
     Language language = EMFMetamodelImporter.importEPackage(ePackage);
     ePackagesToLanguages.put(ePackage, language);
     languagesToEPackages.put(language, ePackage);

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/ConceptsToEClassesMapping.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/ConceptsToEClassesMapping.java
@@ -35,6 +35,7 @@ public class ConceptsToEClassesMapping {
   /** @param prePopulateBuiltins Whether builtins should be pre-populated in this mapping. */
   public ConceptsToEClassesMapping(
       @Nonnull LionWebVersion lionWebVersion, boolean prePopulateBuiltins) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     this.lionWebVersion = lionWebVersion;
     if (prePopulateBuiltins) {
       prePopulateBuiltins(lionWebVersion);
@@ -206,6 +207,7 @@ public class ConceptsToEClassesMapping {
   }
 
   public void prePopulateBuiltins(@Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     ePackagesToLanguages.put(
         BuiltinsPackage.eINSTANCE, LionCoreBuiltins.getInstance(lionWebVersion));
     languagesToEPackages.put(

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/ConceptsToEClassesMapping.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/ConceptsToEClassesMapping.java
@@ -37,7 +37,7 @@ public class ConceptsToEClassesMapping {
       @Nonnull LionWebVersion lionWebVersion, boolean prePopulateBuiltins) {
     this.lionWebVersion = lionWebVersion;
     if (prePopulateBuiltins) {
-      prePopulateBuiltins();
+      prePopulateBuiltins(lionWebVersion);
     }
   }
 
@@ -62,7 +62,7 @@ public class ConceptsToEClassesMapping {
 
   private void processMetamodel(Language language) {
     Objects.requireNonNull(language, "Language should not be null");
-    EMFMetamodelExporter ecoreExporter = new EMFMetamodelExporter(this);
+    EMFMetamodelExporter ecoreExporter = new EMFMetamodelExporter(lionWebVersion, this);
     EPackage ePackage = ecoreExporter.exportLanguage(language);
     ePackagesToLanguages.put(ePackage, language);
     languagesToEPackages.put(language, ePackage);
@@ -205,10 +205,13 @@ public class ConceptsToEClassesMapping {
     return null;
   }
 
-  public void prePopulateBuiltins() {
-    ePackagesToLanguages.put(BuiltinsPackage.eINSTANCE, LionCoreBuiltins.getInstance());
-    languagesToEPackages.put(LionCoreBuiltins.getInstance(), BuiltinsPackage.eINSTANCE);
-    registerMapping(LionCoreBuiltins.getNode(), EcorePackage.eINSTANCE.getEObject());
-    registerMapping(LionCoreBuiltins.getINamed(), BuiltinsPackage.eINSTANCE.getINamed());
+  public void prePopulateBuiltins(@Nonnull LionWebVersion lionWebVersion) {
+    ePackagesToLanguages.put(
+        BuiltinsPackage.eINSTANCE, LionCoreBuiltins.getInstance(lionWebVersion));
+    languagesToEPackages.put(
+        LionCoreBuiltins.getInstance(lionWebVersion), BuiltinsPackage.eINSTANCE);
+    registerMapping(LionCoreBuiltins.getNode(lionWebVersion), EcorePackage.eINSTANCE.getEObject());
+    registerMapping(
+        LionCoreBuiltins.getINamed(lionWebVersion), BuiltinsPackage.eINSTANCE.getINamed());
   }
 }

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/ConceptsToEClassesMapping.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/ConceptsToEClassesMapping.java
@@ -43,7 +43,7 @@ public class ConceptsToEClassesMapping {
 
   private void processEPackage(EPackage ePackage) {
     Objects.requireNonNull(ePackage, "ePackage should not be null");
-    EMFMetamodelImporter EMFMetamodelImporter = new EMFMetamodelImporter(lionWebVersion, this);
+    EMFMetamodelImporter EMFMetamodelImporter = new EMFMetamodelImporter(this);
     Language language = EMFMetamodelImporter.importEPackage(ePackage);
     ePackagesToLanguages.put(ePackage, language);
     languagesToEPackages.put(language, ePackage);
@@ -213,5 +213,9 @@ public class ConceptsToEClassesMapping {
     registerMapping(LionCoreBuiltins.getNode(lionWebVersion), EcorePackage.eINSTANCE.getEObject());
     registerMapping(
         LionCoreBuiltins.getINamed(lionWebVersion), BuiltinsPackage.eINSTANCE.getINamed());
+  }
+
+  public @Nonnull LionWebVersion getLionWebVersion() {
+    return lionWebVersion;
   }
 }

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/ConceptsToEClassesMapping.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/ConceptsToEClassesMapping.java
@@ -21,7 +21,7 @@ public class ConceptsToEClassesMapping {
   private final Map<Concept, EClass> conceptsToEClasses = new HashMap<>();
   private final Map<Interface, EClass> interfacesToEClasses = new HashMap<>();
 
-  private LionWebVersion lionWebVersion;
+  private @Nonnull LionWebVersion lionWebVersion;
 
   /** Creates a mapping with pre-populated builtins. */
   public ConceptsToEClassesMapping() {

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/DataTypeMapping.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/DataTypeMapping.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.emf.mapping;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.DataType;
 import io.lionweb.lioncore.java.language.Enumeration;
 import io.lionweb.lioncore.java.language.LionCoreBuiltins;
@@ -13,6 +14,8 @@ import org.eclipse.emf.ecore.EEnum;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.xml.type.impl.XMLTypePackageImpl;
 
+import javax.annotation.Nonnull;
+
 public class DataTypeMapping {
 
   private final Map<EEnum, Enumeration> eEnumsToEnumerations = new HashMap<>();
@@ -20,6 +23,12 @@ public class DataTypeMapping {
 
   private final Map<EDataType, PrimitiveType> eDataTypesToPrimitiveTypes = new HashMap<>();
   private final Map<PrimitiveType, EDataType> primitiveTypesToEDataTypes = new HashMap<>();
+
+  private LionWebVersion lionWebVersion;
+
+  public DataTypeMapping(@Nonnull LionWebVersion lionWebVersion) {
+    this.lionWebVersion = lionWebVersion;
+  }
 
   public void registerMapping(EEnum eEnum, Enumeration enumeration) {
     eEnumsToEnumerations.put(eEnum, enumeration);
@@ -40,11 +49,11 @@ public class DataTypeMapping {
   }
 
   public EDataType toEDataType(DataType dataType) {
-    if (dataType.equals(LionCoreBuiltins.getBoolean())) {
+    if (dataType.equals(LionCoreBuiltins.getBoolean(lionWebVersion))) {
       return EcorePackage.eINSTANCE.getEBoolean();
-    } else if (dataType.equals(LionCoreBuiltins.getInteger())) {
+    } else if (dataType.equals(LionCoreBuiltins.getInteger(lionWebVersion))) {
       return EcorePackage.eINSTANCE.getEInt();
-    } else if (dataType.equals(LionCoreBuiltins.getString())) {
+    } else if (dataType.equals(LionCoreBuiltins.getString(lionWebVersion))) {
       return EcorePackage.eINSTANCE.getEString();
     } else if (dataType instanceof Enumeration) {
       Enumeration enumeration = (Enumeration) dataType;

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/DataTypeMapping.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/DataTypeMapping.java
@@ -23,9 +23,10 @@ public class DataTypeMapping {
   private final Map<EDataType, PrimitiveType> eDataTypesToPrimitiveTypes = new HashMap<>();
   private final Map<PrimitiveType, EDataType> primitiveTypesToEDataTypes = new HashMap<>();
 
-  private LionWebVersion lionWebVersion;
+  private @Nonnull LionWebVersion lionWebVersion;
 
   public DataTypeMapping(@Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     this.lionWebVersion = lionWebVersion;
   }
 

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/DataTypeMapping.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/DataTypeMapping.java
@@ -8,13 +8,12 @@ import io.lionweb.lioncore.java.language.PrimitiveType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EEnum;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.xml.type.impl.XMLTypePackageImpl;
-
-import javax.annotation.Nonnull;
 
 public class DataTypeMapping {
 

--- a/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporterTest.java
+++ b/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporterTest.java
@@ -3,6 +3,7 @@ package io.lionweb.lioncore.java.emf;
 import static org.junit.Assert.*;
 
 import io.lionweb.java.emf.builtins.BuiltinsPackage;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.serialization.SerializationProvider;
 import java.io.*;
@@ -25,7 +26,7 @@ public class EMFMetamodelExporterTest {
   public void exportLibraryLanguage() {
     Language libraryLang =
         (Language)
-            SerializationProvider.getStandardJsonSerialization()
+            SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1)
                 .deserializeToNodes(this.getClass().getResourceAsStream("/library-language.json"))
                 .get(0);
 

--- a/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporterTest.java
+++ b/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporterTest.java
@@ -30,7 +30,7 @@ public class EMFMetamodelExporterTest {
                 .deserializeToNodes(this.getClass().getResourceAsStream("/library-language.json"))
                 .get(0);
 
-    EMFMetamodelExporter ecoreExporter = new EMFMetamodelExporter();
+    EMFMetamodelExporter ecoreExporter = new EMFMetamodelExporter(LionWebVersion.v2023_1);
     EPackage libraryPkg = ecoreExporter.exportLanguage(libraryLang);
 
     assertEquals("library", libraryPkg.getName());
@@ -156,12 +156,12 @@ public class EMFMetamodelExporterTest {
 
     Language propertiesLang =
         (Language)
-            SerializationProvider.getStandardJsonSerialization()
+            SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1)
                 .deserializeToNodes(
                     this.getClass().getResourceAsStream("/properties-language.json"))
                 .get(0);
 
-    EMFMetamodelExporter ecoreExporter = new EMFMetamodelExporter();
+    EMFMetamodelExporter ecoreExporter = new EMFMetamodelExporter(LionWebVersion.v2023_1);
     EPackage propertiesPkg = ecoreExporter.exportLanguage(propertiesLang);
 
     assertEquals("io_lionweb_Properties", propertiesPkg.getName());
@@ -261,12 +261,12 @@ public class EMFMetamodelExporterTest {
   public void storePropertiesLangWithINamed() throws IOException {
     Language propertiesLang =
         (Language)
-            SerializationProvider.getStandardJsonSerialization()
+            SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1)
                 .deserializeToNodes(
                     this.getClass().getResourceAsStream("/properties-language.json"))
                 .get(0);
 
-    EMFMetamodelExporter ecoreExporter = new EMFMetamodelExporter();
+    EMFMetamodelExporter ecoreExporter = new EMFMetamodelExporter(LionWebVersion.v2023_1);
     EPackage propertiesPkg = ecoreExporter.exportLanguage(propertiesLang);
 
     Resource.Factory.Registry.INSTANCE

--- a/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFModelExporterTest.java
+++ b/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFModelExporterTest.java
@@ -91,7 +91,8 @@ public class EMFModelExporterTest {
         SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1)
             .loadLanguage(this.getClass().getResourceAsStream("/properties-language.json"));
 
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     jsonSerialization.registerLanguage(propertiesLang);
     jsonSerialization.getInstantiator().enableDynamicNodes();
 

--- a/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFModelExporterTest.java
+++ b/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFModelExporterTest.java
@@ -19,7 +19,8 @@ public class EMFModelExporterTest {
 
   @Test
   public void exportLibraryInstance() {
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     jsonSerialization.registerLanguage(LibraryMetamodel.LIBRARY_LANG);
     jsonSerialization.getInstantiator().enableDynamicNodes();
     List<Node> nodes =
@@ -69,7 +70,8 @@ public class EMFModelExporterTest {
   @Test
   public void exportSingleContainment() {
     InputStream languageIs = this.getClass().getResourceAsStream("/properties.lmm.json");
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     Language propertiesLanguage = jsonSerialization.loadLanguage(languageIs);
     jsonSerialization.registerLanguage(propertiesLanguage);
     jsonSerialization.getInstantiator().enableDynamicNodes();

--- a/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFModelExporterTest.java
+++ b/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFModelExporterTest.java
@@ -3,6 +3,7 @@ package io.lionweb.lioncore.java.emf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Language;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.serialization.JsonSerialization;
@@ -18,7 +19,7 @@ public class EMFModelExporterTest {
 
   @Test
   public void exportLibraryInstance() {
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     jsonSerialization.registerLanguage(LibraryMetamodel.LIBRARY_LANG);
     jsonSerialization.getInstantiator().enableDynamicNodes();
     List<Node> nodes =
@@ -27,7 +28,7 @@ public class EMFModelExporterTest {
     List<Node> roots =
         nodes.stream().filter(n -> n.getParent() == null).collect(Collectors.toList());
 
-    EMFModelExporter emfExporter = new EMFModelExporter();
+    EMFModelExporter emfExporter = new EMFModelExporter(LionWebVersion.v2023_1);
     Resource resource = emfExporter.exportResource(roots);
 
     assertEquals(3, resource.getContents().size());
@@ -68,7 +69,7 @@ public class EMFModelExporterTest {
   @Test
   public void exportSingleContainment() {
     InputStream languageIs = this.getClass().getResourceAsStream("/properties.lmm.json");
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     Language propertiesLanguage = jsonSerialization.loadLanguage(languageIs);
     jsonSerialization.registerLanguage(propertiesLanguage);
     jsonSerialization.getInstantiator().enableDynamicNodes();
@@ -78,14 +79,14 @@ public class EMFModelExporterTest {
     List<Node> roots =
         nodes.stream().filter(it -> it.getParent() == null).collect(Collectors.toList());
 
-    EMFModelExporter emfExporter = new EMFModelExporter();
+    EMFModelExporter emfExporter = new EMFModelExporter(LionWebVersion.v2023_1);
     Resource resource = emfExporter.exportResource(roots);
   }
 
   @Test
   public void exportPropertiesInstance() {
     Language propertiesLang =
-        SerializationProvider.getStandardJsonSerialization()
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1)
             .loadLanguage(this.getClass().getResourceAsStream("/properties-language.json"));
 
     JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
@@ -98,7 +99,7 @@ public class EMFModelExporterTest {
     List<Node> roots =
         nodes.stream().filter(n -> n.getParent() == null).collect(Collectors.toList());
 
-    EMFModelExporter emfExporter = new EMFModelExporter();
+    EMFModelExporter emfExporter = new EMFModelExporter(LionWebVersion.v2023_1);
     Resource resource = emfExporter.exportResource(roots);
 
     assertEquals(1, resource.getContents().size());

--- a/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFModelImporterTest.java
+++ b/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFModelImporterTest.java
@@ -3,6 +3,7 @@ package io.lionweb.lioncore.java.emf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
 import io.lionweb.lioncore.java.model.Node;
 import java.io.IOException;
@@ -40,7 +41,7 @@ public class EMFModelImporterTest {
     List<EPackage> ePackages = loadKotlinEPackages();
 
     InputStream is = this.getClass().getResourceAsStream("/KotlinPrinterAST.json");
-    EMFModelImporter importer = new EMFModelImporter();
+    EMFModelImporter importer = new EMFModelImporter(LionWebVersion.v2023_1);
 
     importer.getNodeInstantiator().enableDynamicNodes();
 

--- a/emf/src/test/java/io/lionweb/lioncore/java/emf/LibraryMetamodel.java
+++ b/emf/src/test/java/io/lionweb/lioncore/java/emf/LibraryMetamodel.java
@@ -2,6 +2,7 @@ package io.lionweb.lioncore.java.emf;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.Concept;
 import io.lionweb.lioncore.java.language.Language;
 import io.lionweb.lioncore.java.model.Node;
@@ -24,7 +25,8 @@ public class LibraryMetamodel {
   static {
     InputStream inputStream = LibraryMetamodel.class.getResourceAsStream("/library-language.json");
     JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream));
-    JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+    JsonSerialization jsonSerialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
     List<Node> deserializedNodes = jsonSerialization.deserializeToNodes(jsonElement);
     LIBRARY_LANG =
         deserializedNodes.stream()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-version=0.2.21-SNAPSHOT
-specsVersion=2023.1
+version=0.3.0-SNAPSHOT
+specsVersion=2024.1
 jvmVersion=1.8
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 SONATYPE_CONNECT_TIMEOUT_SECONDS=200


### PR DESCRIPTION
The goal is to support, with the same codebase, all the LionWeb versions, provided they are not mixed together.

Many APIs now get an optional parameter indicating the LionWeb version to be used. If no value is provided the current one is used.

Not also that all "meta" nodes (Concept, Enumeration, Feature, etc.) needs to know to which LionWeb version they refer to.

Probably more checks should be put in place to identify cases in which multiple versions are mixed.

Regarding serialization tests, in all the cases in which we had files, we kept them untouched, so we check the serialization works for v2023.1. At some point we may duplicate some of those tests to check they still work with v2024.1 (with the appropriate, minimal, adaptations).