### PR TITLE
Support FlatBuffers serialization of partitions

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/utils/IdUtils.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/IdUtils.java
@@ -6,6 +6,6 @@ public class IdUtils {
   }
 
   public static String cleanString(String string) {
-    return string.replaceAll("\\.", "-");
+    return string.replaceAll("[^a-zA-Z0-9_-]", "-");
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/utils/IdUtilsTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/utils/IdUtilsTest.java
@@ -1,0 +1,18 @@
+package io.lionweb.lioncore.java.utils;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class IdUtilsTest {
+
+  @Test
+  public void testCleanString() {
+    assertEquals("", IdUtils.cleanString(""));
+    assertEquals("a", IdUtils.cleanString("a"));
+    assertEquals("a-b", IdUtils.cleanString("a@b"));
+    assertEquals("---FF-", IdUtils.cleanString("(@%FF?"));
+    assertEquals("123_456", IdUtils.cleanString("123_456"));
+    assertEquals("123-456", IdUtils.cleanString("123-456"));
+  }
+
+}

--- a/core/src/test/java/io/lionweb/lioncore/java/utils/IdUtilsTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/utils/IdUtilsTest.java
@@ -1,6 +1,7 @@
 package io.lionweb.lioncore.java.utils;
 
 import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 public class IdUtilsTest {
@@ -14,5 +15,4 @@ public class IdUtilsTest {
     assertEquals("123_456", IdUtils.cleanString("123_456"));
     assertEquals("123-456", IdUtils.cleanString("123-456"));
   }
-
 }

--- a/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraFlatBuffersSerialization.java
+++ b/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraFlatBuffersSerialization.java
@@ -166,7 +166,10 @@ public class ExtraFlatBuffersSerialization extends FlatBuffersSerialization {
           node.getParent() == null
               ? containerByAttached.get(node.getID())
               : node.getParent().getID();
-      int parent = builder.createSharedString(parentID);
+      int parent = -1;
+      if (parentID != null) {
+        parent = builder.createSharedString(parentID);
+      }
       FBNode.startFBNode(builder);
       FBNode.addId(builder, id);
       FBNode.addClassifier(builder, classifier);
@@ -174,7 +177,9 @@ public class ExtraFlatBuffersSerialization extends FlatBuffersSerialization {
       FBNode.addContainments(builder, consVector);
       FBNode.addReferences(builder, refsVector);
       FBNode.addAnnotations(builder, annsVector);
-      FBNode.addParent(builder, parent);
+      if (parentID != null) {
+        FBNode.addParent(builder, parent);
+      }
 
       nodesOffsets[i] = FBNode.endFBNode(builder);
       i++;

--- a/extensions/src/test/java/ExtraFlatbuffersSerializationTest.java
+++ b/extensions/src/test/java/ExtraFlatbuffersSerializationTest.java
@@ -61,8 +61,8 @@ public class ExtraFlatbuffersSerializationTest {
   }
 
   /**
-   * In this example we serialize a proper root node as it has no parent and no attach point.
-   * We verify that with an effectively null parentID the serialization can still be completed.
+   * In this example we serialize a proper root node as it has no parent and no attach point. We
+   * verify that with an effectively null parentID the serialization can still be completed.
    */
   @Test
   public void bulkImportSerializationOfPartitions() {
@@ -80,7 +80,7 @@ public class ExtraFlatbuffersSerializationTest {
     bulkImport.addNode(n1);
 
     ExtraFlatBuffersSerialization flatBuffersSerialization =
-            ExtraSerializationProvider.getExtraStandardFlatBuffersSerialization();
+        ExtraSerializationProvider.getExtraStandardFlatBuffersSerialization();
     byte[] bytes = flatBuffersSerialization.serializeBulkImport(bulkImport);
 
     ByteBuffer bb = ByteBuffer.wrap(bytes);


### PR DESCRIPTION
Until now, FlatBuffers serialization has not been working for partitions (i.e., for nodes with a null parent). We fix that.

We also sneak in some changes into a method for removing invalid characters from a string and turning it into a valid ID.