### PR TITLE
Serialization performance follow-up

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationStatus.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationStatus.java
@@ -1,19 +1,18 @@
 package io.lionweb.lioncore.java.serialization;
 
-import io.lionweb.lioncore.java.language.Classifier;
-import io.lionweb.lioncore.java.language.Containment;
-import io.lionweb.lioncore.java.language.Property;
-import io.lionweb.lioncore.java.language.Reference;
+import io.lionweb.lioncore.java.language.*;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 public class SerializationStatus {
   private final Set<String> classifiersConsidered = new HashSet<>();
   private final IdentityHashMap<String, List<Property>> properties = new IdentityHashMap<>();
   private final IdentityHashMap<String, List<Containment>> containments = new IdentityHashMap<>();
   private final IdentityHashMap<String, List<Reference>> references = new IdentityHashMap<>();
+  private final Set<String> consideredLanguageIDs = new HashSet<>();
 
   public boolean hasConsideredClassifier(String classifierId) {
     return classifiersConsidered.contains(classifierId);
@@ -33,5 +32,13 @@ public class SerializationStatus {
 
   public Iterable<Reference> allReferences(Classifier<?> classifier) {
     return references.computeIfAbsent(classifier.getID(), id -> classifier.allReferences());
+  }
+
+  public void considerLanguageDuringSerialization(Consumer<Language> consumer, Language language) {
+    if (consideredLanguageIDs.contains(language.getID())) {
+      return;
+    }
+    consumer.accept(language);
+    consideredLanguageIDs.add(language.getID());
   }
 }

--- a/repo-client/src/main/java/io/lionweb/repoclient/impl/ClientForBulkAPIs.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/impl/ClientForBulkAPIs.java
@@ -160,7 +160,10 @@ public class ClientForBulkAPIs extends LionWebRepoClientImplHelper implements Bu
           List<Node> allNodes =
               conf.getJsonSerialization().deserializeToNodes(responseData.get("chunk"));
           Set<String> idsReturned =
-              allNodes.stream().filter(n -> !(n instanceof ProxyNode)).map(n -> n.getID()).collect(Collectors.toSet());
+              allNodes.stream()
+                  .filter(n -> !(n instanceof ProxyNode))
+                  .map(n -> n.getID())
+                  .collect(Collectors.toSet());
           // We want to return only the roots of the trees returned. From those, the other nodes can
           // be accessed
           return allNodes.stream()


### PR DESCRIPTION
In this PR we do another couple of refinements for the performance of serialization, based on a concrete case I had to deal with.

The case I considered:

* Used annotations
* Used many instances of many different concepts

So I applied similar changes we did to handle nodes to the handling of annotations. Also, I realized on expensive operation was considering new languages for serialization, so I put some guardrails in place to have adding multiple times the same language. 

In my case this helped improving the performance significantly.