### PR TITLE
Ensure that proper Lionweb version is set up through the whole language

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/JsonSerialization.java
@@ -35,7 +35,9 @@ import javax.annotation.Nonnull;
 public class JsonSerialization extends AbstractSerialization {
 
   public static void saveLanguageToFile(Language language, File file) throws IOException {
-    String content = getStandardJsonSerialization().serializeTreesToJsonString(language);
+    String content =
+        getStandardJsonSerialization(language.getLionWebVersion())
+            .serializeTreesToJsonString(language);
     file.getParentFile().mkdirs();
     BufferedWriter writer = new BufferedWriter(new FileWriter(file));
     writer.write(content);

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFExporter.java
@@ -21,6 +21,7 @@ public abstract class AbstractEMFExporter {
 
   public AbstractEMFExporter(LanguageEntitiesToEElementsMapping entitiesToEElementsMapping) {
     this.entitiesToEElementsMapping = entitiesToEElementsMapping;
+    this.lionWebVersion = entitiesToEElementsMapping.getLionWebVersion();
   }
 
   public @Nonnull LionWebVersion getLionWebVersion() {

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/AbstractEMFImporter.java
@@ -13,8 +13,8 @@ import org.eclipse.emf.ecore.resource.Resource;
  * @param <E> kind of imported element
  */
 public abstract class AbstractEMFImporter<E> {
-
   protected final LanguageEntitiesToEElementsMapping entitiesToEElementsMapping;
+  private LionWebVersion lionWebVersion;
 
   public AbstractEMFImporter() {
     this(LionWebVersion.currentVersion);
@@ -22,6 +22,7 @@ public abstract class AbstractEMFImporter<E> {
 
   public AbstractEMFImporter(@Nonnull LionWebVersion lionWebVersion) {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
+    this.lionWebVersion = lionWebVersion;
     this.entitiesToEElementsMapping = new LanguageEntitiesToEElementsMapping(lionWebVersion);
   }
 
@@ -31,7 +32,12 @@ public abstract class AbstractEMFImporter<E> {
    */
   public AbstractEMFImporter(LanguageEntitiesToEElementsMapping entitiesToEElementsMapping) {
     this.entitiesToEElementsMapping = entitiesToEElementsMapping;
+    this.lionWebVersion = entitiesToEElementsMapping.getLionWebVersion();
   }
 
   public abstract List<E> importResource(Resource resource);
+
+  public @Nonnull LionWebVersion getLionWebVersion() {
+    return lionWebVersion;
+  }
 }

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
@@ -175,10 +175,9 @@ public class EMFMetamodelImporter extends AbstractEMFImporter<Language> {
         else {
           String featureName =
               eFeature.getName().substring(0, 1).toUpperCase() + eFeature.getName().substring(1);
-          Concept holderConcept = new Concept(featureName + "Container");
+          Concept holderConcept = new Concept(classifier.getLanguage(), featureName + "Container");
           setIDAndKey(holderConcept, ePackage.getName() + "-" + holderConcept.getName());
           holderConcept.setAbstract(false);
-          classifier.getLanguage().addElement(holderConcept);
 
           Property property = new Property("content", holderConcept);
           setIDAndKey(

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
@@ -18,7 +18,7 @@ public class EMFMetamodelImporter extends AbstractEMFImporter<Language> {
   }
 
   public EMFMetamodelImporter(@Nonnull LionWebVersion lionWebVersion) {
-    super();
+    super(lionWebVersion);
   }
 
   public EMFMetamodelImporter(LanguageEntitiesToEElementsMapping entitiesToEElementsMapping) {
@@ -37,7 +37,7 @@ public class EMFMetamodelImporter extends AbstractEMFImporter<Language> {
   }
 
   public Language importEPackage(EPackage ePackage) {
-    Language metamodel = new Language(ePackage.getName());
+    Language metamodel = new Language(getLionWebVersion(), ePackage.getName());
     metamodel.setVersion("1");
     setIDAndKey(metamodel, ePackage.getName());
 
@@ -121,9 +121,9 @@ public class EMFMetamodelImporter extends AbstractEMFImporter<Language> {
         EEnum eEnum = (EEnum) eClassifier;
         Enumeration enumeration = entitiesToEElementsMapping.getCorrespondingEnumeration(eEnum);
         for (EEnumLiteral enumLiteral : eEnum.getELiterals()) {
-          EnumerationLiteral enumerationLiteral = new EnumerationLiteral(enumLiteral.getName());
+          EnumerationLiteral enumerationLiteral =
+              new EnumerationLiteral(enumeration, enumLiteral.getName());
           setIDAndKey(enumerationLiteral, enumeration.getID() + "-" + enumLiteral.getName());
-          enumeration.addLiteral(enumerationLiteral);
         }
       } else if (eClassifier instanceof EDataType) {
         // Nothing to do here

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelImporter.java
@@ -54,7 +54,7 @@ public class EMFMetamodelImporter extends AbstractEMFImporter<Language> {
         } else {
           Concept concept = new Concept(metamodel, eClass.getName());
           setIDAndKey(concept, ePackage.getName() + "-" + concept.getName());
-          concept.setAbstract(((EClass) eClassifier).isAbstract());
+          concept.setAbstract(eClass.isAbstract());
           metamodel.addElement(concept);
           entitiesToEElementsMapping.registerMapping(concept, eClass);
         }

--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/LanguageEntitiesToEElementsMapping.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/mapping/LanguageEntitiesToEElementsMapping.java
@@ -317,10 +317,11 @@ public class LanguageEntitiesToEElementsMapping {
 
     // Also add type literals from XMLTypePackageImpl
     eDataTypesToPrimitiveTypes.put(
-        XMLTypePackageImpl.Literals.STRING, LionCoreBuiltins.getString());
-    eDataTypesToPrimitiveTypes.put(XMLTypePackageImpl.Literals.INT, LionCoreBuiltins.getInteger());
+        XMLTypePackageImpl.Literals.STRING, LionCoreBuiltins.getString(lionWebVersion));
     eDataTypesToPrimitiveTypes.put(
-        XMLTypePackageImpl.Literals.BOOLEAN, LionCoreBuiltins.getBoolean());
+        XMLTypePackageImpl.Literals.INT, LionCoreBuiltins.getInteger(lionWebVersion));
+    eDataTypesToPrimitiveTypes.put(
+        XMLTypePackageImpl.Literals.BOOLEAN, LionCoreBuiltins.getBoolean(lionWebVersion));
   }
 
   public @Nonnull LionWebVersion getLionWebVersion() {

--- a/emf/src/test/resources/extended-library.ecore
+++ b/emf/src/test/resources/extended-library.ecore
@@ -12,4 +12,8 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="countries" upperBound="-1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//String"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="BookStatus">
+    <eLiterals name="OnLoan" value="1"/>
+    <eLiterals name="OnShelf"/>
+  </eClassifiers>
 </ecore:EPackage>


### PR DESCRIPTION
This update ensures that, when importing/exporting from Ecore meta-model and serializing a LionWeb version, we can choose a LionWeb version and have it set up consistently through all language elements.