### PR TITLE
Configure for publishing to Central Portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "com.diffplug.spotless" version "5.1.0"
     id "java"
     id 'net.researchgate.release' version '3.0.2'
-    id("com.vanniktech.maven.publish") version "0.29.0" apply false
+    alias(libs.plugins.vtpublish) apply false
 }
 
 repositories {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("java-library")
     id("signing")
     alias(libs.plugins.shadow)
-    id("com.vanniktech.maven.publish")
+    alias(libs.plugins.vtpublish)
     jacoco
     alias(libs.plugins.protobuf)
 }
@@ -59,8 +59,6 @@ tasks.register<Javadoc>("myJavadoc") {
         addStringOption("Xdoclint:none", "-quiet")
     }
 }
-
-val isReleaseVersion = !(version as String).endsWith("SNAPSHOT")
 
 tasks.register<Jar>("javadocJar") {
     dependsOn("myJavadoc")
@@ -122,7 +120,7 @@ mavenPublishing {
             }
         }
     }
-    publishToMavenCentral(SonatypeHost.S01, true)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
     signAllPublications()
 }
 

--- a/emf-builtins/build.gradle
+++ b/emf-builtins/build.gradle
@@ -3,7 +3,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
     id 'java-library'
-    id("com.vanniktech.maven.publish")
+    alias(libs.plugins.vtpublish)
     id "eclipse"
     id 'signing'
 }
@@ -94,8 +94,6 @@ processResources {
     from("plugin.xml")
 }
 
-var isReleaseVersion = !(version as String).endsWith("SNAPSHOT")
-
 task javadocJar(type: Jar) {
     archiveClassifier.set("javadoc")
 }
@@ -159,7 +157,7 @@ mavenPublishing {
             }
         }
     }
-    publishToMavenCentral(SonatypeHost.S01, true)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
     signAllPublications()
 }
 

--- a/emf/build.gradle.kts
+++ b/emf/build.gradle.kts
@@ -2,7 +2,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
     id("java-library")
-    id("com.vanniktech.maven.publish")
+    alias(libs.plugins.vtpublish)
     id("signing")
 }
 
@@ -49,8 +49,6 @@ tasks.register<Javadoc>("myJavadoc") {
         addStringOption("link", "https://alexanderpann.github.io/mps-openapi-doc/javadoc_2021.2/")
     }
 }
-
-val isReleaseVersion = !(version as String).endsWith("SNAPSHOT")
 
 tasks.register<Jar>("javadocJar") {
     dependsOn("myJavadoc")
@@ -117,6 +115,6 @@ mavenPublishing {
             }
         }
     }
-    publishToMavenCentral(SonatypeHost.S01, true)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
     signAllPublications()
 }

--- a/extensions/build.gradle.kts
+++ b/extensions/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("java-library")
     id("signing")
     alias(libs.plugins.shadow)
-    id("com.vanniktech.maven.publish")
+    alias(libs.plugins.vtpublish)
     jacoco
     alias(libs.plugins.protobuf)
 }
@@ -88,7 +88,7 @@ mavenPublishing {
             }
         }
     }
-    publishToMavenCentral(SonatypeHost.S01, true)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
     signAllPublications()
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ jvmVersion=1.8
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 SONATYPE_CONNECT_TIMEOUT_SECONDS=200
 SONATYPE_CLOSE_TIMEOUT_SECONDS=2000
-lionwebRepositoryCommitID=74d2c6ea6f719f27e6274182d5ab92c9b53cb3c6
+lionwebRepositoryCommitID=bf8f361aead20b317da0a28fae3ad7a7b1e5b7b1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ junitVersion="5.12.2"
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1"}
 protobuf = { id = "com.google.protobuf", version = "0.9.5"}
 buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.6.2" }
+vtpublish = { id = "com.vanniktech.maven.publish", version = "0.31.0" }
 
 [libraries]
 protobuf = { group = "com.google.protobuf", name = "protobuf-java", version.ref = "protobufVersion" }

--- a/repo-client-testing/build.gradle.kts
+++ b/repo-client-testing/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("java-library")
     alias(libs.plugins.buildConfig)
     id("signing")
-    id("com.vanniktech.maven.publish")
+    alias(libs.plugins.vtpublish)
 }
 
 val jvmVersion = extra["jvmVersion"] as String
@@ -105,7 +105,7 @@ mavenPublishing {
             }
         }
     }
-    publishToMavenCentral(SonatypeHost.S01, true)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
     signAllPublications()
 }
 

--- a/repo-client/build.gradle.kts
+++ b/repo-client/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("java-library")
     id("signing")
     alias(libs.plugins.shadow)
-    id("com.vanniktech.maven.publish")
+    alias(libs.plugins.vtpublish)
     jacoco
 }
 
@@ -78,7 +78,7 @@ mavenPublishing {
             }
         }
     }
-    publishToMavenCentral(SonatypeHost.S01, true)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
     signAllPublications()
 }
 


### PR DESCRIPTION
This is necessary as we moved from OSSRH to Central Portal, as OSSRH is about to be decommissioned.

Since we did the transition we cannot publish through OSSRH anymore.

I tested this by publishing snapshot (which worked).

I am asking a review to @enikao as it may be relevant for LionWeb MPS.