### PR TITLE
Allow annotations to have children

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/model/ClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/ClassifierInstance.java
@@ -35,7 +35,7 @@ public interface ClassifierInstance<T extends Classifier<T>> extends HasFeatureV
   T getClassifier();
 
   /** The immediate parent of the Node. This should be null only for root nodes. */
-  ClassifierInstance<T> getParent();
+  ClassifierInstance<?> getParent();
 
   /** Collects `self` and all its descendants into `result`. */
   static <T extends ClassifierInstance<?>> void collectSelfAndDescendants(

--- a/core/src/main/java/io/lionweb/lioncore/java/model/HasSettableParent.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/HasSettableParent.java
@@ -7,5 +7,5 @@ import javax.annotation.Nullable;
  * node into a containment.
  */
 public interface HasSettableParent {
-  void setParent(@Nullable Node parent);
+  void setParent(@Nullable ClassifierInstance<?> parent);
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
@@ -51,7 +51,7 @@ public interface Node extends ClassifierInstance<Concept> {
   }
 
   @Override
-  Node getParent();
+  ClassifierInstance<?> getParent();
 
   /** The concept of which this Node is an instance. The Concept should not be abstract. */
   Concept getClassifier();

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicAnnotationInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicAnnotationInstance.java
@@ -73,7 +73,7 @@ public class DynamicAnnotationInstance extends DynamicClassifierInstance<Annotat
   }
 
   @Override
-  public ClassifierInstance getParent() {
+  public ClassifierInstance<?> getParent() {
     return annotated;
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicClassifierInstance.java
@@ -217,7 +217,7 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
   private void addContainment(Containment link, Node value) {
     assert link.isMultiple();
     if (value instanceof HasSettableParent) {
-      ((HasSettableParent) value).setParent((Node) this);
+      ((HasSettableParent) value).setParent((ClassifierInstance<?>) this);
     }
     if (containmentValues.containsKey(link.getKey())) {
       containmentValues.get(link.getKey()).add(value);

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
@@ -1,6 +1,7 @@
 package io.lionweb.lioncore.java.model.impl;
 
 import io.lionweb.lioncore.java.language.*;
+import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.model.HasSettableParent;
 import io.lionweb.lioncore.java.model.Node;
 import java.util.*;
@@ -15,7 +16,7 @@ import javax.annotation.Nullable;
  */
 public class DynamicNode extends DynamicClassifierInstance<Concept>
     implements Node, HasSettableParent {
-  private Node parent = null;
+  private ClassifierInstance<?> parent = null;
   private Concept concept = null;
 
   public DynamicNode(@Nonnull String id, @Nonnull Concept concept) {
@@ -33,7 +34,7 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
   }
 
   @Override
-  public Node getParent() {
+  public ClassifierInstance<?> getParent() {
     return this.parent;
   }
 
@@ -57,7 +58,7 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
   }
 
   @Override
-  public void setParent(Node parent) {
+  public void setParent(ClassifierInstance<?> parent) {
     this.parent = parent;
   }
 
@@ -71,8 +72,8 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
     }
     DynamicNode that = (DynamicNode) o;
     return Objects.equals(id, that.id)
-        && shallowNodeEquality(parent, that.parent)
-        && shallowNodeEquality(concept, that.concept)
+        && shallowClassifierInstanceEquality(parent, that.parent)
+        && shallowClassifierInstanceEquality(concept, that.concept)
         && Objects.equals(propertyValues, that.propertyValues)
         && shallowContainmentsEquality(containmentValues, that.containmentValues)
         && Objects.equals(referenceValues, that.referenceValues)
@@ -91,18 +92,23 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
               List<Node> nodes2 = containments2.get(containmentName);
               return nodes1.size() == nodes2.size()
                   && IntStream.range(0, nodes1.size())
-                      .allMatch(i -> shallowNodeEquality(nodes1.get(i), nodes2.get(i)));
+                      .allMatch(
+                          i -> shallowClassifierInstanceEquality(nodes1.get(i), nodes2.get(i)));
             });
   }
 
-  private static boolean shallowNodeEquality(@Nullable Node node1, @Nullable Node node2) {
-    if (node1 == null && node2 == null) {
+  private static boolean shallowClassifierInstanceEquality(
+      @Nullable ClassifierInstance<?> classifierInstance1,
+      @Nullable ClassifierInstance<?> classifierInstance2) {
+    if (classifierInstance1 == null && classifierInstance2 == null) {
       return true;
     }
-    if (node1 != null && node2 != null && node1.getID() != null) {
-      return Objects.equals(node1.getID(), node2.getID());
+    if (classifierInstance1 != null
+        && classifierInstance2 != null
+        && classifierInstance1.getID() != null) {
+      return Objects.equals(classifierInstance1.getID(), classifierInstance2.getID());
     }
-    return Objects.equals(node1, node2);
+    return Objects.equals(classifierInstance1, classifierInstance2);
   }
 
   @Override

--- a/core/src/main/java/io/lionweb/lioncore/java/utils/LanguageValidator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/LanguageValidator.java
@@ -126,7 +126,6 @@ public class LanguageValidator extends Validator<Language> {
               }
               if (el instanceof Annotation) {
                 checkAnnotates((Annotation) el, result);
-                checkAnnotationFeatures((Annotation) el, result);
               }
               if (el instanceof StructuredDataType) {
                 validateStructuralDataType(result, (StructuredDataType) el);
@@ -215,13 +214,6 @@ public class LanguageValidator extends Validator<Language> {
             && annotation.getAnnotates() != null
             && annotation.getAnnotates() != annotation.getExtendedAnnotation().getAnnotates(),
         "When a sub annotation specify a value for annotates it must be the same value the super annotation specifies",
-        annotation);
-  }
-
-  private void checkAnnotationFeatures(Annotation annotation, ValidationResult validationResult) {
-    validationResult.checkForError(
-        !annotation.allContainments().isEmpty(),
-        "An annotation should not have containment links",
         annotation);
   }
 

--- a/core/src/test/java/io/lionweb/lioncore/java/language/AnnotationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/language/AnnotationTest.java
@@ -129,8 +129,8 @@ public class AnnotationTest extends BaseTest {
     assertNodeTreeIsValid(annotation);
     assertLanguageIsValid(language);
 
-    annotation.addFeature(Containment.createOptional("cont", myConcept, "cont"));
+    annotation.addFeature(Containment.createOptional("cont", myConcept, "cont", "cont-key"));
     assertNodeTreeIsValid(annotation);
-    assertLanguageIsNotValid(language);
+    assertLanguageIsValid(language);
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/model/impl/DynamicAnnotationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/model/impl/DynamicAnnotationTest.java
@@ -1,0 +1,24 @@
+package io.lionweb.lioncore.java.model.impl;
+
+import static org.junit.Assert.*;
+
+import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
+import io.lionweb.lioncore.java.model.Node;
+import io.lionweb.lioncore.java.serialization.*;
+import org.junit.Test;
+
+public class DynamicAnnotationTest {
+
+  @Test
+  public void annotationWithChildren() {
+    MyAnnotation myAnnotation = new MyAnnotation("ann1");
+    DynamicNode value1 = new DynamicNode("value1", MyAnnotation.VALUE);
+    ClassifierInstanceUtils.setPropertyValueByName(value1, "amount", 123);
+    ClassifierInstanceUtils.addChild(myAnnotation, "values", value1);
+    assertEquals(
+        1, ClassifierInstanceUtils.getChildrenByContainmentName(myAnnotation, "values").size());
+    Node retrievedValue1 =
+        ClassifierInstanceUtils.getChildrenByContainmentName(myAnnotation, "values").get(0);
+    assertEquals(123, ClassifierInstanceUtils.getPropertyValueByName(retrievedValue1, "amount"));
+  }
+}

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/MyAnnotation.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/MyAnnotation.java
@@ -1,0 +1,44 @@
+package io.lionweb.lioncore.java.serialization;
+
+import io.lionweb.lioncore.java.language.*;
+import io.lionweb.lioncore.java.model.impl.DynamicAnnotationInstance;
+
+public class MyAnnotation extends DynamicAnnotationInstance {
+  public static final Language LANGUAGE =
+      new Language()
+          .setID("myLanguageWithAnnotations-id")
+          .setKey("myLanguageWithAnnotations-key")
+          .setName("LWA")
+          .setVersion("1");
+  public static final Annotation ANNOTATION =
+      new Annotation()
+          .setID("MyAnnotation-id")
+          .setKey("MyAnnotation-key")
+          .setName("MyAnnotation")
+          .setParent(LANGUAGE);
+  public static final Concept VALUE =
+      new Concept().setID("Value-id").setKey("Value-key").setName("Value").setParent(LANGUAGE);
+  public static final Concept ANNOTATED =
+      new Concept()
+          .setID("Annotated-id")
+          .setKey("Annotated-key")
+          .setName("Annotated")
+          .setParent(LANGUAGE);
+
+  static {
+    VALUE.addFeature(
+        Property.createRequired("amount", LionCoreBuiltins.getInteger())
+            .setKey("my-amount")
+            .setID("my-amount"));
+    ANNOTATION.setAnnotates(ANNOTATED);
+    ANNOTATION.addFeature(
+        Containment.createMultiple("values", VALUE).setKey("my-values").setID("my-values"));
+    LANGUAGE.addElement(ANNOTATION);
+    LANGUAGE.addElement(VALUE);
+    LANGUAGE.addElement(ANNOTATED);
+  }
+
+  public MyAnnotation(String id) {
+    super(id, ANNOTATION);
+  }
+}


### PR DESCRIPTION
Until now annotations were forbidden to have children.
Enabling this means also that we can have Node which have as parent an Annotation and not a Node.

Fix #181 