### PR TITLE
Verify that an SDT specify fields

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/language/Field.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Field.java
@@ -26,6 +26,17 @@ public class Field extends M3Node<Field> implements NamespacedEntity, IKeyed<Fie
     setID(id);
   }
 
+  public Field(
+      @Nullable String name,
+      @Nullable DataType<?> type,
+      @Nullable String id,
+      @Nullable String key) {
+    setName(name);
+    setType(type);
+    setID(id);
+    setKey(key);
+  }
+
   public Field(@Nonnull StructuredDataType structuredDataType, @Nullable String name) {
     structuredDataType.addField(this);
     setParent(structuredDataType);

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Link.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Link.java
@@ -56,6 +56,10 @@ public abstract class Link<T extends M3Node> extends Feature<T> {
     return getPropertyValue("multiple", Boolean.class, false);
   }
 
+  public boolean isSingle() {
+    return !isMultiple();
+  }
+
   public T setMultiple(boolean multiple) {
     this.setPropertyValue("multiple", multiple);
     return (T) this;

--- a/core/src/main/java/io/lionweb/lioncore/java/language/StructuredDataType.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/StructuredDataType.java
@@ -33,6 +33,13 @@ public class StructuredDataType extends DataType<StructuredDataType> implements 
     setID(id);
   }
 
+  public StructuredDataType(
+      @Nullable Language language, @Nullable String name, String id, String key) {
+    super(language, name);
+    setID(id);
+    setKey(key);
+  }
+
   public @Nonnull StructuredDataType addField(@Nonnull Field field) {
     Objects.requireNonNull(field, "field should not be null");
     this.addContainmentMultipleValue("fields", field);

--- a/core/src/main/java/io/lionweb/lioncore/java/utils/NodeTreeValidator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/NodeTreeValidator.java
@@ -25,6 +25,26 @@ public class NodeTreeValidator extends Validator<Node> {
           "A root node should be an instance of a Partition concept",
           node);
     }
+    node.getClassifier()
+        .allContainments()
+        .forEach(
+            containment -> {
+              int actualNChildren = node.getChildren(containment).size();
+              validationResult.checkForError(
+                  containment.isRequired() && actualNChildren == 0,
+                  "Containment "
+                      + containment.getName()
+                      + " is required but no children are specified",
+                  node);
+              validationResult.checkForError(
+                  containment.isSingle() && actualNChildren > 1,
+                  "Containment "
+                      + containment.getName()
+                      + " is single but it has "
+                      + actualNChildren
+                      + " children",
+                  node);
+            });
     ClassifierInstanceUtils.getChildren(node)
         .forEach(child -> validateNodeAndDescendants(child, validationResult));
   }

--- a/core/src/test/java/io/lionweb/lioncore/java/self/LionCoreTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/self/LionCoreTest.java
@@ -1,9 +1,9 @@
 package io.lionweb.lioncore.java.self;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 import io.lionweb.lioncore.java.language.Concept;
+import io.lionweb.lioncore.java.language.Containment;
 import io.lionweb.lioncore.java.language.Property;
 import io.lionweb.lioncore.java.utils.LanguageValidator;
 import io.lionweb.lioncore.java.utils.ValidationResult;
@@ -39,5 +39,13 @@ public class LionCoreTest {
     assertEquals("LionCore-builtins", name.getDeclaringLanguage().getKey());
     Property version = language.getPropertyByName("version");
     assertNotNull(version);
+  }
+
+  @Test
+  public void checkSDTFieldsAreRequired() {
+    Concept sdt = LionCore.getStructuredDataType();
+    Containment fields = sdt.getContainmentByName("fields");
+    assertTrue(fields.isRequired());
+    assertFalse(fields.isOptional());
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/utils/LanguageValidatorTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/utils/LanguageValidatorTest.java
@@ -7,6 +7,7 @@ import io.lionweb.lioncore.java.self.LionCore;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Test;
 
@@ -283,5 +284,23 @@ public class LanguageValidatorTest {
     b.setAnnotates(c);
     b.setExtendedAnnotation(a);
     assertEquals(Collections.emptySet(), l.validate().getIssues());
+  }
+
+  @Test
+  public void anSDTWithNoFieldsIsInvalid() {
+    Language l = new Language("MyLanguage", "my_language_id", "my_language_key");
+    StructuredDataType sdt = new StructuredDataType(l, "SDT", "sdt_id", "sdt_key");
+    Set<Issue> issuesA = l.validate().getIssues();
+    assertEquals(1, issuesA.size());
+    Issue issueA0 = issuesA.iterator().next();
+    assertEquals(
+        new Issue(
+            IssueSeverity.Error,
+            "Containment fields is required but no children are specified",
+            sdt),
+        issueA0);
+    sdt.addField(new Field("MyField", LionCoreBuiltins.getString(), "f_id", "f_key"));
+    Set<Issue> issuesB = l.validate().getIssues();
+    assertEquals(Collections.emptySet(), issuesB);
   }
 }


### PR DESCRIPTION
We verify that LionCore specifies that and we verify that this is checked when validating languages.

Fix #174