### PR TITLE
Derive abstract property of a LW concept from Ecore isAbstract

### DIFF
--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
@@ -58,7 +58,7 @@ public class EMFMetamodelImporter extends AbstractEMFImporter<Language> {
         } else {
           Concept concept = new Concept(metamodel, eClass.getName());
           setIDAndKey(concept, ePackage.getName() + "-" + concept.getName());
-          concept.setAbstract(concept.isAbstract());
+          concept.setAbstract(((EClass) eClassifier).isAbstract());
           metamodel.addElement(concept);
           conceptsToEClassesMapping.registerMapping(concept, eClass);
         }

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
@@ -58,7 +58,7 @@ public class EMFMetamodelImporter extends AbstractEMFImporter<Language> {
         } else {
           Concept concept = new Concept(metamodel, eClass.getName());
           setIDAndKey(concept, ePackage.getName() + "-" + concept.getName());
-          concept.setAbstract(false);
+          concept.setAbstract(concept.isAbstract());
           metamodel.addElement(concept);
           conceptsToEClassesMapping.registerMapping(concept, eClass);
         }

--- a/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporterTest.java
+++ b/emf/src/test/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporterTest.java
@@ -25,7 +25,7 @@ public class EMFMetamodelImporterTest {
     Language language = languages.get(0);
     assertEquals("library", language.getName());
 
-    assertEquals(5, language.getElements().size());
+    assertEquals(6, language.getElements().size());
 
     Concept book = (Concept) language.getElementByName("Book");
     assertNull(book.getExtendedConcept());
@@ -57,19 +57,22 @@ public class EMFMetamodelImporterTest {
     assertEquals(true, bookAuthor.isRequired());
     assertEquals(false, bookAuthor.isMultiple());
 
+    Concept namedElement = (Concept) language.getElementByName("NamedElement");
+    assertTrue(namedElement.isAbstract());
+
     Concept library = (Concept) language.getElementByName("Library");
-    assertNull(library.getExtendedConcept());
+    assertNotNull(library.getExtendedConcept());
     assertEquals(0, library.getImplemented().size());
     assertFalse(library.isAbstract());
     assertEquals("library.Library", library.qualifiedName());
-    assertEquals(2, library.getFeatures().size());
+    assertEquals(1, library.getFeatures().size());
     assertEquals(2, library.allFeatures().size());
 
     Property libraryName = (Property) library.getFeatureByName("name");
     assertEquals(LionCoreBuiltins.getString(), libraryName.getType());
-    assertSame(library, libraryName.getContainer());
-    assertEquals("library.Library.name", libraryName.qualifiedName());
-    assertEquals("library-Library-name", libraryName.getKey());
+    assertSame(library.getExtendedConcept(), libraryName.getContainer());
+    assertEquals("library.NamedElement.name", libraryName.qualifiedName());
+    assertEquals("library-NamedElement-name", libraryName.getKey());
     assertEquals(false, libraryName.isOptional());
     assertEquals(true, libraryName.isRequired());
 
@@ -82,17 +85,18 @@ public class EMFMetamodelImporterTest {
     assertEquals(true, libraryBooks.isMultiple());
 
     Concept writer = (Concept) language.getElementByName("Writer");
-    assertNull(writer.getExtendedConcept());
+    assertNotNull(writer.getExtendedConcept());
+    assertSame(namedElement, writer.getExtendedConcept());
     assertEquals(0, writer.getImplemented().size());
     assertFalse(writer.isAbstract());
     assertEquals("library.Writer", writer.qualifiedName());
-    assertEquals(1, writer.getFeatures().size());
+    assertEquals(0, writer.getFeatures().size());
     assertEquals(1, writer.allFeatures().size());
 
     Property writerName = (Property) writer.getFeatureByName("name");
     assertEquals(LionCoreBuiltins.getString(), writerName.getType());
-    assertSame(writer, writerName.getContainer());
-    assertEquals("library.Writer.name", writerName.qualifiedName());
+    assertSame(writer.getExtendedConcept(), writerName.getContainer());
+    assertEquals("library.NamedElement.name", writerName.qualifiedName());
     assertEquals(false, writerName.isOptional());
     assertEquals(true, writerName.isRequired());
 
@@ -113,8 +117,8 @@ public class EMFMetamodelImporterTest {
 
     Property guideBookWriterName = (Property) guideBookWriter.getFeatureByName("name");
     assertEquals(LionCoreBuiltins.getString(), guideBookWriterName.getType());
-    assertSame(writer, guideBookWriterName.getContainer());
-    assertEquals("library.Writer.name", guideBookWriterName.qualifiedName());
+    assertSame(writer.getExtendedConcept(), guideBookWriterName.getContainer());
+    assertEquals("library.NamedElement.name", guideBookWriterName.qualifiedName());
     assertEquals(false, guideBookWriterName.isOptional());
     assertEquals(true, guideBookWriterName.isRequired());
 
@@ -137,8 +141,8 @@ public class EMFMetamodelImporterTest {
 
     Property specialistBookWriterName = (Property) specialistBookWriter.getFeatureByName("name");
     assertEquals(LionCoreBuiltins.getString(), specialistBookWriterName.getType());
-    assertSame(writer, specialistBookWriterName.getContainer());
-    assertEquals("library.Writer.name", specialistBookWriterName.qualifiedName());
+    assertSame(writer.getExtendedConcept(), specialistBookWriterName.getContainer());
+    assertEquals("library.NamedElement.name", specialistBookWriterName.qualifiedName());
     assertEquals(false, specialistBookWriterName.isOptional());
     assertEquals(true, specialistBookWriterName.isRequired());
   }

--- a/emf/src/test/resources/library.ecore
+++ b/emf/src/test/resources/library.ecore
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- as found https://wiki.eclipse.org/Example_library_EMF_model -->
-  <ecore:EPackage xmi:version="2.0"
-    xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="library"
-    nsURI="http://www.eclipse.org/emf/jcrm/samples/emf/sample/Library" nsPrefix="library">
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="library" nsURI="http://www.eclipse.org/emf/jcrm/samples/emf/sample/Library"
+    nsPrefix="library">
   <eClassifiers xsi:type="ecore:EClass" name="Book">
     <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
       <details key="name" value="Book"/>
@@ -31,14 +29,7 @@
       </eAnnotations>
     </eStructuralFeatures>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="Library">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" unique="false" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
-      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
-        <details key="kind" value="element"/>
-        <details key="name" value="name"/>
-      </eAnnotations>
-    </eStructuralFeatures>
+  <eClassifiers xsi:type="ecore:EClass" name="Library" eSuperTypes="#//NamedElement">
     <eStructuralFeatures xsi:type="ecore:EReference" name="books" upperBound="-1"
         eType="#//Book" containment="true">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
@@ -47,19 +38,14 @@
       </eAnnotations>
     </eStructuralFeatures>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="Writer">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" unique="false" lowerBound="1"
-        eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String">
-      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
-        <details key="kind" value="element"/>
-        <details key="name" value="name"/>
-      </eAnnotations>
-    </eStructuralFeatures>
-  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Writer" eSuperTypes="#//NamedElement"/>
   <eClassifiers xsi:type="ecore:EClass" name="GuideBookWriter" eSuperTypes="#//Writer">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="countries" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="SpecialistBookWriter" eSuperTypes="#//Writer">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="subject" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="NamedElement" abstract="true">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"/>
   </eClassifiers>
 </ecore:EPackage>


### PR DESCRIPTION
I find it strange that `abstract` property of a concept is set to `false` in the current version. A metamodel can have an abstract class/concept, so this property should be derived from the Ecore source.