### PR TITLE
Improving the Dynamic node equals

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
@@ -1,9 +1,7 @@
 package io.lionweb.lioncore.java.model.impl;
 
 import io.lionweb.lioncore.java.language.*;
-import io.lionweb.lioncore.java.model.ClassifierInstance;
-import io.lionweb.lioncore.java.model.HasSettableParent;
-import io.lionweb.lioncore.java.model.Node;
+import io.lionweb.lioncore.java.model.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -76,8 +74,31 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
         && shallowClassifierInstanceEquality(concept, that.concept)
         && Objects.equals(propertyValues, that.propertyValues)
         && shallowContainmentsEquality(containmentValues, that.containmentValues)
-        && Objects.equals(referenceValues, that.referenceValues)
-        && Objects.equals(annotations, that.annotations);
+        && shallowReferenceEquality(referenceValues, that.referenceValues)
+        && shallowAnnotationsEquality(annotations, that.annotations);
+  }
+
+  private static boolean shallowReferenceEquality(
+      Map<String, List<ReferenceValue>> reference1, Map<String, List<ReferenceValue>> reference2) {
+    if (!reference1.keySet().equals(reference2.keySet())) {
+      return false;
+    }
+    return reference1.keySet().stream()
+        .allMatch(
+            referenceName -> {
+              List<ReferenceValue> references1 = reference1.get(referenceName);
+              List<ReferenceValue> references2 = reference2.get(referenceName);
+              return references1.size() == references2.size()
+                  && IntStream.range(0, references1.size())
+                      .allMatch(
+                          i ->
+                              Objects.equals(
+                                      references1.get(i).getResolveInfo(),
+                                      references2.get(i).getResolveInfo())
+                                  && Objects.equals(
+                                      references1.get(i).getReferredID(),
+                                      references2.get(i).getReferredID()));
+            });
   }
 
   private static boolean shallowContainmentsEquality(
@@ -109,6 +130,14 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
       return Objects.equals(classifierInstance1.getID(), classifierInstance2.getID());
     }
     return Objects.equals(classifierInstance1, classifierInstance2);
+  }
+
+  private static boolean shallowAnnotationsEquality(
+      List<AnnotationInstance> annotations1, List<AnnotationInstance> annotations2) {
+    return annotations1.size() == annotations2.size()
+        && IntStream.range(0, annotations1.size())
+            .allMatch(
+                i -> shallowClassifierInstanceEquality(annotations1.get(i), annotations2.get(i)));
   }
 
   @Override

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
@@ -1,11 +1,11 @@
 package io.lionweb.lioncore.java.model.impl;
 
 import io.lionweb.lioncore.java.language.*;
+import io.lionweb.lioncore.java.model.AnnotationInstance;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.model.HasSettableParent;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.ReferenceValue;
-import io.lionweb.lioncore.java.model.AnnotationInstance;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -95,13 +95,18 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
               return references1.size() == references2.size()
                   && IntStream.range(0, references1.size())
                       .allMatch(
-                          i ->
-                              Objects.equals(
-                                      references1.get(i).getResolveInfo(),
-                                      references2.get(i).getResolveInfo())
-                                  && Objects.equals(
-                                      references1.get(i).getReferredID(),
-                                      references2.get(i).getReferredID()));
+                          i -> {
+                            String referredID1 = references1.get(i).getReferredID();
+                            String referredID2 = references2.get(i).getReferredID();
+                            String resolveInfo1 = references1.get(i).getResolveInfo();
+                            String resolveInfo2 = references2.get(i).getResolveInfo();
+
+                            if (referredID1 == null && referredID2 == null) {
+                              return Objects.equals(resolveInfo1, resolveInfo2);
+                            } else {
+                              return Objects.equals(referredID1, referredID2);
+                            }
+                          });
             });
   }
 

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
@@ -1,7 +1,11 @@
 package io.lionweb.lioncore.java.model.impl;
 
 import io.lionweb.lioncore.java.language.*;
-import io.lionweb.lioncore.java.model.*;
+import io.lionweb.lioncore.java.model.ClassifierInstance;
+import io.lionweb.lioncore.java.model.HasSettableParent;
+import io.lionweb.lioncore.java.model.Node;
+import io.lionweb.lioncore.java.model.ReferenceValue;
+import io.lionweb.lioncore.java.model.AnnotationInstance;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;

--- a/core/src/test/java/io/lionweb/lioncore/java/model/impl/DynamicNodeTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/model/impl/DynamicNodeTest.java
@@ -543,4 +543,50 @@ public class DynamicNodeTest {
     assertEquals(true, a.equals(b));
     assertEquals(true, b.equals(a));
   }
+
+  @Test
+  public void equalityConsideringReferences() {
+    DynamicNode node1 = new DynamicNode("id1", MyNodeWithAmount.CONCEPT);
+    DynamicNode node2 = new DynamicNode("id1", MyNodeWithAmount.CONCEPT);
+    Reference reference = new Reference("ref");
+
+    // Case: both nodes have the same reference values
+    node1.addReferenceValue(reference, new ReferenceValue(null, "resolve1"));
+    node2.addReferenceValue(reference, new ReferenceValue(null, "resolve1"));
+    assertEquals(true, node1.equals(node2));
+
+    // Case: nodes have different reference values
+    node2.addReferenceValue(reference, new ReferenceValue(null, "resolve2"));
+    assertEquals(false, node1.equals(node2));
+
+    // Case: one node has a null referredID, the other has a non-null referredID
+    node1.addReferenceValue(reference, new ReferenceValue(null, "resolve2"));
+    node2.addReferenceValue(reference, new ReferenceValue(new DynamicNode(), null));
+    assertEquals(false, node1.equals(node2));
+
+    // Case: both nodes have null referredID and same resolveInfo
+    node1.addReferenceValue(reference, new ReferenceValue(null, "resolve3"));
+    node2.addReferenceValue(reference, new ReferenceValue(null, "resolve3"));
+    assertEquals(true, node1.equals(node2));
+  }
+
+  @Test
+  public void equalityConsideringAnnotations() {
+    DynamicNode node1 = new DynamicNode("id1", MyNodeWithAmount.CONCEPT);
+    DynamicNode node2 = new DynamicNode("id1", MyNodeWithAmount.CONCEPT);
+    Annotation annotation = new Annotation(new Language("lang"), "annotation");
+
+    // Case: both nodes have the same annotations
+    node1.addAnnotation(new DynamicAnnotationInstance("a1", annotation, node1));
+    node2.addAnnotation(new DynamicAnnotationInstance("a1", annotation, node2));
+    assertEquals(true, node1.equals(node2));
+
+    // Case: nodes have different annotations
+    node2.addAnnotation(new DynamicAnnotationInstance("a2", annotation, node2));
+    assertEquals(false, node1.equals(node2));
+
+    // Case: nodes have the same annotations again
+    node1.addAnnotation(new DynamicAnnotationInstance("a2", annotation, node1));
+    assertEquals(true, node1.equals(node2));
+  }
 }


### PR DESCRIPTION
## Description

- #187 
- The method now uses the helper methods shallowClassifierInstanceEquality, shallowReferenceEquality, and shallowAnnotationsEquality to compare the respective fields;
- Proposing the change since while working on a project the equals method was caught in a loop then throwing a stack overflow error.

## Testing 

- Ensured no tests are broken;
- Added equality tests for references and annotations.
 
## Checklist

- [X] The correct base branch is being used;
- [x]  All active GitHub checks for tests and formatting are passing;