### PR TITLE
Adopting LW Version dependant IDs for LionCore and LionCoreBuiltins

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/language/Concept.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Concept.java
@@ -1,7 +1,7 @@
 package io.lionweb.lioncore.java.language;
 
 import io.lionweb.lioncore.java.LionWebVersion;
-import io.lionweb.lioncore.java.model.ReferenceValue;
+import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
 import io.lionweb.lioncore.java.self.LionCore;
 import java.util.*;
 import javax.annotation.Nonnull;
@@ -118,7 +118,7 @@ public class Concept extends Classifier<Concept> {
 
   public void addImplementedInterface(@Nonnull Interface iface) {
     Objects.requireNonNull(iface, "Interface should not be null");
-    this.addReferenceMultipleValue("implements", new ReferenceValue(iface, iface.getName()));
+    this.addReferenceMultipleValue("implements", ClassifierInstanceUtils.referenceTo(iface));
   }
 
   // TODO should we verify the Concept does not extend itself, even indirectly?
@@ -126,7 +126,7 @@ public class Concept extends Classifier<Concept> {
     if (extended == null) {
       this.setReferenceSingleValue("extends", null);
     } else {
-      this.setReferenceSingleValue("extends", new ReferenceValue(extended, extended.getName()));
+      this.setReferenceSingleValue("extends", ClassifierInstanceUtils.referenceTo(extended));
     }
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Interface.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Interface.java
@@ -1,7 +1,7 @@
 package io.lionweb.lioncore.java.language;
 
 import io.lionweb.lioncore.java.LionWebVersion;
-import io.lionweb.lioncore.java.model.ReferenceValue;
+import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
 import io.lionweb.lioncore.java.self.LionCore;
 import java.util.*;
 import javax.annotation.Nonnull;
@@ -72,7 +72,7 @@ public class Interface extends Classifier<Interface> {
   public void addExtendedInterface(@Nonnull Interface extendedInterface) {
     Objects.requireNonNull(extendedInterface, "extendedInterface should not be null");
     this.addReferenceMultipleValue(
-        "extends", new ReferenceValue(extendedInterface, extendedInterface.getName()));
+        "extends", ClassifierInstanceUtils.referenceTo(extendedInterface));
   }
 
   @Nonnull

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Link.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Link.java
@@ -1,7 +1,7 @@
 package io.lionweb.lioncore.java.language;
 
 import io.lionweb.lioncore.java.LionWebVersion;
-import io.lionweb.lioncore.java.model.ReferenceValue;
+import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
 import io.lionweb.lioncore.java.model.impl.M3Node;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -73,7 +73,7 @@ public abstract class Link<T extends M3Node> extends Feature<T> {
     if (type == null) {
       this.setReferenceSingleValue("type", null);
     } else {
-      this.setReferenceSingleValue("type", new ReferenceValue(type, type.getName()));
+      this.setReferenceSingleValue("type", ClassifierInstanceUtils.referenceTo(type));
     }
     return (T) this;
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
@@ -14,7 +14,14 @@ public class LionCoreBuiltins extends Language {
   /** This is private to prevent instantiation and enforce the Singleton pattern. */
   private LionCoreBuiltins(@Nonnull LionWebVersion lionWebVersion) {
     super(lionWebVersion, "LionCore_builtins");
-    setID("LionCore-builtins");
+    final String versionIDSuffix;
+    if (lionWebVersion != LionWebVersion.v2023_1) {
+      versionIDSuffix = "-" + lionWebVersion.getVersionString().replaceAll("\\.", "_");
+    } else {
+      versionIDSuffix = "";
+    }
+
+    setID("LionCore-builtins" + versionIDSuffix);
     setKey("LionCore-builtins");
     setVersion(lionWebVersion.getVersionString());
     PrimitiveType string = new PrimitiveType(lionWebVersion, this, "String");
@@ -24,21 +31,23 @@ public class LionCoreBuiltins extends Language {
       new PrimitiveType(lionWebVersion, this, "JSON");
     }
 
-    Concept node = new Concept(lionWebVersion, this, "Node").setID("LionCore-builtins-Node");
+    Concept node =
+        new Concept(lionWebVersion, this, "Node").setID("LionCore-builtins-Node" + versionIDSuffix);
     node.setAbstract(true);
 
     Interface iNamed =
-        new Interface(lionWebVersion, this, "INamed").setID("LionCore-builtins-INamed");
+        new Interface(lionWebVersion, this, "INamed")
+            .setID("LionCore-builtins-INamed" + versionIDSuffix);
     iNamed.addFeature(
         Property.createRequired(lionWebVersion, "name", string)
-            .setID("LionCore-builtins-INamed-name")
+            .setID("LionCore-builtins-INamed-name" + versionIDSuffix)
             .setKey("LionCore-builtins-INamed-name"));
 
     this.getElements()
         .forEach(
             e -> {
               if (e.getID() == null) {
-                e.setID("LionCore-builtins-" + e.getName());
+                e.setID("LionCore-builtins-" + e.getName() + versionIDSuffix);
               }
               if (e.getKey() == null) {
                 e.setKey("LionCore-builtins-" + e.getName());

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
@@ -15,11 +15,10 @@ public class LionCoreBuiltins extends Language {
   private LionCoreBuiltins(@Nonnull LionWebVersion lionWebVersion) {
     super(lionWebVersion, "LionCore_builtins");
     final String versionIDSuffix;
-    if (lionWebVersion != LionWebVersion.v2023_1) {
-      versionIDSuffix = "-" + lionWebVersion.getVersionString().replaceAll("\\.", "_");
-    } else {
-      versionIDSuffix = "";
-    }
+    versionIDSuffix =
+        lionWebVersion != LionWebVersion.v2023_1
+            ? "-" + lionWebVersion.getVersionString().replaceAll("\\.", "_")
+            : "";
 
     setID("LionCore-builtins" + versionIDSuffix);
     setKey("LionCore-builtins");

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
@@ -17,7 +17,7 @@ public class LionCoreBuiltins extends Language {
     final String versionIDSuffix;
     versionIDSuffix =
         lionWebVersion != LionWebVersion.v2023_1
-            ? "-" + lionWebVersion.getVersionString().replaceAll("\\.", "_")
+            ? "-" + lionWebVersion.getVersionString().replaceAll("\\.", "-")
             : "";
 
     setID("LionCore-builtins" + versionIDSuffix);

--- a/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/LionCoreBuiltins.java
@@ -1,6 +1,7 @@
 package io.lionweb.lioncore.java.language;
 
 import io.lionweb.lioncore.java.LionWebVersion;
+import io.lionweb.lioncore.java.utils.IdUtils;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -17,7 +18,7 @@ public class LionCoreBuiltins extends Language {
     final String versionIDSuffix;
     versionIDSuffix =
         lionWebVersion != LionWebVersion.v2023_1
-            ? "-" + lionWebVersion.getVersionString().replaceAll("\\.", "-")
+            ? "-" + IdUtils.cleanString(lionWebVersion.getVersionString())
             : "";
 
     setID("LionCore-builtins" + versionIDSuffix);

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Property.java
@@ -1,7 +1,7 @@
 package io.lionweb.lioncore.java.language;
 
 import io.lionweb.lioncore.java.LionWebVersion;
-import io.lionweb.lioncore.java.model.ReferenceValue;
+import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
 import io.lionweb.lioncore.java.self.LionCore;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
 public class Property extends Feature<Property> {
 
   public static Property createOptional(
-      @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable DataType type) {
+      @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable DataType<?> type) {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     Property property = new Property(lionWebVersion, name, null);
     property.setOptional(true);
@@ -31,7 +31,7 @@ public class Property extends Feature<Property> {
     return property;
   }
 
-  public static Property createOptional(@Nullable String name, @Nullable DataType type) {
+  public static Property createOptional(@Nullable String name, @Nullable DataType<?> type) {
     Property property = new Property(name, null);
     property.setOptional(true);
     property.setType(type);
@@ -39,7 +39,7 @@ public class Property extends Feature<Property> {
   }
 
   public static Property createRequired(
-      @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable DataType type) {
+      @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable DataType<?> type) {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     Property property = new Property(lionWebVersion, name, null);
     property.setOptional(false);
@@ -47,7 +47,7 @@ public class Property extends Feature<Property> {
     return property;
   }
 
-  public static Property createRequired(@Nullable String name, @Nullable DataType type) {
+  public static Property createRequired(@Nullable String name, @Nullable DataType<?> type) {
     Property property = new Property(name, null);
     property.setOptional(false);
     property.setType(type);
@@ -120,7 +120,7 @@ public class Property extends Feature<Property> {
     if (type == null) {
       setReferenceSingleValue("type", null);
     } else {
-      setReferenceSingleValue("type", new ReferenceValue(type, type.getName()));
+      setReferenceSingleValue("type", ClassifierInstanceUtils.referenceTo(type));
     }
     return this;
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/ClassifierInstanceUtils.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/ClassifierInstanceUtils.java
@@ -1,9 +1,7 @@
 package io.lionweb.lioncore.java.model;
 
-import io.lionweb.lioncore.java.language.Classifier;
-import io.lionweb.lioncore.java.language.Containment;
-import io.lionweb.lioncore.java.language.Property;
-import io.lionweb.lioncore.java.language.Reference;
+import io.lionweb.lioncore.java.LionWebVersion;
+import io.lionweb.lioncore.java.language.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -251,5 +249,41 @@ public class ClassifierInstanceUtils {
     Objects.requireNonNull(child, "child should not be null");
     Containment containment = _this.getClassifier().getContainmentByName(containmentName);
     _this.addChild(containment, child);
+  }
+
+  public static ReferenceValue referenceTo(@Nonnull LanguageEntity<?> _this) {
+    // Unfortunately we cannot refer to LionCore and LionCoreBuiltins as this method get called
+    // during their initialization
+    if (_this.getLanguage() != null
+        && "LionCore_M3".equals(_this.getLanguage().getName())
+        && _this.getLionWebVersion() == LionWebVersion.v2024_1) {
+      return new ReferenceValue(_this, "LionWeb.LionCore_M3." + _this.getName());
+    } else if (_this.getLanguage() != null
+        && _this.getLanguage() instanceof LionCoreBuiltins
+        && _this.getLionWebVersion() == LionWebVersion.v2024_1) {
+      return new ReferenceValue(_this, "LionWeb.LionCore_builtins." + _this.getName());
+    } else {
+      return new ReferenceValue(_this, _this.getName());
+    }
+  }
+
+  public static boolean isBuiltinElement(@Nonnull Node _this) {
+    if (_this instanceof LanguageEntity<?>) {
+      return isBuiltinElement((LanguageEntity<?>) _this);
+    } else {
+      return false;
+    }
+  }
+
+  public static boolean isBuiltinElement(@Nonnull LanguageEntity<?> _this) {
+    if ("LionCore_M3".equals(_this.getLanguage().getName())
+        && _this.getLionWebVersion() == LionWebVersion.v2024_1) {
+      return true;
+    } else if (_this.getLanguage() instanceof LionCoreBuiltins
+        && _this.getLionWebVersion() == LionWebVersion.v2024_1) {
+      return true;
+    } else {
+      return false;
+    }
   }
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/ClassifierInstanceUtils.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/ClassifierInstanceUtils.java
@@ -1,5 +1,8 @@
 package io.lionweb.lioncore.java.model;
 
+import static io.lionweb.lioncore.java.utils.Autoresolve.LIONCOREBUILTINS_AUTORESOLVE_PREFIX;
+import static io.lionweb.lioncore.java.utils.Autoresolve.LIONCORE_AUTORESOLVE_PREFIX;
+
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.*;
 import java.util.*;
@@ -257,11 +260,11 @@ public class ClassifierInstanceUtils {
     if (_this.getLanguage() != null
         && "LionCore_M3".equals(_this.getLanguage().getName())
         && _this.getLionWebVersion() == LionWebVersion.v2024_1) {
-      return new ReferenceValue(_this, "LionWeb.LionCore_M3." + _this.getName());
+      return new ReferenceValue(_this, LIONCORE_AUTORESOLVE_PREFIX + _this.getName());
     } else if (_this.getLanguage() != null
         && _this.getLanguage() instanceof LionCoreBuiltins
         && _this.getLionWebVersion() == LionWebVersion.v2024_1) {
-      return new ReferenceValue(_this, "LionWeb.LionCore_builtins." + _this.getName());
+      return new ReferenceValue(_this, LIONCOREBUILTINS_AUTORESOLVE_PREFIX + _this.getName());
     } else {
       return new ReferenceValue(_this, _this.getName());
     }

--- a/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
@@ -164,9 +164,13 @@ public class LionCore {
 
   public static @Nonnull Language getInstance(@Nonnull LionWebVersion lionWebVersion) {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
+    String versionIDSuffix = "";
+    if (lionWebVersion != LionWebVersion.v2023_1) {
+      versionIDSuffix = "-" + lionWebVersion.getVersionString().replaceAll("\\.", "_");
+    }
     if (!INSTANCES.containsKey(lionWebVersion)) {
       final Language instance = new Language(lionWebVersion, "LionCore_M3");
-      instance.setID("-id-LionCore-M3");
+      instance.setID("-id-LionCore-M3" + versionIDSuffix);
       instance.setKey("LionCore-M3");
       instance.setVersion(lionWebVersion.getVersionString());
 
@@ -206,21 +210,24 @@ public class LionCore {
               lionWebVersion,
               "abstract",
               LionCoreBuiltins.getBoolean(lionWebVersion),
-              "-id-Concept-abstract"));
+              "-id-Concept-abstract" + versionIDSuffix));
       concept.addFeature(
           Property.createRequired(
               lionWebVersion,
               "partition",
               LionCoreBuiltins.getBoolean(lionWebVersion),
-              "-id-Concept-partition"));
+              "-id-Concept-partition" + versionIDSuffix));
       concept.addFeature(
-          Reference.createOptional(lionWebVersion, "extends", concept, "-id-Concept-extends"));
+          Reference.createOptional(
+              lionWebVersion, "extends", concept, "-id-Concept-extends" + versionIDSuffix));
       concept.addFeature(
-          Reference.createMultiple(lionWebVersion, "implements", iface, "-id-Concept-implements"));
+          Reference.createMultiple(
+              lionWebVersion, "implements", iface, "-id-Concept-implements" + versionIDSuffix));
 
       iface.setExtendedConcept(classifier);
       iface.addFeature(
-          Reference.createMultiple(lionWebVersion, "extends", iface, "-id-Interface-extends"));
+          Reference.createMultiple(
+              lionWebVersion, "extends", iface, "-id-Interface-extends" + versionIDSuffix));
 
       containment.setExtendedConcept(link);
 
@@ -230,7 +237,7 @@ public class LionCore {
       enumeration.setExtendedConcept(dataType);
       enumeration.addFeature(
           Containment.createMultiple(lionWebVersion, "literals", enumerationLiteral)
-              .setID("-id-Enumeration-literals"));
+              .setID("-id-Enumeration-literals" + versionIDSuffix));
 
       enumerationLiteral.addImplementedInterface(iKeyed);
 
@@ -241,13 +248,13 @@ public class LionCore {
               lionWebVersion,
               "optional",
               LionCoreBuiltins.getBoolean(lionWebVersion),
-              "-id-Feature-optional"));
+              "-id-Feature-optional" + versionIDSuffix));
 
       classifier.setAbstract(true);
       classifier.setExtendedConcept(languageEntity);
       classifier.addFeature(
           Containment.createMultiple(
-              lionWebVersion, "features", feature, "-id-Classifier-features"));
+              lionWebVersion, "features", feature, "-id-Classifier-features" + versionIDSuffix));
 
       link.setAbstract(true);
       link.setExtendedConcept(feature);
@@ -256,9 +263,10 @@ public class LionCore {
               lionWebVersion,
               "multiple",
               LionCoreBuiltins.getBoolean(lionWebVersion),
-              "-id-Link-multiple"));
+              "-id-Link-multiple" + versionIDSuffix));
       link.addFeature(
-          Reference.createRequired(lionWebVersion, "type", classifier, "-id-Link-type"));
+          Reference.createRequired(
+              lionWebVersion, "type", classifier, "-id-Link-type" + versionIDSuffix));
 
       language.setPartition(true);
       language.addImplementedInterface(iKeyed);
@@ -267,13 +275,16 @@ public class LionCore {
               lionWebVersion,
               "version",
               LionCoreBuiltins.getString(lionWebVersion),
-              "-id-Language-version"));
+              "-id-Language-version" + versionIDSuffix));
       language.addFeature(
           Reference.createMultiple(lionWebVersion, "dependsOn", language)
-              .setID("-id-Language-dependsOn"));
+              .setID("-id-Language-dependsOn" + versionIDSuffix));
       language.addFeature(
           Containment.createMultiple(
-                  lionWebVersion, "entities", languageEntity, "-id-Language-entities")
+                  lionWebVersion,
+                  "entities",
+                  languageEntity,
+                  "-id-Language-entities" + versionIDSuffix)
               .setKey("Language-entities"));
 
       languageEntity.setAbstract(true);
@@ -283,7 +294,8 @@ public class LionCore {
 
       property.setExtendedConcept(feature);
       property.addFeature(
-          Reference.createRequired(lionWebVersion, "type", dataType, "-id-Property-type")
+          Reference.createRequired(
+                  lionWebVersion, "type", dataType, "-id-Property-type" + versionIDSuffix)
               .setKey("Property-type"));
 
       reference.setExtendedConcept(link);
@@ -291,42 +303,49 @@ public class LionCore {
       iKeyed.addExtendedInterface(LionCoreBuiltins.getINamed(lionWebVersion));
       iKeyed.addFeature(
           Property.createRequired(lionWebVersion, "key", LionCoreBuiltins.getString(lionWebVersion))
-              .setID("-id-IKeyed-key"));
+              .setID("-id-IKeyed-key" + versionIDSuffix));
 
       annotation.setExtendedConcept(classifier);
       annotation.addFeature(
           Reference.createOptional(
-              lionWebVersion, "annotates", classifier, "-id-Annotation-annotates"));
+              lionWebVersion,
+              "annotates",
+              classifier,
+              "-id-Annotation-annotates" + versionIDSuffix));
       annotation.addFeature(
           Reference.createOptional(
-              lionWebVersion, "extends", annotation, "-id-Annotation-extends"));
+              lionWebVersion, "extends", annotation, "-id-Annotation-extends" + versionIDSuffix));
       annotation.addFeature(
           Reference.createMultiple(
-              lionWebVersion, "implements", iface, "-id-Annotation-implements"));
+              lionWebVersion, "implements", iface, "-id-Annotation-implements" + versionIDSuffix));
 
       if (lionWebVersion != LionWebVersion.v2023_1) {
         structuredDataType.setExtendedConcept(dataType);
         structuredDataType.addFeature(
             Containment.createMultiple(
-                    lionWebVersion, "fields", field, "-id-StructuredDataType-fields")
+                    lionWebVersion,
+                    "fields",
+                    field,
+                    "-id-StructuredDataType-fields" + versionIDSuffix)
                 .setOptional(false));
 
         field.addImplementedInterface(iKeyed);
         field.addFeature(
-            Reference.createRequired(lionWebVersion, "type", dataType, "-id-Field-type"));
+            Reference.createRequired(
+                lionWebVersion, "type", dataType, "-id-Field-type" + versionIDSuffix));
       }
 
-      checkIDs(instance);
+      checkIDs(instance, versionIDSuffix);
       INSTANCES.put(lionWebVersion, instance);
     }
     return INSTANCES.get(lionWebVersion);
   }
 
-  private static void checkIDs(@Nonnull M3Node node) {
+  private static void checkIDs(@Nonnull M3Node node, String versionIDSuffix) {
     if (node.getID() == null) {
       if (node instanceof NamespacedEntity) {
         NamespacedEntity namespacedEntity = (NamespacedEntity) node;
-        node.setID("-id-" + namespacedEntity.getName().replaceAll("\\.", "_"));
+        node.setID("-id-" + namespacedEntity.getName().replaceAll("\\.", "_") + versionIDSuffix);
         if (node instanceof IKeyed<?> && ((IKeyed<?>) node).getKey() == null) {
           ((IKeyed<?>) node).setKey(namespacedEntity.getName());
         }
@@ -347,7 +366,7 @@ public class LionCore {
     }
 
     // TODO To be changed once getChildren is implemented correctly
-    getChildrenHelper(node).forEach(c -> checkIDs(c));
+    getChildrenHelper(node).forEach(c -> checkIDs(c, versionIDSuffix));
   }
 
   private static List<? extends M3Node> getChildrenHelper(M3Node node) {

--- a/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
@@ -166,7 +166,7 @@ public class LionCore {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     String versionIDSuffix = "";
     if (lionWebVersion != LionWebVersion.v2023_1) {
-      versionIDSuffix = "-" + lionWebVersion.getVersionString().replaceAll("\\.", "_");
+      versionIDSuffix = "-" + lionWebVersion.getVersionString().replaceAll("\\.", "-");
     }
     if (!INSTANCES.containsKey(lionWebVersion)) {
       final Language instance = new Language(lionWebVersion, "LionCore_M3");

--- a/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/self/LionCore.java
@@ -3,6 +3,7 @@ package io.lionweb.lioncore.java.self;
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.impl.M3Node;
+import io.lionweb.lioncore.java.utils.IdUtils;
 import java.util.*;
 import javax.annotation.Nonnull;
 
@@ -166,7 +167,7 @@ public class LionCore {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     String versionIDSuffix = "";
     if (lionWebVersion != LionWebVersion.v2023_1) {
-      versionIDSuffix = "-" + lionWebVersion.getVersionString().replaceAll("\\.", "-");
+      versionIDSuffix = "-" + IdUtils.cleanString(lionWebVersion.getVersionString());
     }
     if (!INSTANCES.containsKey(lionWebVersion)) {
       final Language instance = new Language(lionWebVersion, "LionCore_M3");

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
@@ -2,13 +2,11 @@ package io.lionweb.lioncore.java.serialization;
 
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.api.ClassifierInstanceResolver;
-import io.lionweb.lioncore.java.language.Classifier;
-import io.lionweb.lioncore.java.language.Containment;
-import io.lionweb.lioncore.java.language.LionCoreBuiltins;
-import io.lionweb.lioncore.java.language.Reference;
+import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.ReferenceValue;
+import io.lionweb.lioncore.java.self.LionCore;
 import io.lionweb.lioncore.java.serialization.data.SerializedClassifierInstance;
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +25,6 @@ class NodePopulator {
 
   // If there are references to builtins which are broken, we will try to resolve them to this
   // version
-  private LionWebVersion autoResolveVersion;
   private Map<String, Node> autoResolveMap = new HashMap<>();
 
   NodePopulator(
@@ -49,14 +46,20 @@ class NodePopulator {
     this.serialization = serialization;
     this.classifierInstanceResolver = classifierInstanceResolver;
     this.deserializationStatus = deserializationStatus;
-    this.autoResolveVersion = autoResolveVersion;
 
     LionCoreBuiltins lionCoreBuiltins = LionCoreBuiltins.getInstance(autoResolveVersion);
     lionCoreBuiltins
         .getElements()
         .forEach(
             element -> {
-              autoResolveMap.put(element.getName(), element);
+              autoResolveMap.put("LionWeb.LionCore_builtins." + element.getName(), element);
+            });
+    Language lionCore = LionCore.getInstance(autoResolveVersion);
+    lionCore
+        .getElements()
+        .forEach(
+            element -> {
+              autoResolveMap.put("LionWeb.LionCore_M3." + element.getName(), element);
             });
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
@@ -127,7 +127,10 @@ class NodePopulator {
                       entry -> {
                         Node referred =
                             (Node) classifierInstanceResolver.resolve(entry.getReference());
-                        if (entry.getReference() != null && referred == null) {
+                        // Referred could be null either because entry.getReference() was null or
+                        // because it pointed
+                        // to a node we cannot find
+                        if (referred == null) {
 
                           // For LionCore Builtins, we want to automatically update references,
                           // using Resolve Info
@@ -135,20 +138,24 @@ class NodePopulator {
                           if (autoresolvedElement != null) {
                             referred = autoresolvedElement;
                           } else {
-
-                            switch (serialization.getUnavailableReferenceTargetPolicy()) {
-                              case NULL_REFERENCES:
-                                referred = null;
-                                break;
-                              case PROXY_NODES:
-                                referred = deserializationStatus.resolve(entry.getReference());
-                                break;
-                              case THROW_ERROR:
-                                throw new DeserializationException(
-                                    "Unable to resolve reference to "
-                                        + entry.getReference()
-                                        + " for feature "
-                                        + serializedReferenceValue.getMetaPointer());
+                            if (entry.getReference() != null) {
+                              // Here we are only interested in references there were set, but to
+                              // Nodes we cannot
+                              // find
+                              switch (serialization.getUnavailableReferenceTargetPolicy()) {
+                                case NULL_REFERENCES:
+                                  referred = null;
+                                  break;
+                                case PROXY_NODES:
+                                  referred = deserializationStatus.resolve(entry.getReference());
+                                  break;
+                                case THROW_ERROR:
+                                  throw new DeserializationException(
+                                      "Unable to resolve reference to "
+                                          + entry.getReference()
+                                          + " for feature "
+                                          + serializedReferenceValue.getMetaPointer());
+                              }
                             }
                           }
                         }

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
@@ -127,36 +127,27 @@ class NodePopulator {
                       entry -> {
                         Node referred =
                             (Node) classifierInstanceResolver.resolve(entry.getReference());
-                        // Referred could be null either because entry.getReference() was null or
-                        // because it pointed
-                        // to a node we cannot find
-                        if (referred == null) {
 
-                          // For LionCore Builtins, we want to automatically update references,
-                          // using Resolve Info
-                          Node autoresolvedElement = autoResolveMap.get(entry.getResolveInfo());
-                          if (autoresolvedElement != null) {
-                            referred = autoresolvedElement;
-                          } else {
-                            if (entry.getReference() != null) {
-                              // Here we are only interested in references there were set, but to
-                              // Nodes we cannot
-                              // find
-                              switch (serialization.getUnavailableReferenceTargetPolicy()) {
-                                case NULL_REFERENCES:
-                                  referred = null;
-                                  break;
-                                case PROXY_NODES:
-                                  referred = deserializationStatus.resolve(entry.getReference());
-                                  break;
-                                case THROW_ERROR:
-                                  throw new DeserializationException(
-                                      "Unable to resolve reference to "
-                                          + entry.getReference()
-                                          + " for feature "
-                                          + serializedReferenceValue.getMetaPointer());
-                              }
-                            }
+                        if (entry.getReference() == null) {
+                          referred = autoResolveMap.get(entry.getResolveInfo());
+                        }
+                        if (referred == null && entry.getReference() != null) {
+                          // Here we are only interested in references there were set, but to
+                          // Nodes we cannot
+                          // find
+                          switch (serialization.getUnavailableReferenceTargetPolicy()) {
+                            case NULL_REFERENCES:
+                              referred = null;
+                              break;
+                            case PROXY_NODES:
+                              referred = deserializationStatus.resolve(entry.getReference());
+                              break;
+                            case THROW_ERROR:
+                              throw new DeserializationException(
+                                  "Unable to resolve reference to "
+                                      + entry.getReference()
+                                      + " for feature "
+                                      + serializedReferenceValue.getMetaPointer());
                           }
                         }
                         ReferenceValue referenceValue =

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/NodePopulator.java
@@ -1,5 +1,8 @@
 package io.lionweb.lioncore.java.serialization;
 
+import static io.lionweb.lioncore.java.utils.Autoresolve.LIONCOREBUILTINS_AUTORESOLVE_PREFIX;
+import static io.lionweb.lioncore.java.utils.Autoresolve.LIONCORE_AUTORESOLVE_PREFIX;
+
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.api.ClassifierInstanceResolver;
 import io.lionweb.lioncore.java.language.*;
@@ -54,14 +57,14 @@ class NodePopulator {
             element -> {
               // See
               // https://lionweb.io/specification/2024.1/metametamodel/metametamodel.html#predefined-builtins-keys
-              autoResolveMap.put("LionWeb.LionCore_builtins." + element.getName(), element);
+              autoResolveMap.put(LIONCOREBUILTINS_AUTORESOLVE_PREFIX + element.getName(), element);
             });
     Language lionCore = LionCore.getInstance(autoResolveVersion);
     lionCore
         .getElements()
         .forEach(
             element -> {
-              autoResolveMap.put("LionWeb.LionCore_M3." + element.getName(), element);
+              autoResolveMap.put(LIONCORE_AUTORESOLVE_PREFIX + element.getName(), element);
             });
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/utils/Autoresolve.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/Autoresolve.java
@@ -1,0 +1,6 @@
+package io.lionweb.lioncore.java.utils;
+
+public class Autoresolve {
+  public static final String LIONCORE_AUTORESOLVE_PREFIX = "LionWeb.LionCore_M3.";
+  public static final String LIONCOREBUILTINS_AUTORESOLVE_PREFIX = "LionWeb.LionCore_builtins.";
+}

--- a/core/src/main/java/io/lionweb/lioncore/java/utils/IdUtils.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/IdUtils.java
@@ -1,0 +1,11 @@
+package io.lionweb.lioncore.java.utils;
+
+public class IdUtils {
+  private IdUtils() {
+    // Prevent instantiation
+  }
+
+  public static String cleanString(String string) {
+    return string.replaceAll("\\.", "-");
+  }
+}

--- a/core/src/main/java/io/lionweb/lioncore/java/utils/LanguageValidator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/LanguageValidator.java
@@ -33,8 +33,14 @@ public class LanguageValidator extends Validator<Language> {
                     .checkForError(feature.getName() == null, "Simple name not set", feature)
                     .checkForError(feature.getContainer() == null, "Container not set", feature)
                     .checkForError(
-                        feature.getContainer() != null && feature.getContainer() != classifier,
-                        "Features container not set correctly",
+                        feature.getContainer() != null
+                            && ((Node) feature.getContainer()).getID() != null
+                            && !((Node) feature.getContainer()).getID().equals(classifier.getID()),
+                        "Features container not set correctly: set to "
+                            + feature.getContainer()
+                            + " when "
+                            + classifier
+                            + " was expected",
                         feature));
     validateNamesAreUnique(classifier.getFeatures(), result);
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/utils/Naming.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/Naming.java
@@ -3,6 +3,11 @@ package io.lionweb.lioncore.java.utils;
 import java.util.regex.Pattern;
 
 public class Naming {
+
+  private Naming() {
+    // Prevent instantiation
+  }
+
   public static void validateQualifiedName(String qualifiedName) {
     if (!Pattern.matches("[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*", qualifiedName)) {
       throw new InvalidName("qualified name", qualifiedName);

--- a/core/src/test/java/io/lionweb/lioncore/java/language/BuiltinIDsAndKeysTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/language/BuiltinIDsAndKeysTest.java
@@ -1,5 +1,8 @@
 package io.lionweb.lioncore.java.language;
 
+import static io.lionweb.lioncore.java.LionWebVersion.v2023_1;
+import static io.lionweb.lioncore.java.LionWebVersion.v2024_1;
+
 import io.lionweb.lioncore.java.self.LionCore;
 import org.junit.Assert;
 import org.junit.Test;
@@ -7,62 +10,141 @@ import org.junit.Test;
 public class BuiltinIDsAndKeysTest {
 
   @Test
-  public void M3ElementsHasExpectedIDs() {
-    Assert.assertEquals("-id-Concept", LionCore.getConcept().getID());
+  public void M3ElementsHasExpectedIDsIn2023_1() {
+    Assert.assertEquals("-id-Concept", LionCore.getConcept(v2023_1).getID());
     Assert.assertEquals(
-        "-id-Concept-abstract", LionCore.getConcept().getPropertyByName("abstract").getID());
+        "-id-Concept-abstract", LionCore.getConcept(v2023_1).getPropertyByName("abstract").getID());
     Assert.assertEquals(
-        "-id-Concept-extends", LionCore.getConcept().getReferenceByName("extends").getID());
+        "-id-Concept-extends", LionCore.getConcept(v2023_1).getReferenceByName("extends").getID());
     Assert.assertEquals(
-        "-id-Concept-implements", LionCore.getConcept().getReferenceByName("implements").getID());
+        "-id-Concept-implements",
+        LionCore.getConcept(v2023_1).getReferenceByName("implements").getID());
 
-    Assert.assertEquals("-id-Interface", LionCore.getInterface().getID());
+    Assert.assertEquals("-id-Interface", LionCore.getInterface(v2023_1).getID());
     Assert.assertEquals(
-        "-id-Interface-extends", LionCore.getInterface().getReferenceByName("extends").getID());
+        "-id-Interface-extends",
+        LionCore.getInterface(v2023_1).getReferenceByName("extends").getID());
 
-    Assert.assertEquals("-id-Containment", LionCore.getContainment().getID());
+    Assert.assertEquals("-id-Containment", LionCore.getContainment(v2023_1).getID());
 
-    Assert.assertEquals("-id-DataType", LionCore.getDataType().getID());
+    Assert.assertEquals("-id-DataType", LionCore.getDataType(v2023_1).getID());
 
-    Assert.assertEquals("-id-Enumeration", LionCore.getEnumeration().getID());
+    Assert.assertEquals("-id-Enumeration", LionCore.getEnumeration(v2023_1).getID());
     Assert.assertEquals(
         "-id-Enumeration-literals",
-        LionCore.getEnumeration().getContainmentByName("literals").getID());
+        LionCore.getEnumeration(v2023_1).getContainmentByName("literals").getID());
 
-    Assert.assertEquals("-id-EnumerationLiteral", LionCore.getEnumerationLiteral().getID());
+    Assert.assertEquals("-id-EnumerationLiteral", LionCore.getEnumerationLiteral(v2023_1).getID());
 
-    Assert.assertEquals("-id-Feature", LionCore.getFeature().getID());
+    Assert.assertEquals("-id-Feature", LionCore.getFeature(v2023_1).getID());
     Assert.assertEquals(
-        "-id-Feature-optional", LionCore.getFeature().getPropertyByName("optional").getID());
+        "-id-Feature-optional", LionCore.getFeature(v2023_1).getPropertyByName("optional").getID());
 
-    Assert.assertEquals("-id-Classifier", LionCore.getClassifier().getID());
+    Assert.assertEquals("-id-Classifier", LionCore.getClassifier(v2023_1).getID());
     Assert.assertEquals(
         "-id-Classifier-features",
-        LionCore.getClassifier().getContainmentByName("features").getID());
+        LionCore.getClassifier(v2023_1).getContainmentByName("features").getID());
 
-    Assert.assertEquals("-id-Link", LionCore.getLink().getID());
+    Assert.assertEquals("-id-Link", LionCore.getLink(v2023_1).getID());
     Assert.assertEquals(
-        "-id-Link-multiple", LionCore.getLink().getPropertyByName("multiple").getID());
-    Assert.assertEquals("-id-Link-type", LionCore.getLink().getReferenceByName("type").getID());
-
-    Assert.assertEquals("-id-Language", LionCore.getLanguage().getID());
+        "-id-Link-multiple", LionCore.getLink(v2023_1).getPropertyByName("multiple").getID());
     Assert.assertEquals(
-        "LionCore-builtins-INamed-name", LionCore.getLanguage().getPropertyByName("name").getID());
-    Assert.assertEquals("-id-IKeyed-key", LionCore.getLanguage().getPropertyByName("key").getID());
+        "-id-Link-type", LionCore.getLink(v2023_1).getReferenceByName("type").getID());
+
+    Assert.assertEquals("-id-Language", LionCore.getLanguage(v2023_1).getID());
     Assert.assertEquals(
-        "-id-Language-dependsOn", LionCore.getLanguage().getReferenceByName("dependsOn").getID());
+        "LionCore-builtins-INamed-name",
+        LionCore.getLanguage(v2023_1).getPropertyByName("name").getID());
     Assert.assertEquals(
-        "-id-Language-entities", LionCore.getLanguage().getContainmentByName("entities").getID());
-
-    Assert.assertEquals("-id-LanguageEntity", LionCore.getLanguageEntity().getID());
-
-    Assert.assertEquals("-id-PrimitiveType", LionCore.getPrimitiveType().getID());
-
-    Assert.assertEquals("-id-Property", LionCore.getProperty().getID());
+        "-id-IKeyed-key", LionCore.getLanguage(v2023_1).getPropertyByName("key").getID());
     Assert.assertEquals(
-        "-id-Property-type", LionCore.getProperty().getReferenceByName("type").getID());
+        "-id-Language-dependsOn",
+        LionCore.getLanguage(v2023_1).getReferenceByName("dependsOn").getID());
+    Assert.assertEquals(
+        "-id-Language-entities",
+        LionCore.getLanguage(v2023_1).getContainmentByName("entities").getID());
 
-    Assert.assertEquals("-id-Reference", LionCore.getReference().getID());
+    Assert.assertEquals("-id-LanguageEntity", LionCore.getLanguageEntity(v2023_1).getID());
+
+    Assert.assertEquals("-id-PrimitiveType", LionCore.getPrimitiveType(v2023_1).getID());
+
+    Assert.assertEquals("-id-Property", LionCore.getProperty(v2023_1).getID());
+    Assert.assertEquals(
+        "-id-Property-type", LionCore.getProperty(v2023_1).getReferenceByName("type").getID());
+
+    Assert.assertEquals("-id-Reference", LionCore.getReference(v2023_1).getID());
+  }
+
+  @Test
+  public void M3ElementsHasExpectedIDsIn2024_1() {
+    Assert.assertEquals("-id-Concept-2024_1", LionCore.getConcept(v2024_1).getID());
+    Assert.assertEquals(
+        "-id-Concept-abstract-2024_1",
+        LionCore.getConcept(v2024_1).getPropertyByName("abstract").getID());
+    Assert.assertEquals(
+        "-id-Concept-extends-2024_1",
+        LionCore.getConcept(v2024_1).getReferenceByName("extends").getID());
+    Assert.assertEquals(
+        "-id-Concept-implements-2024_1",
+        LionCore.getConcept(v2024_1).getReferenceByName("implements").getID());
+
+    Assert.assertEquals("-id-Interface-2024_1", LionCore.getInterface(v2024_1).getID());
+    Assert.assertEquals(
+        "-id-Interface-extends-2024_1",
+        LionCore.getInterface(v2024_1).getReferenceByName("extends").getID());
+
+    Assert.assertEquals("-id-Containment-2024_1", LionCore.getContainment(v2024_1).getID());
+
+    Assert.assertEquals("-id-DataType-2024_1", LionCore.getDataType(v2024_1).getID());
+
+    Assert.assertEquals("-id-Enumeration-2024_1", LionCore.getEnumeration(v2024_1).getID());
+    Assert.assertEquals(
+        "-id-Enumeration-literals-2024_1",
+        LionCore.getEnumeration(v2024_1).getContainmentByName("literals").getID());
+
+    Assert.assertEquals(
+        "-id-EnumerationLiteral-2024_1", LionCore.getEnumerationLiteral(v2024_1).getID());
+
+    Assert.assertEquals("-id-Feature-2024_1", LionCore.getFeature(v2024_1).getID());
+    Assert.assertEquals(
+        "-id-Feature-optional-2024_1",
+        LionCore.getFeature(v2024_1).getPropertyByName("optional").getID());
+
+    Assert.assertEquals("-id-Classifier-2024_1", LionCore.getClassifier(v2024_1).getID());
+    Assert.assertEquals(
+        "-id-Classifier-features-2024_1",
+        LionCore.getClassifier(v2024_1).getContainmentByName("features").getID());
+
+    Assert.assertEquals("-id-Link-2024_1", LionCore.getLink(v2024_1).getID());
+    Assert.assertEquals(
+        "-id-Link-multiple-2024_1",
+        LionCore.getLink(v2024_1).getPropertyByName("multiple").getID());
+    Assert.assertEquals(
+        "-id-Link-type-2024_1", LionCore.getLink(v2024_1).getReferenceByName("type").getID());
+
+    Assert.assertEquals("-id-Language-2024_1", LionCore.getLanguage(v2024_1).getID());
+    Assert.assertEquals(
+        "LionCore-builtins-INamed-name-2024_1",
+        LionCore.getLanguage(v2024_1).getPropertyByName("name").getID());
+    Assert.assertEquals(
+        "-id-IKeyed-key-2024_1", LionCore.getLanguage(v2024_1).getPropertyByName("key").getID());
+    Assert.assertEquals(
+        "-id-Language-dependsOn-2024_1",
+        LionCore.getLanguage(v2024_1).getReferenceByName("dependsOn").getID());
+    Assert.assertEquals(
+        "-id-Language-entities-2024_1",
+        LionCore.getLanguage(v2024_1).getContainmentByName("entities").getID());
+
+    Assert.assertEquals("-id-LanguageEntity-2024_1", LionCore.getLanguageEntity(v2024_1).getID());
+
+    Assert.assertEquals("-id-PrimitiveType-2024_1", LionCore.getPrimitiveType(v2024_1).getID());
+
+    Assert.assertEquals("-id-Property-2024_1", LionCore.getProperty(v2024_1).getID());
+    Assert.assertEquals(
+        "-id-Property-type-2024_1",
+        LionCore.getProperty(v2024_1).getReferenceByName("type").getID());
+
+    Assert.assertEquals("-id-Reference-2024_1", LionCore.getReference(v2024_1).getID());
   }
 
   @Test

--- a/core/src/test/java/io/lionweb/lioncore/java/language/BuiltinIDsAndKeysTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/language/BuiltinIDsAndKeysTest.java
@@ -77,74 +77,74 @@ public class BuiltinIDsAndKeysTest {
 
   @Test
   public void M3ElementsHasExpectedIDsIn2024_1() {
-    Assert.assertEquals("-id-Concept-2024_1", LionCore.getConcept(v2024_1).getID());
+    Assert.assertEquals("-id-Concept-2024-1", LionCore.getConcept(v2024_1).getID());
     Assert.assertEquals(
-        "-id-Concept-abstract-2024_1",
+        "-id-Concept-abstract-2024-1",
         LionCore.getConcept(v2024_1).getPropertyByName("abstract").getID());
     Assert.assertEquals(
-        "-id-Concept-extends-2024_1",
+        "-id-Concept-extends-2024-1",
         LionCore.getConcept(v2024_1).getReferenceByName("extends").getID());
     Assert.assertEquals(
-        "-id-Concept-implements-2024_1",
+        "-id-Concept-implements-2024-1",
         LionCore.getConcept(v2024_1).getReferenceByName("implements").getID());
 
-    Assert.assertEquals("-id-Interface-2024_1", LionCore.getInterface(v2024_1).getID());
+    Assert.assertEquals("-id-Interface-2024-1", LionCore.getInterface(v2024_1).getID());
     Assert.assertEquals(
-        "-id-Interface-extends-2024_1",
+        "-id-Interface-extends-2024-1",
         LionCore.getInterface(v2024_1).getReferenceByName("extends").getID());
 
-    Assert.assertEquals("-id-Containment-2024_1", LionCore.getContainment(v2024_1).getID());
+    Assert.assertEquals("-id-Containment-2024-1", LionCore.getContainment(v2024_1).getID());
 
-    Assert.assertEquals("-id-DataType-2024_1", LionCore.getDataType(v2024_1).getID());
+    Assert.assertEquals("-id-DataType-2024-1", LionCore.getDataType(v2024_1).getID());
 
-    Assert.assertEquals("-id-Enumeration-2024_1", LionCore.getEnumeration(v2024_1).getID());
+    Assert.assertEquals("-id-Enumeration-2024-1", LionCore.getEnumeration(v2024_1).getID());
     Assert.assertEquals(
-        "-id-Enumeration-literals-2024_1",
+        "-id-Enumeration-literals-2024-1",
         LionCore.getEnumeration(v2024_1).getContainmentByName("literals").getID());
 
     Assert.assertEquals(
-        "-id-EnumerationLiteral-2024_1", LionCore.getEnumerationLiteral(v2024_1).getID());
+        "-id-EnumerationLiteral-2024-1", LionCore.getEnumerationLiteral(v2024_1).getID());
 
-    Assert.assertEquals("-id-Feature-2024_1", LionCore.getFeature(v2024_1).getID());
+    Assert.assertEquals("-id-Feature-2024-1", LionCore.getFeature(v2024_1).getID());
     Assert.assertEquals(
-        "-id-Feature-optional-2024_1",
+        "-id-Feature-optional-2024-1",
         LionCore.getFeature(v2024_1).getPropertyByName("optional").getID());
 
-    Assert.assertEquals("-id-Classifier-2024_1", LionCore.getClassifier(v2024_1).getID());
+    Assert.assertEquals("-id-Classifier-2024-1", LionCore.getClassifier(v2024_1).getID());
     Assert.assertEquals(
-        "-id-Classifier-features-2024_1",
+        "-id-Classifier-features-2024-1",
         LionCore.getClassifier(v2024_1).getContainmentByName("features").getID());
 
-    Assert.assertEquals("-id-Link-2024_1", LionCore.getLink(v2024_1).getID());
+    Assert.assertEquals("-id-Link-2024-1", LionCore.getLink(v2024_1).getID());
     Assert.assertEquals(
-        "-id-Link-multiple-2024_1",
+        "-id-Link-multiple-2024-1",
         LionCore.getLink(v2024_1).getPropertyByName("multiple").getID());
     Assert.assertEquals(
-        "-id-Link-type-2024_1", LionCore.getLink(v2024_1).getReferenceByName("type").getID());
+        "-id-Link-type-2024-1", LionCore.getLink(v2024_1).getReferenceByName("type").getID());
 
-    Assert.assertEquals("-id-Language-2024_1", LionCore.getLanguage(v2024_1).getID());
+    Assert.assertEquals("-id-Language-2024-1", LionCore.getLanguage(v2024_1).getID());
     Assert.assertEquals(
-        "LionCore-builtins-INamed-name-2024_1",
+        "LionCore-builtins-INamed-name-2024-1",
         LionCore.getLanguage(v2024_1).getPropertyByName("name").getID());
     Assert.assertEquals(
-        "-id-IKeyed-key-2024_1", LionCore.getLanguage(v2024_1).getPropertyByName("key").getID());
+        "-id-IKeyed-key-2024-1", LionCore.getLanguage(v2024_1).getPropertyByName("key").getID());
     Assert.assertEquals(
-        "-id-Language-dependsOn-2024_1",
+        "-id-Language-dependsOn-2024-1",
         LionCore.getLanguage(v2024_1).getReferenceByName("dependsOn").getID());
     Assert.assertEquals(
-        "-id-Language-entities-2024_1",
+        "-id-Language-entities-2024-1",
         LionCore.getLanguage(v2024_1).getContainmentByName("entities").getID());
 
-    Assert.assertEquals("-id-LanguageEntity-2024_1", LionCore.getLanguageEntity(v2024_1).getID());
+    Assert.assertEquals("-id-LanguageEntity-2024-1", LionCore.getLanguageEntity(v2024_1).getID());
 
-    Assert.assertEquals("-id-PrimitiveType-2024_1", LionCore.getPrimitiveType(v2024_1).getID());
+    Assert.assertEquals("-id-PrimitiveType-2024-1", LionCore.getPrimitiveType(v2024_1).getID());
 
-    Assert.assertEquals("-id-Property-2024_1", LionCore.getProperty(v2024_1).getID());
+    Assert.assertEquals("-id-Property-2024-1", LionCore.getProperty(v2024_1).getID());
     Assert.assertEquals(
-        "-id-Property-type-2024_1",
+        "-id-Property-type-2024-1",
         LionCore.getProperty(v2024_1).getReferenceByName("type").getID());
 
-    Assert.assertEquals("-id-Reference-2024_1", LionCore.getReference(v2024_1).getID());
+    Assert.assertEquals("-id-Reference-2024-1", LionCore.getReference(v2024_1).getID());
   }
 
   @Test

--- a/core/src/test/java/io/lionweb/lioncore/java/language/LionCoreBuiltinsTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/language/LionCoreBuiltinsTest.java
@@ -32,13 +32,13 @@ public class LionCoreBuiltinsTest {
   @Test
   public void primitiveTypesHaveAgreedIDsv2024() {
     assertEquals(
-        "LionCore-builtins-String-2024_1",
+        "LionCore-builtins-String-2024-1",
         LionCoreBuiltins.getString(LionWebVersion.v2024_1).getID());
     assertEquals(
-        "LionCore-builtins-Boolean-2024_1",
+        "LionCore-builtins-Boolean-2024-1",
         LionCoreBuiltins.getBoolean(LionWebVersion.v2024_1).getID());
     assertEquals(
-        "LionCore-builtins-Integer-2024_1",
+        "LionCore-builtins-Integer-2024-1",
         LionCoreBuiltins.getInteger(LionWebVersion.v2024_1).getID());
     assertThrows(
         IllegalArgumentException.class, () -> LionCoreBuiltins.getJSON(LionWebVersion.v2024_1));

--- a/core/src/test/java/io/lionweb/lioncore/java/language/LionCoreBuiltinsTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/language/LionCoreBuiltinsTest.java
@@ -32,11 +32,14 @@ public class LionCoreBuiltinsTest {
   @Test
   public void primitiveTypesHaveAgreedIDsv2024() {
     assertEquals(
-        "LionCore-builtins-String", LionCoreBuiltins.getString(LionWebVersion.v2024_1).getID());
+        "LionCore-builtins-String-2024_1",
+        LionCoreBuiltins.getString(LionWebVersion.v2024_1).getID());
     assertEquals(
-        "LionCore-builtins-Boolean", LionCoreBuiltins.getBoolean(LionWebVersion.v2024_1).getID());
+        "LionCore-builtins-Boolean-2024_1",
+        LionCoreBuiltins.getBoolean(LionWebVersion.v2024_1).getID());
     assertEquals(
-        "LionCore-builtins-Integer", LionCoreBuiltins.getInteger(LionWebVersion.v2024_1).getID());
+        "LionCore-builtins-Integer-2024_1",
+        LionCoreBuiltins.getInteger(LionWebVersion.v2024_1).getID());
     assertThrows(
         IllegalArgumentException.class, () -> LionCoreBuiltins.getJSON(LionWebVersion.v2024_1));
   }

--- a/core/src/test/java/io/lionweb/lioncore/java/self/CorrespondanceWithDocumentationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/self/CorrespondanceWithDocumentationTest.java
@@ -20,7 +20,10 @@ public class CorrespondanceWithDocumentationTest {
       "86118d62d20edd3bd8973ef2af64690f97a41d8d";
 
   private static final String SPECIFICATION_2024_1_COMMIT_CONSIDERED =
-      "61e3f929afb57c94143c20906f94a682777fe0c8";
+      "980dd6a8ba5fc4b97d3b53233c09e2bda090c347";
+
+  private static final String SPECIFICATION_2023_1_PATH = "/metametamodel/lioncore.json";
+  private static final String SPECIFICATION_2024_1_PATH = "/2024.1/metametamodel/lioncore.json";
 
   @Test
   public void lioncoreIsTheSameAsInTheOrganizationRepo2023_1() throws IOException {
@@ -30,7 +33,7 @@ public class CorrespondanceWithDocumentationTest {
         new URL(
             "https://raw.githubusercontent.com/LionWeb-io/specification/"
                 + SPECIFICATION_2023_1_COMMIT_CONSIDERED
-                + "/metametamodel/lioncore.json");
+                + SPECIFICATION_2023_1_PATH);
     List<Node> nodes = jsonSer.deserializeToNodes(url);
 
     Language deserializedLioncore = (Language) nodes.get(0);
@@ -54,7 +57,7 @@ public class CorrespondanceWithDocumentationTest {
         new URL(
             "https://raw.githubusercontent.com/LionWeb-io/specification/"
                 + SPECIFICATION_2024_1_COMMIT_CONSIDERED
-                + "/metametamodel/lioncore.json");
+                + SPECIFICATION_2024_1_PATH);
     List<Node> nodes = jsonSer.deserializeToNodes(url);
 
     Language deserializedLioncore = (Language) nodes.get(0);

--- a/core/src/test/java/io/lionweb/lioncore/java/self/CorrespondanceWithDocumentationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/self/CorrespondanceWithDocumentationTest.java
@@ -17,10 +17,10 @@ import org.junit.Test;
 public class CorrespondanceWithDocumentationTest {
 
   private static final String SPECIFICATION_2023_1_COMMIT_CONSIDERED =
-      "cf17074aad9552a78100b7ccead395a1eeba5fca";
+      "73b1c88e8e8f365c76bcf13340da310ed74d5f8e";
 
   private static final String SPECIFICATION_2024_1_COMMIT_CONSIDERED =
-      "cf17074aad9552a78100b7ccead395a1eeba5fca";
+      "73b1c88e8e8f365c76bcf13340da310ed74d5f8e";
 
   private static final String SPECIFICATION_LIONCORE_2023_1_PATH =
       "/2023.1/metametamodel/lioncore.json";

--- a/core/src/test/java/io/lionweb/lioncore/java/self/CorrespondanceWithDocumentationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/self/CorrespondanceWithDocumentationTest.java
@@ -17,13 +17,19 @@ import org.junit.Test;
 public class CorrespondanceWithDocumentationTest {
 
   private static final String SPECIFICATION_2023_1_COMMIT_CONSIDERED =
-      "86118d62d20edd3bd8973ef2af64690f97a41d8d";
+      "cf17074aad9552a78100b7ccead395a1eeba5fca";
 
   private static final String SPECIFICATION_2024_1_COMMIT_CONSIDERED =
-      "980dd6a8ba5fc4b97d3b53233c09e2bda090c347";
+      "cf17074aad9552a78100b7ccead395a1eeba5fca";
 
-  private static final String SPECIFICATION_2023_1_PATH = "/metametamodel/lioncore.json";
-  private static final String SPECIFICATION_2024_1_PATH = "/2024.1/metametamodel/lioncore.json";
+  private static final String SPECIFICATION_LIONCORE_2023_1_PATH =
+      "/2023.1/metametamodel/lioncore.json";
+  private static final String SPECIFICATION_LIONCORE_2024_1_PATH =
+      "/2024.1/metametamodel/lioncore.json";
+  private static final String SPECIFICATION_LIONCOREBUILTINS_2023_1_PATH =
+      "/2023.1/metametamodel/builtins.json";
+  private static final String SPECIFICATION_LIONCOREBUILTINS_2024_1_PATH =
+      "/2024.1/metametamodel/builtins.json";
 
   @Test
   public void lioncoreIsTheSameAsInTheOrganizationRepo2023_1() throws IOException {
@@ -33,7 +39,7 @@ public class CorrespondanceWithDocumentationTest {
         new URL(
             "https://raw.githubusercontent.com/LionWeb-io/specification/"
                 + SPECIFICATION_2023_1_COMMIT_CONSIDERED
-                + SPECIFICATION_2023_1_PATH);
+                + SPECIFICATION_LIONCORE_2023_1_PATH);
     List<Node> nodes = jsonSer.deserializeToNodes(url);
 
     Language deserializedLioncore = (Language) nodes.get(0);
@@ -57,7 +63,7 @@ public class CorrespondanceWithDocumentationTest {
         new URL(
             "https://raw.githubusercontent.com/LionWeb-io/specification/"
                 + SPECIFICATION_2024_1_COMMIT_CONSIDERED
-                + SPECIFICATION_2024_1_PATH);
+                + SPECIFICATION_LIONCORE_2024_1_PATH);
     List<Node> nodes = jsonSer.deserializeToNodes(url);
 
     Language deserializedLioncore = (Language) nodes.get(0);
@@ -79,7 +85,7 @@ public class CorrespondanceWithDocumentationTest {
         new URL(
             "https://raw.githubusercontent.com/LionWeb-io/specification/"
                 + SPECIFICATION_2023_1_COMMIT_CONSIDERED
-                + "/metametamodel/builtins.json");
+                + SPECIFICATION_LIONCOREBUILTINS_2023_1_PATH);
     List<Node> nodes = jsonSer.deserializeToNodes(url);
 
     Language deserializedBuiltins = (Language) nodes.get(0);
@@ -101,7 +107,7 @@ public class CorrespondanceWithDocumentationTest {
         new URL(
             "https://raw.githubusercontent.com/LionWeb-io/specification/"
                 + SPECIFICATION_2024_1_COMMIT_CONSIDERED
-                + "/metametamodel/builtins.json");
+                + SPECIFICATION_LIONCOREBUILTINS_2024_1_PATH);
     List<Node> nodes = jsonSer.deserializeToNodes(url);
 
     Language deserializedBuiltins = (Language) nodes.get(0);

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/NodePopulatorTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/NodePopulatorTest.java
@@ -1,6 +1,7 @@
 package io.lionweb.lioncore.java.serialization;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.LionCoreBuiltins;
@@ -50,7 +51,7 @@ public class NodePopulatorTest {
                     + "          \"targets\": [\n"
                     + "            {\n"
                     + "              \"resolveInfo\": \"Boolean\",\n"
-                    + "              \"reference\": \"LionCore-builtins-Boolean\"\n"
+                    + "              \"reference\": \"LionCore-builtins-Boolean-2024_1\"\n"
                     + "            }\n"
                     + "          ]\n"
                     + "        }\n"
@@ -105,7 +106,9 @@ public class NodePopulatorTest {
                     + "          \"targets\": [\n"
                     + "            {\n"
                     + "              \"resolveInfo\": \"Boolean\",\n"
-                    + "              \"reference\": \"LionCore-builtins-Boolean-for-some-version-different-than-the-one-we-are-using\"\n"
+                    + "              \"reference\": \""
+                    + LionCoreBuiltins.getInstance(LionWebVersion.v2023_1)
+                    + "\"\n"
                     + "            }\n"
                     + "          ]\n"
                     + "        }\n"
@@ -116,12 +119,13 @@ public class NodePopulatorTest {
                     + "}");
     SerializedClassifierInstance serializedNode = chunk.getClassifierInstances().get(0);
 
-    DynamicNode node = new DynamicNode("my-node", LionCore.getProperty());
-    nodePopulator.populateClassifierInstance(node, serializedNode);
-
-    assertEquals(
-        LionCoreBuiltins.getBoolean(),
-        ClassifierInstanceUtils.getOnlyReferenceValueByReferenceName(node, "type").getReferred());
+    try {
+      DynamicNode node = new DynamicNode("my-node", LionCore.getProperty());
+      nodePopulator.populateClassifierInstance(node, serializedNode);
+      fail("Exception was expected");
+    } catch (DeserializationException t) {
+      t.printStackTrace();
+    }
   }
 
   @Test

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/NodePopulatorTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/NodePopulatorTest.java
@@ -51,7 +51,7 @@ public class NodePopulatorTest {
                     + "          \"targets\": [\n"
                     + "            {\n"
                     + "              \"resolveInfo\": \"Boolean\",\n"
-                    + "              \"reference\": \"LionCore-builtins-Boolean-2024_1\"\n"
+                    + "              \"reference\": \"LionCore-builtins-Boolean-2024-1\"\n"
                     + "            }\n"
                     + "          ]\n"
                     + "        }\n"
@@ -136,7 +136,10 @@ public class NodePopulatorTest {
         new DeserializationStatus(Collections.emptyList(), serialization.getInstanceResolver());
     NodePopulator nodePopulator =
         new NodePopulator(
-            serialization, serialization.getInstanceResolver(), deserializationStatus);
+            serialization,
+            serialization.getInstanceResolver(),
+            deserializationStatus,
+            LionWebVersion.v2024_1);
 
     SerializedChunk chunk =
         new LowLevelJsonSerialization()
@@ -163,7 +166,7 @@ public class NodePopulatorTest {
                     + "          },\n"
                     + "          \"targets\": [\n"
                     + "            {\n"
-                    + "              \"resolveInfo\": \"Boolean\",\n"
+                    + "              \"resolveInfo\": \"LionWeb.LionCore_builtins.Boolean\",\n"
                     + "              \"reference\": null\n"
                     + "            }\n"
                     + "          ]\n"

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/NodePopulatorTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/NodePopulatorTest.java
@@ -1,0 +1,181 @@
+package io.lionweb.lioncore.java.serialization;
+
+import static org.junit.Assert.assertEquals;
+
+import io.lionweb.lioncore.java.LionWebVersion;
+import io.lionweb.lioncore.java.language.LionCoreBuiltins;
+import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
+import io.lionweb.lioncore.java.model.impl.DynamicNode;
+import io.lionweb.lioncore.java.self.LionCore;
+import io.lionweb.lioncore.java.serialization.data.SerializedChunk;
+import io.lionweb.lioncore.java.serialization.data.SerializedClassifierInstance;
+import java.util.Collections;
+import org.junit.Test;
+
+public class NodePopulatorTest {
+
+  @Test
+  public void populateReferenceToBuiltinsValueWithCorrectID() {
+    AbstractSerialization serialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2024_1);
+    DeserializationStatus deserializationStatus =
+        new DeserializationStatus(Collections.emptyList(), serialization.getInstanceResolver());
+    NodePopulator nodePopulator =
+        new NodePopulator(
+            serialization, serialization.getInstanceResolver(), deserializationStatus);
+
+    SerializedChunk chunk =
+        new LowLevelJsonSerialization()
+            .deserializeSerializationBlock(
+                "{\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
+                    + "  \"languages\": [],\n"
+                    + "  \"nodes\": [\n"
+                    + "    {\n"
+                    + "      \"id\": \"my-node\",\n"
+                    + "      \"classifier\": {\n"
+                    + "        \"language\": \"LionCore-M3\",\n"
+                    + "        \"version\": \"2024.1\",\n"
+                    + "        \"key\": \"Property\"\n"
+                    + "      },\n"
+                    + "      \"properties\": [],\n"
+                    + "      \"containments\": [],\n"
+                    + "      \"references\": [\n"
+                    + "        {\n"
+                    + "          \"reference\": {\n"
+                    + "            \"language\": \"LionCore-M3\",\n"
+                    + "            \"version\": \"2024.1\",\n"
+                    + "            \"key\": \"Property-type\"\n"
+                    + "          },\n"
+                    + "          \"targets\": [\n"
+                    + "            {\n"
+                    + "              \"resolveInfo\": \"Boolean\",\n"
+                    + "              \"reference\": \"LionCore-builtins-Boolean\"\n"
+                    + "            }\n"
+                    + "          ]\n"
+                    + "        }\n"
+                    + "      ],\n"
+                    + "      \"parent\": \"io-lionweb-Properties-BooleanValue\"\n"
+                    + "    }\n"
+                    + "  ]\n"
+                    + "}");
+    SerializedClassifierInstance serializedNode = chunk.getClassifierInstances().get(0);
+
+    DynamicNode node = new DynamicNode("my-node", LionCore.getProperty());
+    nodePopulator.populateClassifierInstance(node, serializedNode);
+
+    assertEquals(
+        LionCoreBuiltins.getBoolean(),
+        ClassifierInstanceUtils.getOnlyReferenceValueByReferenceName(node, "type").getReferred());
+  }
+
+  @Test
+  public void populateReferenceToBuiltinsValueWithIncorrectID() {
+    AbstractSerialization serialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2024_1);
+    DeserializationStatus deserializationStatus =
+        new DeserializationStatus(Collections.emptyList(), serialization.getInstanceResolver());
+    NodePopulator nodePopulator =
+        new NodePopulator(
+            serialization, serialization.getInstanceResolver(), deserializationStatus);
+
+    SerializedChunk chunk =
+        new LowLevelJsonSerialization()
+            .deserializeSerializationBlock(
+                "{\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
+                    + "  \"languages\": [],\n"
+                    + "  \"nodes\": [\n"
+                    + "    {\n"
+                    + "      \"id\": \"my-node\",\n"
+                    + "      \"classifier\": {\n"
+                    + "        \"language\": \"LionCore-M3\",\n"
+                    + "        \"version\": \"2024.1\",\n"
+                    + "        \"key\": \"Property\"\n"
+                    + "      },\n"
+                    + "      \"properties\": [],\n"
+                    + "      \"containments\": [],\n"
+                    + "      \"references\": [\n"
+                    + "        {\n"
+                    + "          \"reference\": {\n"
+                    + "            \"language\": \"LionCore-M3\",\n"
+                    + "            \"version\": \"2024.1\",\n"
+                    + "            \"key\": \"Property-type\"\n"
+                    + "          },\n"
+                    + "          \"targets\": [\n"
+                    + "            {\n"
+                    + "              \"resolveInfo\": \"Boolean\",\n"
+                    + "              \"reference\": \"LionCore-builtins-Boolean-for-some-version-different-than-the-one-we-are-using\"\n"
+                    + "            }\n"
+                    + "          ]\n"
+                    + "        }\n"
+                    + "      ],\n"
+                    + "      \"parent\": \"io-lionweb-Properties-BooleanValue\"\n"
+                    + "    }\n"
+                    + "  ]\n"
+                    + "}");
+    SerializedClassifierInstance serializedNode = chunk.getClassifierInstances().get(0);
+
+    DynamicNode node = new DynamicNode("my-node", LionCore.getProperty());
+    nodePopulator.populateClassifierInstance(node, serializedNode);
+
+    assertEquals(
+        LionCoreBuiltins.getBoolean(),
+        ClassifierInstanceUtils.getOnlyReferenceValueByReferenceName(node, "type").getReferred());
+  }
+
+  @Test
+  public void populateReferenceToBuiltinsValueWithNoID() {
+    AbstractSerialization serialization =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2024_1);
+    DeserializationStatus deserializationStatus =
+        new DeserializationStatus(Collections.emptyList(), serialization.getInstanceResolver());
+    NodePopulator nodePopulator =
+        new NodePopulator(
+            serialization, serialization.getInstanceResolver(), deserializationStatus);
+
+    SerializedChunk chunk =
+        new LowLevelJsonSerialization()
+            .deserializeSerializationBlock(
+                "{\n"
+                    + "  \"serializationFormatVersion\": \"2024.1\",\n"
+                    + "  \"languages\": [],\n"
+                    + "  \"nodes\": [\n"
+                    + "    {\n"
+                    + "      \"id\": \"my-node\",\n"
+                    + "      \"classifier\": {\n"
+                    + "        \"language\": \"LionCore-M3\",\n"
+                    + "        \"version\": \"2024.1\",\n"
+                    + "        \"key\": \"Property\"\n"
+                    + "      },\n"
+                    + "      \"properties\": [],\n"
+                    + "      \"containments\": [],\n"
+                    + "      \"references\": [\n"
+                    + "        {\n"
+                    + "          \"reference\": {\n"
+                    + "            \"language\": \"LionCore-M3\",\n"
+                    + "            \"version\": \"2024.1\",\n"
+                    + "            \"key\": \"Property-type\"\n"
+                    + "          },\n"
+                    + "          \"targets\": [\n"
+                    + "            {\n"
+                    + "              \"resolveInfo\": \"Boolean\",\n"
+                    + "              \"reference\": null\n"
+                    + "            }\n"
+                    + "          ]\n"
+                    + "        }\n"
+                    + "      ],\n"
+                    + "      \"parent\": \"io-lionweb-Properties-BooleanValue\"\n"
+                    + "    }\n"
+                    + "  ]\n"
+                    + "}");
+    SerializedClassifierInstance serializedNode = chunk.getClassifierInstances().get(0);
+
+    DynamicNode node = new DynamicNode("my-node", LionCore.getProperty());
+    nodePopulator.populateClassifierInstance(node, serializedNode);
+
+    assertEquals(
+        LionCoreBuiltins.getBoolean(),
+        ClassifierInstanceUtils.getOnlyReferenceValueByReferenceName(node, "type").getReferred());
+  }
+}

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
@@ -108,10 +108,10 @@ public class SerializationOfLionCoreTest extends SerializationTest {
 
     SerializedClassifierInstance LionCore_M3 =
         serializedChunk.getClassifierInstances().stream()
-            .filter(n -> "-id-LionCore-M3-2024_1".equals(n.getID()))
+            .filter(n -> "-id-LionCore-M3-2024-1".equals(n.getID()))
             .findFirst()
             .get();
-    assertEquals("-id-LionCore-M3-2024_1", LionCore_M3.getID());
+    assertEquals("-id-LionCore-M3-2024-1", LionCore_M3.getID());
     assertEquals(new MetaPointer("LionCore-M3", "2024.1", "Language"), LionCore_M3.getClassifier());
     assertEquals(
         Arrays.asList(
@@ -128,24 +128,24 @@ public class SerializationOfLionCoreTest extends SerializationTest {
             new SerializedContainmentValue(
                 new MetaPointer("LionCore-M3", "2024.1", "Language-entities"),
                 Arrays.asList(
-                    "-id-Annotation-2024_1",
-                    "-id-Concept-2024_1",
-                    "-id-Interface-2024_1",
-                    "-id-Containment-2024_1",
-                    "-id-DataType-2024_1",
-                    "-id-Enumeration-2024_1",
-                    "-id-EnumerationLiteral-2024_1",
-                    "-id-Feature-2024_1",
-                    "-id-Field-2024_1",
-                    "-id-Classifier-2024_1",
-                    "-id-Link-2024_1",
-                    "-id-Language-2024_1",
-                    "-id-LanguageEntity-2024_1",
-                    "-id-IKeyed-2024_1",
-                    "-id-PrimitiveType-2024_1",
-                    "-id-Property-2024_1",
-                    "-id-Reference-2024_1",
-                    "-id-StructuredDataType-2024_1"))),
+                    "-id-Annotation-2024-1",
+                    "-id-Concept-2024-1",
+                    "-id-Interface-2024-1",
+                    "-id-Containment-2024-1",
+                    "-id-DataType-2024-1",
+                    "-id-Enumeration-2024-1",
+                    "-id-EnumerationLiteral-2024-1",
+                    "-id-Feature-2024-1",
+                    "-id-Field-2024-1",
+                    "-id-Classifier-2024-1",
+                    "-id-Link-2024-1",
+                    "-id-Language-2024-1",
+                    "-id-LanguageEntity-2024-1",
+                    "-id-IKeyed-2024-1",
+                    "-id-PrimitiveType-2024-1",
+                    "-id-Property-2024-1",
+                    "-id-Reference-2024-1",
+                    "-id-StructuredDataType-2024-1"))),
         LionCore_M3.getContainments());
     assertEquals(
         Arrays.asList(
@@ -156,7 +156,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
 
     SerializedClassifierInstance LionCore_M3_Interface_extends =
         serializedChunk.getClassifierInstances().stream()
-            .filter(n -> "-id-Interface-extends-2024_1".equals(n.getID()))
+            .filter(n -> "-id-Interface-extends-2024-1".equals(n.getID()))
             .findFirst()
             .get();
   }

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/SerializationOfLionCoreTest.java
@@ -108,10 +108,10 @@ public class SerializationOfLionCoreTest extends SerializationTest {
 
     SerializedClassifierInstance LionCore_M3 =
         serializedChunk.getClassifierInstances().stream()
-            .filter(n -> "-id-LionCore-M3".equals(n.getID()))
+            .filter(n -> "-id-LionCore-M3-2024_1".equals(n.getID()))
             .findFirst()
             .get();
-    assertEquals("-id-LionCore-M3", LionCore_M3.getID());
+    assertEquals("-id-LionCore-M3-2024_1", LionCore_M3.getID());
     assertEquals(new MetaPointer("LionCore-M3", "2024.1", "Language"), LionCore_M3.getClassifier());
     assertEquals(
         Arrays.asList(
@@ -128,24 +128,24 @@ public class SerializationOfLionCoreTest extends SerializationTest {
             new SerializedContainmentValue(
                 new MetaPointer("LionCore-M3", "2024.1", "Language-entities"),
                 Arrays.asList(
-                    "-id-Annotation",
-                    "-id-Concept",
-                    "-id-Interface",
-                    "-id-Containment",
-                    "-id-DataType",
-                    "-id-Enumeration",
-                    "-id-EnumerationLiteral",
-                    "-id-Feature",
-                    "-id-Field",
-                    "-id-Classifier",
-                    "-id-Link",
-                    "-id-Language",
-                    "-id-LanguageEntity",
-                    "-id-IKeyed",
-                    "-id-PrimitiveType",
-                    "-id-Property",
-                    "-id-Reference",
-                    "-id-StructuredDataType"))),
+                    "-id-Annotation-2024_1",
+                    "-id-Concept-2024_1",
+                    "-id-Interface-2024_1",
+                    "-id-Containment-2024_1",
+                    "-id-DataType-2024_1",
+                    "-id-Enumeration-2024_1",
+                    "-id-EnumerationLiteral-2024_1",
+                    "-id-Feature-2024_1",
+                    "-id-Field-2024_1",
+                    "-id-Classifier-2024_1",
+                    "-id-Link-2024_1",
+                    "-id-Language-2024_1",
+                    "-id-LanguageEntity-2024_1",
+                    "-id-IKeyed-2024_1",
+                    "-id-PrimitiveType-2024_1",
+                    "-id-Property-2024_1",
+                    "-id-Reference-2024_1",
+                    "-id-StructuredDataType-2024_1"))),
         LionCore_M3.getContainments());
     assertEquals(
         Arrays.asList(
@@ -156,7 +156,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
 
     SerializedClassifierInstance LionCore_M3_Interface_extends =
         serializedChunk.getClassifierInstances().stream()
-            .filter(n -> "-id-Interface-extends".equals(n.getID()))
+            .filter(n -> "-id-Interface-extends-2024_1".equals(n.getID()))
             .findFirst()
             .get();
   }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,8 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version '2.0.21'
+    }
+}
 rootProject.name = 'lionweb-java'
 include('core')
 include('emf')


### PR DESCRIPTION
Initial proposal for making the IDs dependant on the LionWeb Version.

Note that tests will fail as we need to update the version of LionCore stored in the specs.

I kept the IDs for 2023.1 as they were, adding the suffix `-2024_1` to the IDs for version 2024.1.

I also started working on a way to "auto-rewire" references to elements from LionCoreBuiltins using the resolveInfo but without enforcing the referred field to be empty.

Implements #172 