### PR TITLE
Add support for downloading/uploading entire repositories

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/AbstractSerialization.java
@@ -161,17 +161,6 @@ public abstract class AbstractSerialization {
     return serializeNodesToSerializationBlock(classifierInstances);
   }
 
-  public SerializedChunk groupNodesIntoSerializationBlock(
-      Collection<SerializedClassifierInstance> serializedClassifierInstances) {
-    SerializedChunk serializedChunk = new SerializedChunk();
-    serializedChunk.setSerializationFormatVersion(lionWebVersion.getVersionString());
-    for (SerializedClassifierInstance serializedClassifierInstance :
-        serializedClassifierInstances) {
-      serializedChunk.addClassifierInstance(serializedClassifierInstance);
-    }
-    return serializedChunk;
-  }
-
   public SerializedChunk serializeNodesToSerializationBlock(
       Collection<ClassifierInstance<?>> classifierInstances) {
     SerializedChunk serializedChunk = new SerializedChunk();

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
@@ -2,7 +2,6 @@ package io.lionweb.lioncore.java.serialization;
 
 import com.google.gson.*;
 import io.lionweb.lioncore.java.LionWebVersion;
-import io.lionweb.lioncore.java.language.Classifier;
 import io.lionweb.lioncore.java.serialization.data.*;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -10,7 +9,6 @@ import java.io.FileReader;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
@@ -142,13 +140,13 @@ public class LowLevelJsonSerialization {
   }
 
   public static SerializedChunk groupNodesIntoSerializationBlock(
-          Collection<SerializedClassifierInstance> serializedClassifierInstances,
-          LionWebVersion lionWebVersion) {
+      Collection<SerializedClassifierInstance> serializedClassifierInstances,
+      LionWebVersion lionWebVersion) {
     SerializedChunk serializedChunk = new SerializedChunk();
     serializedChunk.setSerializationFormatVersion(lionWebVersion.getVersionString());
     SerializationStatus serializationStatus = new SerializationStatus(serializedChunk);
     for (SerializedClassifierInstance serializedClassifierInstance :
-            serializedClassifierInstances) {
+        serializedClassifierInstances) {
       serializedChunk.addClassifierInstance(serializedClassifierInstance);
       serializationStatus.consider(serializedClassifierInstance);
     }

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
@@ -139,6 +139,7 @@ public class LowLevelJsonSerialization {
         .toJson(serializeToJsonElement(serializedChunk));
   }
 
+  /** Create a SerializedChunk containing the given nodes. */
   public static SerializedChunk groupNodesIntoSerializationBlock(
       Collection<SerializedClassifierInstance> serializedClassifierInstances,
       LionWebVersion lionWebVersion) {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/LowLevelJsonSerialization.java
@@ -1,6 +1,8 @@
 package io.lionweb.lioncore.java.serialization;
 
 import com.google.gson.*;
+import io.lionweb.lioncore.java.LionWebVersion;
+import io.lionweb.lioncore.java.language.Classifier;
 import io.lionweb.lioncore.java.serialization.data.*;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -8,6 +10,7 @@ import java.io.FileReader;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
@@ -136,6 +139,20 @@ public class LowLevelJsonSerialization {
         .setPrettyPrinting()
         .create()
         .toJson(serializeToJsonElement(serializedChunk));
+  }
+
+  public static SerializedChunk groupNodesIntoSerializationBlock(
+          Collection<SerializedClassifierInstance> serializedClassifierInstances,
+          LionWebVersion lionWebVersion) {
+    SerializedChunk serializedChunk = new SerializedChunk();
+    serializedChunk.setSerializationFormatVersion(lionWebVersion.getVersionString());
+    SerializationStatus serializationStatus = new SerializationStatus(serializedChunk);
+    for (SerializedClassifierInstance serializedClassifierInstance :
+            serializedClassifierInstances) {
+      serializedChunk.addClassifierInstance(serializedClassifierInstance);
+      serializationStatus.consider(serializedClassifierInstance);
+    }
+    return serializedChunk;
   }
 
   //

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationStatus.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationStatus.java
@@ -5,7 +5,6 @@ import io.lionweb.lioncore.java.serialization.data.MetaPointer;
 import io.lionweb.lioncore.java.serialization.data.SerializedChunk;
 import io.lionweb.lioncore.java.serialization.data.SerializedClassifierInstance;
 import io.lionweb.lioncore.java.serialization.data.UsedLanguage;
-
 import java.util.*;
 import java.util.function.Consumer;
 

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationStatus.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationStatus.java
@@ -64,6 +64,9 @@ public class SerializationStatus {
     }
   }
 
+  /**
+   * Consider the given classifier and all of its properties to track the used languages.
+   */
   public void consider(Classifier<?> classifier, Consumer<Language> languageConsumer) {
     if (!hasConsideredClassifier(classifier.getID())) {
       Objects.requireNonNull(classifier, "A node should have a concept in order to be serialized");

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationStatus.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationStatus.java
@@ -64,9 +64,7 @@ public class SerializationStatus {
     }
   }
 
-  /**
-   * Consider the given classifier and all of its properties to track the used languages.
-   */
+  /** Consider the given classifier and all of its properties to track the used languages. */
   public void consider(Classifier<?> classifier, Consumer<Language> languageConsumer) {
     if (!hasConsideredClassifier(classifier.getID())) {
       Objects.requireNonNull(classifier, "A node should have a concept in order to be serialized");

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationStatus.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationStatus.java
@@ -15,10 +15,13 @@ public class SerializationStatus {
   private final IdentityHashMap<String, List<Reference>> references = new IdentityHashMap<>();
   private final Set<String> consideredLanguageIDs = new HashSet<>();
   private final SerializedChunk serializedChunk;
+  // This is a cache, reflecting the list of languages in serializedChunk,
+  // but as a set, for faster access
   private final Set<UsedLanguage> usedLanguages = new HashSet<>();
 
   public SerializationStatus(SerializedChunk serializedChunk) {
     this.serializedChunk = serializedChunk;
+    this.usedLanguages.addAll(serializedChunk.getLanguages());
   }
 
   public boolean hasConsideredClassifier(String classifierId) {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/data/SerializedClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/data/SerializedClassifierInstance.java
@@ -37,9 +37,12 @@ public class SerializedClassifierInstance {
     setClassifier(concept);
   }
 
+  /**
+   * Remove all containments. This is useful when we want to create a partitions, as they cannot be
+   * created when having children.
+   */
   public void clearContainments() {
     containments.clear();
-    ;
   }
 
   public List<SerializedContainmentValue> getContainments() {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/data/SerializedClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/data/SerializedClassifierInstance.java
@@ -37,6 +37,10 @@ public class SerializedClassifierInstance {
     setClassifier(concept);
   }
 
+  public void clearContainments() {
+    containments.clear();;
+  }
+
   public List<SerializedContainmentValue> getContainments() {
     return Collections.unmodifiableList(this.containments);
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/data/SerializedClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/data/SerializedClassifierInstance.java
@@ -38,7 +38,8 @@ public class SerializedClassifierInstance {
   }
 
   public void clearContainments() {
-    containments.clear();;
+    containments.clear();
+    ;
   }
 
   public List<SerializedContainmentValue> getContainments() {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/data/SerializedClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/data/SerializedClassifierInstance.java
@@ -38,8 +38,8 @@ public class SerializedClassifierInstance {
   }
 
   /**
-   * Remove all containments. This is useful when we want to create a partitions, as they cannot be
-   * created when having children.
+   * Remove all containments. This is useful when we want to create a partition, as they cannot be
+   * created with children. Children can only be added in a second moment.
    */
   public void clearContainments() {
     containments.clear();

--- a/extensions/src/functionalTest/java/io/lionweb/repoclient/PropertiesLanguage.java
+++ b/extensions/src/functionalTest/java/io/lionweb/repoclient/PropertiesLanguage.java
@@ -1,0 +1,78 @@
+package io.lionweb.repoclient;
+
+import io.lionweb.lioncore.java.LionWebVersion;
+import io.lionweb.lioncore.java.language.*;
+
+public class PropertiesLanguage {
+  public static final Concept propertiesPartition;
+  public static final Concept propertiesFile;
+  public static final Concept property;
+  public static final Language propertiesLanguage;
+  private static LionWebVersion lionWebVersionUsed = LionWebVersion.v2023_1;
+
+  static {
+    // Create language
+    String name = "Properties";
+    String cleanedName = name.toLowerCase().replace(".", "_");
+    propertiesLanguage = new Language(lionWebVersionUsed, name);
+    propertiesLanguage.setID("language-" + cleanedName + "-id");
+    propertiesLanguage.setVersion("1");
+    propertiesLanguage.setKey("language-" + cleanedName + "-key");
+
+    // Create concepts
+    propertiesPartition = createConcept(propertiesLanguage, "PropertiesPartition");
+    propertiesPartition.setPartition(true);
+    propertiesFile = createConcept(propertiesLanguage, "PropertiesFile");
+    property = createConcept(propertiesLanguage, "Property");
+
+    // Register concept features
+    propertiesPartition.setPartition(true);
+    addContainment(propertiesPartition, "files", propertiesFile, Multiplicity.ZERO_TO_MANY);
+    Property filePath = new Property(LionWebVersion.v2023_1, "path", propertiesFile);
+    filePath.setID(propertiesFile.getID() + "-path");
+    filePath.setKey(propertiesFile.getKey() + "-path");
+    filePath.setType(LionCoreBuiltins.getString(lionWebVersionUsed));
+    propertiesFile.addFeature(filePath);
+
+    addContainment(propertiesFile, "properties", property, Multiplicity.ZERO_TO_MANY);
+    property.addImplementedInterface(LionCoreBuiltins.getINamed(lionWebVersionUsed));
+  }
+
+  private static Concept createConcept(Language language, String name) {
+    Concept concept = new Concept(lionWebVersionUsed, language, name);
+    concept.setID(
+        language.getID().replace("language-", "").replace("-id", "") + "-" + name + "-id");
+    concept.setKey(
+        language.getKey().replace("language-", "").replace("-key", "") + "-" + name + "-key");
+    language.addElement(concept);
+    return concept;
+  }
+
+  private static Containment addContainment(
+      Classifier<?> owner, String name, Classifier<?> target, Multiplicity multiplicity) {
+    Containment containment = new Containment(lionWebVersionUsed);
+    containment.setName(name);
+    containment.setID(owner.getID().replace("-id", "") + "-" + name + "-id");
+    containment.setKey(owner.getKey().replace("-key", "") + "-" + name + "-key");
+    containment.setType(target);
+    containment.setOptional(multiplicity.optional);
+    containment.setMultiple(multiplicity.multiple);
+    owner.addFeature(containment);
+    return containment;
+  }
+
+  public enum Multiplicity {
+    OPTIONAL(true, false),
+    SINGLE(false, false),
+    ZERO_TO_MANY(true, true),
+    ONE_TO_MANY(false, true);
+
+    public final boolean optional;
+    public final boolean multiple;
+
+    Multiplicity(boolean optional, boolean multiple) {
+      this.optional = optional;
+      this.multiple = multiple;
+    }
+  }
+}

--- a/extensions/src/functionalTest/java/io/lionweb/repoclient/RepoSerializationTest.java
+++ b/extensions/src/functionalTest/java/io/lionweb/repoclient/RepoSerializationTest.java
@@ -1,0 +1,114 @@
+package io.lionweb.repoclient;
+
+import io.lionweb.lioncore.java.LionWebVersion;
+import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
+import io.lionweb.lioncore.java.model.Node;
+import io.lionweb.lioncore.java.model.impl.DynamicNode;
+import io.lionweb.repoclient.api.HistorySupport;
+import io.lionweb.repoclient.api.RepositoryConfiguration;
+import io.lionweb.repoclient.testing.AbstractRepoClientFunctionalTest;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
+public class RepoSerializationTest extends AbstractRepoClientFunctionalTest {
+
+  public RepoSerializationTest() {
+    super(LionWebVersion.v2023_1, true);
+  }
+
+  private void storePropertiesPartitions(String repositoryName) throws IOException {
+    ExtendedLionWebRepoClient client =
+            new ExtendedLionWebRepoClient(
+                    LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName);
+    client.createRepository(
+            new RepositoryConfiguration(
+                    repositoryName, LionWebVersion.v2023_1, HistorySupport.DISABLED));
+
+    int nPartitions = 100;
+    int nFiles = 10;
+    for (int i = 0; i < nPartitions; i++) {
+      DynamicNode partition = new DynamicNode("p-" + i, PropertiesLanguage.propertiesPartition);
+      client.createPartition(partition);
+
+      for (int j = 0; j < nFiles; j++) {
+        DynamicNode file =
+                new DynamicNode("p-" + i + "-file-" + j, PropertiesLanguage.propertiesFile);
+        ClassifierInstanceUtils.setPropertyValueByName(file, "path", "path-" + j + ".json");
+
+        DynamicNode propertyA =
+                new DynamicNode("p-" + i + "-file-" + j + "-a", PropertiesLanguage.property);
+        ClassifierInstanceUtils.setPropertyValueByName(propertyA, "name", "A");
+        ClassifierInstanceUtils.addChild(file, "properties", propertyA);
+
+        DynamicNode propertyB =
+                new DynamicNode("p-" + i + "-file-" + j + "-b", PropertiesLanguage.property);
+        ClassifierInstanceUtils.setPropertyValueByName(propertyB, "name", "B");
+        ClassifierInstanceUtils.addChild(file, "properties", propertyB);
+
+        DynamicNode propertyC =
+                new DynamicNode("p-" + i + "-file-" + j + "-c", PropertiesLanguage.property);
+        ClassifierInstanceUtils.setPropertyValueByName(propertyC, "name", "C");
+        ClassifierInstanceUtils.addChild(file, "properties", propertyC);
+
+        ClassifierInstanceUtils.addChild(partition, "files", file);
+      }
+      client.store(partition);
+    }
+
+    Set<String> actualPartitionsIDs = new HashSet<>(client.listPartitionsIDs());
+    Set<String> expectedPartitionsIDs = IntStream.range(0, 100)
+            .mapToObj(i -> "p-" + i)
+            .collect(Collectors.toSet());
+    assertEquals(expectedPartitionsIDs, actualPartitionsIDs);
+
+    Node p20 = client.retrieve("p-20");
+    assertEquals(nFiles, ClassifierInstanceUtils.getChildrenByContainmentName(p20, "files").size());
+  }
+
+  @Test
+  public void uploadAndDownloadPartitions() throws IOException {
+    String repositoryName = "uploadAndDownloadPartitions";
+    storePropertiesPartitions(repositoryName);
+
+    ExtendedLionWebRepoClient client =
+            new ExtendedLionWebRepoClient(
+                    LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName);
+    File zip = new File("/Users/ftomassetti/repos/lionweb-java/pippo.zip");
+    RepoSerialization repoSerialization = new RepoSerialization();
+    client.getJsonSerialization().registerLanguage(PropertiesLanguage.propertiesLanguage);
+    repoSerialization.downloadRepoAsZip(client, zip);
+
+    ExtendedLionWebRepoClient clientCopy1 =
+            new ExtendedLionWebRepoClient(
+                    LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName+"-copy1");
+    clientCopy1.createRepository(
+            new RepositoryConfiguration(
+                    repositoryName+"-copy1", LionWebVersion.v2023_1, HistorySupport.DISABLED));
+    long t0 = System.currentTimeMillis();
+    repoSerialization.simpleUploadZipToRepo(clientCopy1, zip);
+    long t1 = System.currentTimeMillis();
+    System.out.println("Simple upload took " + (t1-t0) + "ms");
+
+    ExtendedLionWebRepoClient clientCopy2 =
+            new ExtendedLionWebRepoClient(
+                    LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName+"-copy2");
+    clientCopy2.createRepository(
+            new RepositoryConfiguration(
+                    repositoryName+"-copy2", LionWebVersion.v2023_1, HistorySupport.DISABLED));
+    long t2 = System.currentTimeMillis();
+    repoSerialization.bulkUploadZipToRepo(clientCopy2, zip);
+    long t3 = System.currentTimeMillis();
+    System.out.println("Bulk upload took " + (t3-t2) + "ms");
+  }
+}

--- a/extensions/src/functionalTest/java/io/lionweb/repoclient/RepoSerializationTest.java
+++ b/extensions/src/functionalTest/java/io/lionweb/repoclient/RepoSerializationTest.java
@@ -1,5 +1,7 @@
 package io.lionweb.repoclient;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
 import io.lionweb.lioncore.java.model.Node;
@@ -15,11 +17,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Testcontainers;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Testcontainers
 public class RepoSerializationTest extends AbstractRepoClientFunctionalTest {
@@ -33,11 +32,11 @@ public class RepoSerializationTest extends AbstractRepoClientFunctionalTest {
 
   private void storePropertiesPartitions(String repositoryName) throws IOException {
     ExtendedLionWebRepoClient client =
-            new ExtendedLionWebRepoClient(
-                    LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName);
+        new ExtendedLionWebRepoClient(
+            LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName);
     client.createRepository(
-            new RepositoryConfiguration(
-                    repositoryName, LionWebVersion.v2023_1, HistorySupport.DISABLED));
+        new RepositoryConfiguration(
+            repositoryName, LionWebVersion.v2023_1, HistorySupport.DISABLED));
 
     for (int i = 0; i < nPartitions; i++) {
       DynamicNode partition = new DynamicNode("p-" + i, PropertiesLanguage.propertiesPartition);
@@ -45,21 +44,21 @@ public class RepoSerializationTest extends AbstractRepoClientFunctionalTest {
 
       for (int j = 0; j < nFiles; j++) {
         DynamicNode file =
-                new DynamicNode("p-" + i + "-file-" + j, PropertiesLanguage.propertiesFile);
+            new DynamicNode("p-" + i + "-file-" + j, PropertiesLanguage.propertiesFile);
         ClassifierInstanceUtils.setPropertyValueByName(file, "path", "path-" + j + ".json");
 
         DynamicNode propertyA =
-                new DynamicNode("p-" + i + "-file-" + j + "-a", PropertiesLanguage.property);
+            new DynamicNode("p-" + i + "-file-" + j + "-a", PropertiesLanguage.property);
         ClassifierInstanceUtils.setPropertyValueByName(propertyA, "name", "A");
         ClassifierInstanceUtils.addChild(file, "properties", propertyA);
 
         DynamicNode propertyB =
-                new DynamicNode("p-" + i + "-file-" + j + "-b", PropertiesLanguage.property);
+            new DynamicNode("p-" + i + "-file-" + j + "-b", PropertiesLanguage.property);
         ClassifierInstanceUtils.setPropertyValueByName(propertyB, "name", "B");
         ClassifierInstanceUtils.addChild(file, "properties", propertyB);
 
         DynamicNode propertyC =
-                new DynamicNode("p-" + i + "-file-" + j + "-c", PropertiesLanguage.property);
+            new DynamicNode("p-" + i + "-file-" + j + "-c", PropertiesLanguage.property);
         ClassifierInstanceUtils.setPropertyValueByName(propertyC, "name", "C");
         ClassifierInstanceUtils.addChild(file, "properties", propertyC);
 
@@ -72,9 +71,8 @@ public class RepoSerializationTest extends AbstractRepoClientFunctionalTest {
 
   private void checkContentOfRepo(ExtendedLionWebRepoClient client) throws IOException {
     Set<String> actualPartitionsIDs = new HashSet<>(client.listPartitionsIDs());
-    Set<String> expectedPartitionsIDs = IntStream.range(0, 100)
-            .mapToObj(i -> "p-" + i)
-            .collect(Collectors.toSet());
+    Set<String> expectedPartitionsIDs =
+        IntStream.range(0, 100).mapToObj(i -> "p-" + i).collect(Collectors.toSet());
     assertEquals(expectedPartitionsIDs, actualPartitionsIDs);
 
     Node p20 = client.retrieve("p-20");
@@ -87,36 +85,36 @@ public class RepoSerializationTest extends AbstractRepoClientFunctionalTest {
     storePropertiesPartitions(repositoryName);
 
     ExtendedLionWebRepoClient client =
-            new ExtendedLionWebRepoClient(
-                    LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName);
+        new ExtendedLionWebRepoClient(
+            LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName);
     File zip = Files.createTempFile("", ".zip").toFile();
     RepoSerialization repoSerialization = new RepoSerialization();
     client.getJsonSerialization().registerLanguage(PropertiesLanguage.propertiesLanguage);
     repoSerialization.downloadRepoAsZip(client, zip);
 
     ExtendedLionWebRepoClient clientCopy1 =
-            new ExtendedLionWebRepoClient(
-                    LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName+"-copy1");
+        new ExtendedLionWebRepoClient(
+            LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName + "-copy1");
     clientCopy1.createRepository(
-            new RepositoryConfiguration(
-                    repositoryName+"-copy1", LionWebVersion.v2023_1, HistorySupport.DISABLED));
+        new RepositoryConfiguration(
+            repositoryName + "-copy1", LionWebVersion.v2023_1, HistorySupport.DISABLED));
     long t0 = System.currentTimeMillis();
     repoSerialization.simpleUploadZipToRepo(clientCopy1, zip);
     long t1 = System.currentTimeMillis();
-    System.out.println("Simple upload took " + (t1-t0) + "ms");
+    System.out.println("Simple upload took " + (t1 - t0) + "ms");
     clientCopy1.getJsonSerialization().registerLanguage(PropertiesLanguage.propertiesLanguage);
     checkContentOfRepo(clientCopy1);
 
     ExtendedLionWebRepoClient clientCopy2 =
-            new ExtendedLionWebRepoClient(
-                    LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName+"-copy2");
+        new ExtendedLionWebRepoClient(
+            LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName + "-copy2");
     clientCopy2.createRepository(
-            new RepositoryConfiguration(
-                    repositoryName+"-copy2", LionWebVersion.v2023_1, HistorySupport.DISABLED));
+        new RepositoryConfiguration(
+            repositoryName + "-copy2", LionWebVersion.v2023_1, HistorySupport.DISABLED));
     long t2 = System.currentTimeMillis();
     repoSerialization.bulkUploadZipToRepo(clientCopy2, zip);
     long t3 = System.currentTimeMillis();
-    System.out.println("Bulk upload took " + (t3-t2) + "ms");
+    System.out.println("Bulk upload took " + (t3 - t2) + "ms");
     clientCopy2.getJsonSerialization().registerLanguage(PropertiesLanguage.propertiesLanguage);
     checkContentOfRepo(clientCopy2);
   }
@@ -127,38 +125,40 @@ public class RepoSerializationTest extends AbstractRepoClientFunctionalTest {
     storePropertiesPartitions(repositoryName);
 
     ExtendedLionWebRepoClient client =
-            new ExtendedLionWebRepoClient(
-                    LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName);
+        new ExtendedLionWebRepoClient(
+            LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName);
     File dir = Files.createTempDirectory("repo-data-dir").toFile();
     RepoSerialization repoSerialization = new RepoSerialization();
     client.getJsonSerialization().registerLanguage(PropertiesLanguage.propertiesLanguage);
     repoSerialization.downloadRepoAsDirectory(client, dir);
     assertEquals(nPartitions, client.listPartitionsIDs().size());
-    assertEquals(nPartitions, Arrays.stream(dir.listFiles()).filter(f -> f.getName().endsWith(".json")).count());
+    assertEquals(
+        nPartitions,
+        Arrays.stream(dir.listFiles()).filter(f -> f.getName().endsWith(".json")).count());
 
     ExtendedLionWebRepoClient clientCopy1 =
-            new ExtendedLionWebRepoClient(
-                    LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName+"-copy1");
+        new ExtendedLionWebRepoClient(
+            LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName + "-copy1");
     clientCopy1.createRepository(
-            new RepositoryConfiguration(
-                    repositoryName+"-copy1", LionWebVersion.v2023_1, HistorySupport.DISABLED));
+        new RepositoryConfiguration(
+            repositoryName + "-copy1", LionWebVersion.v2023_1, HistorySupport.DISABLED));
     long t0 = System.currentTimeMillis();
     repoSerialization.simpleUploadDirectoryToRepo(clientCopy1, dir);
     long t1 = System.currentTimeMillis();
-    System.out.println("Simple upload took " + (t1-t0) + "ms");
+    System.out.println("Simple upload took " + (t1 - t0) + "ms");
     clientCopy1.getJsonSerialization().registerLanguage(PropertiesLanguage.propertiesLanguage);
     checkContentOfRepo(clientCopy1);
 
     ExtendedLionWebRepoClient clientCopy2 =
-            new ExtendedLionWebRepoClient(
-                    LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName+"-copy2");
+        new ExtendedLionWebRepoClient(
+            LionWebVersion.v2023_1, "localhost", getModelRepoPort(), repositoryName + "-copy2");
     clientCopy2.createRepository(
-            new RepositoryConfiguration(
-                    repositoryName+"-copy2", LionWebVersion.v2023_1, HistorySupport.DISABLED));
+        new RepositoryConfiguration(
+            repositoryName + "-copy2", LionWebVersion.v2023_1, HistorySupport.DISABLED));
     long t2 = System.currentTimeMillis();
     repoSerialization.bulkUploadDirectoryToRepo(clientCopy2, dir);
     long t3 = System.currentTimeMillis();
-    System.out.println("Bulk upload took " + (t3-t2) + "ms");
+    System.out.println("Bulk upload took " + (t3 - t2) + "ms");
     clientCopy2.getJsonSerialization().registerLanguage(PropertiesLanguage.propertiesLanguage);
     checkContentOfRepo(clientCopy2);
   }

--- a/extensions/src/main/java/io/lionweb/repoclient/RepoSerialization.java
+++ b/extensions/src/main/java/io/lionweb/repoclient/RepoSerialization.java
@@ -27,7 +27,7 @@ import kotlin.text.Charsets;
 
 /** This class contains the logic to store and retrieve entire repositories at once. */
 public class RepoSerialization {
-  private int nNodesThreshold = 100_000;
+  private int numberOfNodesThreshold = 100_000;
   private TransferFormat transferFormat = TransferFormat.FLATBUFFERS;
   private Compression compression = Compression.DISABLED;
 
@@ -56,7 +56,8 @@ public class RepoSerialization {
   public <C extends RawBulkAPIClient & BulkAPIClient> void downloadRepoAsZip(
       C apiClient, File zipFile) throws IOException {
     try (FileOutputStream fos = new FileOutputStream(zipFile);
-        ZipOutputStream zos = new ZipOutputStream(fos)) {
+        BufferedOutputStream bos = new BufferedOutputStream(fos);
+        ZipOutputStream zos = new ZipOutputStream(bos)) {
 
       for (String partitionID : apiClient.listPartitionsIDs()) {
         String partitionData =
@@ -126,7 +127,7 @@ public class RepoSerialization {
       SerializedChunk serializedChunk =
           lowLevelJsonSerialization.deserializeSerializationBlock(file);
       bulkImport.addNodes(serializedChunk.getClassifierInstances());
-      if (bulkImport.numberOfNodes() >= nNodesThreshold) {
+      if (bulkImport.numberOfNodes() >= numberOfNodesThreshold) {
         apiClient.bulkImport(bulkImport, transferFormat, compression);
         bulkImport.clear();
       }
@@ -235,7 +236,7 @@ public class RepoSerialization {
             lowLevelJsonSerialization.deserializeSerializationBlock(tempFile);
         bulkImport.addNodes(serializedChunk.getClassifierInstances());
 
-        if (bulkImport.numberOfNodes() >= nNodesThreshold) {
+        if (bulkImport.numberOfNodes() >= numberOfNodesThreshold) {
           apiClient.bulkImport(bulkImport, transferFormat, compression);
           bulkImport.clear();
         }

--- a/extensions/src/main/java/io/lionweb/repoclient/RepoSerialization.java
+++ b/extensions/src/main/java/io/lionweb/repoclient/RepoSerialization.java
@@ -20,6 +20,7 @@ import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 import kotlin.text.Charsets;
 
+/** This class contains the logic to store and retrieve entire repositories at once. */
 public class RepoSerialization {
   private int nNodesThreshold = 100_000;
   private TransferFormat transferFormat = TransferFormat.FLATBUFFERS;

--- a/extensions/src/main/java/io/lionweb/repoclient/RepoSerialization.java
+++ b/extensions/src/main/java/io/lionweb/repoclient/RepoSerialization.java
@@ -7,8 +7,6 @@ import io.lionweb.serialization.extensions.AdditionalAPIClient;
 import io.lionweb.serialization.extensions.BulkImport;
 import io.lionweb.serialization.extensions.Compression;
 import io.lionweb.serialization.extensions.TransferFormat;
-import kotlin.text.Charsets;
-
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -17,112 +15,177 @@ import java.util.Collections;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
+import kotlin.text.Charsets;
 
 public class RepoSerialization {
-    private int nNodesThreshold = 100_000;
-    private TransferFormat transferFormat = TransferFormat.FLATBUFFERS;
-    private Compression compression = Compression.DISABLED;
+  private int nNodesThreshold = 100_000;
+  private TransferFormat transferFormat = TransferFormat.FLATBUFFERS;
+  private Compression compression = Compression.DISABLED;
 
-    public void downloadRepoAsDirectory(BulkAPIClient bulkAPIClient,
-                                        File directory) throws IOException {
-        for (String partitionID: bulkAPIClient.listPartitionsIDs()) {
-            String partitionData = bulkAPIClient.rawRetrieve(bulkAPIClient.listPartitionsIDs(), Integer.MAX_VALUE);
-            File partitionFile = new File(directory, partitionID + ".json");
-            Files.write(partitionFile.toPath(),
-                    Collections.singletonList(partitionData),
-                    StandardOpenOption.CREATE,
-                    StandardOpenOption.TRUNCATE_EXISTING);
-        }
+  public void downloadRepoAsDirectory(BulkAPIClient bulkAPIClient, File directory)
+      throws IOException {
+    for (String partitionID : bulkAPIClient.listPartitionsIDs()) {
+      String partitionData =
+          bulkAPIClient.rawRetrieve(bulkAPIClient.listPartitionsIDs(), Integer.MAX_VALUE);
+      File partitionFile = new File(directory, partitionID + ".json");
+      Files.write(
+          partitionFile.toPath(),
+          Collections.singletonList(partitionData),
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING);
+    }
+  }
+
+  public void downloadRepoAsZip(BulkAPIClient bulkAPIClient, File zipFile) throws IOException {
+    try (FileOutputStream fos = new FileOutputStream(zipFile);
+        ZipOutputStream zos = new ZipOutputStream(fos)) {
+
+      for (String partitionID : bulkAPIClient.listPartitionsIDs()) {
+        String partitionData =
+            bulkAPIClient.rawRetrieve(Collections.singletonList(partitionID), Integer.MAX_VALUE);
+
+        ZipEntry entry = new ZipEntry(partitionID + ".json");
+        zos.putNextEntry(entry);
+
+        byte[] dataBytes = partitionData.getBytes(StandardCharsets.UTF_8);
+        zos.write(dataBytes, 0, dataBytes.length);
+
+        zos.closeEntry();
+      }
+    }
+  }
+
+  public void simpleUploadDirectoryToRepo(BulkAPIClient bulkAPIClient, File directory)
+      throws IOException {
+    if (!directory.isDirectory()) {
+      throw new IllegalArgumentException(
+          "Provided file is not a directory: " + directory.getAbsolutePath());
     }
 
-    public void downloadRepoAsZip(BulkAPIClient bulkAPIClient, File zipFile) throws IOException {
-        try (FileOutputStream fos = new FileOutputStream(zipFile);
-             ZipOutputStream zos = new ZipOutputStream(fos)) {
-
-            for (String partitionID : bulkAPIClient.listPartitionsIDs()) {
-                String partitionData = bulkAPIClient.rawRetrieve(Collections.singletonList(partitionID), Integer.MAX_VALUE);
-
-                ZipEntry entry = new ZipEntry(partitionID + ".json");
-                zos.putNextEntry(entry);
-
-                byte[] dataBytes = partitionData.getBytes(StandardCharsets.UTF_8);
-                zos.write(dataBytes, 0, dataBytes.length);
-
-                zos.closeEntry();
-            }
-        }
+    File[] files = directory.listFiles((dir, name) -> name.endsWith(".json"));
+    if (files == null) {
+      throw new IOException("Unable to list files in directory: " + directory.getAbsolutePath());
     }
 
-    public void uploadDirectoryToRepo(BulkAPIClient bulkAPIClient, File directory) throws IOException {
-        if (!directory.isDirectory()) {
-            throw new IllegalArgumentException("Provided file is not a directory: " + directory.getAbsolutePath());
-        }
+    for (File file : files) {
+      String content = new String(Files.readAllBytes(file.toPath()), Charsets.UTF_8);
 
-        File[] files = directory.listFiles((dir, name) -> name.endsWith(".json"));
-        if (files == null) {
-            throw new IOException("Unable to list files in directory: " + directory.getAbsolutePath());
-        }
+      bulkAPIClient.rawStore(content);
+    }
+  }
 
-        for (File file : files) {
-            String content = new String(Files.readAllBytes(file.toPath()), Charsets.UTF_8);
-
-            bulkAPIClient.rawStore(content);
-        }
+  public void bulkUploadDirectoryToRepo(AdditionalAPIClient additionalAPIClient, File directory)
+      throws IOException {
+    if (!directory.isDirectory()) {
+      throw new IllegalArgumentException(
+          "Provided file is not a directory: " + directory.getAbsolutePath());
     }
 
-    public void uploadDirectoryToRepo(AdditionalAPIClient additionalAPIClient, File directory) throws IOException {
-        if (!directory.isDirectory()) {
-            throw new IllegalArgumentException("Provided file is not a directory: " + directory.getAbsolutePath());
-        }
-
-        File[] files = directory.listFiles((dir, name) -> name.endsWith(".json"));
-        if (files == null) {
-            throw new IOException("Unable to list files in directory: " + directory.getAbsolutePath());
-        }
-
-        LowLevelJsonSerialization lowLevelJsonSerialization = new LowLevelJsonSerialization();
-        BulkImport bulkImport = new BulkImport();
-        for (File file : files) {
-            SerializedChunk serializedChunk = lowLevelJsonSerialization.deserializeSerializationBlock(file);
-            bulkImport.addNodes(serializedChunk.getClassifierInstances());
-            if (bulkImport.numberOfNodes() >= nNodesThreshold) {
-                additionalAPIClient.bulkImport(bulkImport, transferFormat, compression);
-                bulkImport.clear();
-            }
-        }
-        if (!bulkImport.isEmpty()) {
-            additionalAPIClient.bulkImport(bulkImport, transferFormat, compression);
-        }
+    File[] files = directory.listFiles((dir, name) -> name.endsWith(".json"));
+    if (files == null) {
+      throw new IOException("Unable to list files in directory: " + directory.getAbsolutePath());
     }
 
-    public void uploadZipToRepo(BulkAPIClient bulkAPIClient, File zip) throws IOException {
-        if (!zip.isFile()) {
-            throw new IllegalArgumentException("Provided path is not a valid zip file: " + zip.getAbsolutePath());
-        }
-
-        try (FileInputStream fis = new FileInputStream(zip);
-             ZipInputStream zis = new ZipInputStream(fis, StandardCharsets.UTF_8)) {
-
-            ZipEntry entry;
-            final int BUFFER_SIZE = 32 * 1024;
-            byte[] buffer = new byte[BUFFER_SIZE];
-            while ((entry = zis.getNextEntry()) != null) {
-                if (!entry.getName().endsWith(".json")) {
-                    continue;
-                }
-
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                int bytesRead;
-                while ((bytesRead = zis.read(buffer)) != -1) {
-                    baos.write(buffer, 0, bytesRead);
-                }
-
-                String content = new String(baos.toByteArray(), StandardCharsets.UTF_8);
-
-                bulkAPIClient.rawStore(content);
-
-                zis.closeEntry();
-            }
-        }
+    LowLevelJsonSerialization lowLevelJsonSerialization = new LowLevelJsonSerialization();
+    BulkImport bulkImport = new BulkImport();
+    for (File file : files) {
+      SerializedChunk serializedChunk =
+          lowLevelJsonSerialization.deserializeSerializationBlock(file);
+      bulkImport.addNodes(serializedChunk.getClassifierInstances());
+      if (bulkImport.numberOfNodes() >= nNodesThreshold) {
+        additionalAPIClient.bulkImport(bulkImport, transferFormat, compression);
+        bulkImport.clear();
+      }
     }
+    if (!bulkImport.isEmpty()) {
+      additionalAPIClient.bulkImport(bulkImport, transferFormat, compression);
+    }
+  }
+
+  public void simpleUploadZipToRepo(BulkAPIClient bulkAPIClient, File zip) throws IOException {
+    if (!zip.isFile()) {
+      throw new IllegalArgumentException(
+          "Provided path is not a valid zip file: " + zip.getAbsolutePath());
+    }
+
+    try (FileInputStream fis = new FileInputStream(zip);
+        ZipInputStream zis = new ZipInputStream(fis, StandardCharsets.UTF_8)) {
+
+      ZipEntry entry;
+      final int BUFFER_SIZE = 32 * 1024;
+      byte[] buffer = new byte[BUFFER_SIZE];
+      while ((entry = zis.getNextEntry()) != null) {
+        if (!entry.getName().endsWith(".json")) {
+          continue;
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int bytesRead;
+        while ((bytesRead = zis.read(buffer)) != -1) {
+          baos.write(buffer, 0, bytesRead);
+        }
+
+        String content = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+        System.out.println("STORE " + entry.getName());
+        bulkAPIClient.rawStore(content);
+
+        zis.closeEntry();
+      }
+    }
+  }
+
+  public void bulkUploadZipToRepo(AdditionalAPIClient additionalAPIClient, File zip)
+      throws IOException {
+    if (!zip.isFile()) {
+      throw new IllegalArgumentException(
+          "Provided path is not a valid zip file: " + zip.getAbsolutePath());
+    }
+
+    final int BUFFER_SIZE = 32 * 1024;
+
+    LowLevelJsonSerialization lowLevelJsonSerialization = new LowLevelJsonSerialization();
+    BulkImport bulkImport = new BulkImport();
+
+    try (FileInputStream fis = new FileInputStream(zip);
+        ZipInputStream zis = new ZipInputStream(fis, StandardCharsets.UTF_8)) {
+
+      ZipEntry entry;
+      byte[] buffer = new byte[BUFFER_SIZE];
+
+      while ((entry = zis.getNextEntry()) != null) {
+        if (!entry.getName().endsWith(".json")) {
+          continue;
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int bytesRead;
+        while ((bytesRead = zis.read(buffer)) != -1) {
+          baos.write(buffer, 0, bytesRead);
+        }
+
+        // Write to temp file (needed because deserializeSerializationBlock expects a File)
+        File tempFile = File.createTempFile("partition-", ".json");
+        tempFile.deleteOnExit();
+        try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+          baos.writeTo(fos);
+        }
+
+        SerializedChunk serializedChunk =
+            lowLevelJsonSerialization.deserializeSerializationBlock(tempFile);
+        bulkImport.addNodes(serializedChunk.getClassifierInstances());
+
+        if (bulkImport.numberOfNodes() >= nNodesThreshold) {
+          additionalAPIClient.bulkImport(bulkImport, transferFormat, compression);
+          bulkImport.clear();
+        }
+
+        zis.closeEntry();
+      }
+    }
+
+    if (!bulkImport.isEmpty()) {
+      additionalAPIClient.bulkImport(bulkImport, transferFormat, compression);
+    }
+  }
 }

--- a/extensions/src/main/java/io/lionweb/repoclient/RepoSerialization.java
+++ b/extensions/src/main/java/io/lionweb/repoclient/RepoSerialization.java
@@ -31,6 +31,10 @@ public class RepoSerialization {
   private TransferFormat transferFormat = TransferFormat.FLATBUFFERS;
   private Compression compression = Compression.DISABLED;
 
+  /**
+   * Download all the content of the repository accessed by the apiClient into a directory. In this
+   * directory one file per partition is created. The file is in JSON format.
+   */
   public <C extends RawBulkAPIClient & BulkAPIClient> void downloadRepoAsDirectory(
       C apiClient, File directory) throws IOException {
     for (String partitionID : apiClient.listPartitionsIDs()) {
@@ -45,6 +49,10 @@ public class RepoSerialization {
     }
   }
 
+  /**
+   * Download all the content of the repository accessed by the apiClient into a zip file. In this
+   * zip file, one entry per partition is created. The entry is in JSON format.
+   */
   public <C extends RawBulkAPIClient & BulkAPIClient> void downloadRepoAsZip(
       C apiClient, File zipFile) throws IOException {
     try (FileOutputStream fos = new FileOutputStream(zipFile);
@@ -65,6 +73,11 @@ public class RepoSerialization {
     }
   }
 
+  /**
+   * Upload all the content of a directory to a given repository, using the standard bulk API (and
+   * not the more performant bulk import). The directory and all the subdirectories are examined,
+   * looking for files with extension ".json" (ignoring case).
+   */
   public void simpleUploadDirectoryToRepo(RawBulkAPIClient apiClient, File directory)
       throws IOException {
     if (!directory.isDirectory()) {
@@ -95,7 +108,12 @@ public class RepoSerialization {
     }
   }
 
-  public void bulkUploadDirectoryToRepo(AdditionalAPIClient apiClient, File directory)
+  /**
+   * Upload all the content of a directory to a given repository, using the bulkImport operation
+   * (and not the standard bulk operations). The directory and all the subdirectories are examined,
+   * looking for files with extension ".json" (ignoring case).
+   */
+  public void uploadDirectoryToRepoUsingBulkImport(AdditionalAPIClient apiClient, File directory)
       throws IOException {
     if (!directory.isDirectory()) {
       throw new IllegalArgumentException(
@@ -118,6 +136,11 @@ public class RepoSerialization {
     }
   }
 
+  /**
+   * Upload all the content of a zip to a given repository, using the standard bulk API (and not the
+   * more performant bulk import). All the zip is examined, looking for entries with extension
+   * ".json" (ignoring case).
+   */
   public void simpleUploadZipToRepo(RawBulkAPIClient apiClient, File zip) throws IOException {
     if (!zip.isFile()) {
       throw new IllegalArgumentException(
@@ -131,7 +154,7 @@ public class RepoSerialization {
       final int BUFFER_SIZE = 32 * 1024;
       byte[] buffer = new byte[BUFFER_SIZE];
       while ((entry = zis.getNextEntry()) != null) {
-        if (!entry.getName().endsWith(".json")) {
+        if (!entry.getName().toLowerCase().endsWith(".json")) {
           continue;
         }
 
@@ -167,7 +190,13 @@ public class RepoSerialization {
     }
   }
 
-  public void bulkUploadZipToRepo(AdditionalAPIClient apiClient, File zip) throws IOException {
+  /**
+   * Upload all the content of a zip to a given repository, using the bulkImport operation (and not
+   * the standard bulk operations). All the zip is examined, looking for entries with extension
+   * ".json" (ignoring case).
+   */
+  public void uploadZipToRepoUsingBulkImport(AdditionalAPIClient apiClient, File zip)
+      throws IOException {
     if (!zip.isFile()) {
       throw new IllegalArgumentException(
           "Provided path is not a valid zip file: " + zip.getAbsolutePath());
@@ -185,7 +214,7 @@ public class RepoSerialization {
       byte[] buffer = new byte[BUFFER_SIZE];
 
       while ((entry = zis.getNextEntry()) != null) {
-        if (!entry.getName().endsWith(".json")) {
+        if (!entry.getName().toLowerCase().endsWith(".json")) {
           continue;
         }
 
@@ -224,7 +253,7 @@ public class RepoSerialization {
     try (Stream<Path> paths = Files.walk(directory.toPath())) {
       return paths
           .filter(Files::isRegularFile)
-          .filter(path -> path.toString().endsWith(".json"))
+          .filter(path -> path.toString().toLowerCase().endsWith(".json"))
           .map(Path::toFile)
           .collect(Collectors.toList());
     }

--- a/extensions/src/main/java/io/lionweb/repoclient/RepoSerialization.java
+++ b/extensions/src/main/java/io/lionweb/repoclient/RepoSerialization.java
@@ -1,0 +1,128 @@
+package io.lionweb.repoclient;
+
+import io.lionweb.lioncore.java.serialization.LowLevelJsonSerialization;
+import io.lionweb.lioncore.java.serialization.data.SerializedChunk;
+import io.lionweb.repoclient.api.BulkAPIClient;
+import io.lionweb.serialization.extensions.AdditionalAPIClient;
+import io.lionweb.serialization.extensions.BulkImport;
+import io.lionweb.serialization.extensions.Compression;
+import io.lionweb.serialization.extensions.TransferFormat;
+import kotlin.text.Charsets;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+public class RepoSerialization {
+    private int nNodesThreshold = 100_000;
+    private TransferFormat transferFormat = TransferFormat.FLATBUFFERS;
+    private Compression compression = Compression.DISABLED;
+
+    public void downloadRepoAsDirectory(BulkAPIClient bulkAPIClient,
+                                        File directory) throws IOException {
+        for (String partitionID: bulkAPIClient.listPartitionsIDs()) {
+            String partitionData = bulkAPIClient.rawRetrieve(bulkAPIClient.listPartitionsIDs(), Integer.MAX_VALUE);
+            File partitionFile = new File(directory, partitionID + ".json");
+            Files.write(partitionFile.toPath(),
+                    Collections.singletonList(partitionData),
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING);
+        }
+    }
+
+    public void downloadRepoAsZip(BulkAPIClient bulkAPIClient, File zipFile) throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(zipFile);
+             ZipOutputStream zos = new ZipOutputStream(fos)) {
+
+            for (String partitionID : bulkAPIClient.listPartitionsIDs()) {
+                String partitionData = bulkAPIClient.rawRetrieve(Collections.singletonList(partitionID), Integer.MAX_VALUE);
+
+                ZipEntry entry = new ZipEntry(partitionID + ".json");
+                zos.putNextEntry(entry);
+
+                byte[] dataBytes = partitionData.getBytes(StandardCharsets.UTF_8);
+                zos.write(dataBytes, 0, dataBytes.length);
+
+                zos.closeEntry();
+            }
+        }
+    }
+
+    public void uploadDirectoryToRepo(BulkAPIClient bulkAPIClient, File directory) throws IOException {
+        if (!directory.isDirectory()) {
+            throw new IllegalArgumentException("Provided file is not a directory: " + directory.getAbsolutePath());
+        }
+
+        File[] files = directory.listFiles((dir, name) -> name.endsWith(".json"));
+        if (files == null) {
+            throw new IOException("Unable to list files in directory: " + directory.getAbsolutePath());
+        }
+
+        for (File file : files) {
+            String content = new String(Files.readAllBytes(file.toPath()), Charsets.UTF_8);
+
+            bulkAPIClient.rawStore(content);
+        }
+    }
+
+    public void uploadDirectoryToRepo(AdditionalAPIClient additionalAPIClient, File directory) throws IOException {
+        if (!directory.isDirectory()) {
+            throw new IllegalArgumentException("Provided file is not a directory: " + directory.getAbsolutePath());
+        }
+
+        File[] files = directory.listFiles((dir, name) -> name.endsWith(".json"));
+        if (files == null) {
+            throw new IOException("Unable to list files in directory: " + directory.getAbsolutePath());
+        }
+
+        LowLevelJsonSerialization lowLevelJsonSerialization = new LowLevelJsonSerialization();
+        BulkImport bulkImport = new BulkImport();
+        for (File file : files) {
+            SerializedChunk serializedChunk = lowLevelJsonSerialization.deserializeSerializationBlock(file);
+            bulkImport.addNodes(serializedChunk.getClassifierInstances());
+            if (bulkImport.numberOfNodes() >= nNodesThreshold) {
+                additionalAPIClient.bulkImport(bulkImport, transferFormat, compression);
+                bulkImport.clear();
+            }
+        }
+        if (!bulkImport.isEmpty()) {
+            additionalAPIClient.bulkImport(bulkImport, transferFormat, compression);
+        }
+    }
+
+    public void uploadZipToRepo(BulkAPIClient bulkAPIClient, File zip) throws IOException {
+        if (!zip.isFile()) {
+            throw new IllegalArgumentException("Provided path is not a valid zip file: " + zip.getAbsolutePath());
+        }
+
+        try (FileInputStream fis = new FileInputStream(zip);
+             ZipInputStream zis = new ZipInputStream(fis, StandardCharsets.UTF_8)) {
+
+            ZipEntry entry;
+            final int BUFFER_SIZE = 32 * 1024;
+            byte[] buffer = new byte[BUFFER_SIZE];
+            while ((entry = zis.getNextEntry()) != null) {
+                if (!entry.getName().endsWith(".json")) {
+                    continue;
+                }
+
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                int bytesRead;
+                while ((bytesRead = zis.read(buffer)) != -1) {
+                    baos.write(buffer, 0, bytesRead);
+                }
+
+                String content = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+                bulkAPIClient.rawStore(content);
+
+                zis.closeEntry();
+            }
+        }
+    }
+}

--- a/extensions/src/main/java/io/lionweb/repoclient/impl/ClientForAdditionalAPIs.java
+++ b/extensions/src/main/java/io/lionweb/repoclient/impl/ClientForAdditionalAPIs.java
@@ -3,8 +3,8 @@ package io.lionweb.repoclient.impl;
 import static io.lionweb.serialization.extensions.CompressionSupport.considerCompression;
 
 import com.google.gson.*;
-import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.serialization.JsonSerialization;
+import io.lionweb.lioncore.java.serialization.LowLevelJsonSerialization;
 import io.lionweb.lioncore.protobuf.PBBulkImport;
 import io.lionweb.repoclient.RequestFailureException;
 import io.lionweb.serialization.extensions.*;
@@ -107,13 +107,12 @@ public class ClientForAdditionalAPIs extends LionWebRepoClientImplHelper
               jEl.add("containment", jContainment);
               bodyAttachPoints.add(jEl);
             });
-    JsonArray bodyNodes =
-        conf.getJsonSerialization()
-            .serializeTreesToJsonElement(
-                bulkImport.getNodes().toArray(new ClassifierInstance<?>[0]))
-            .getAsJsonObject()
-            .get("nodes")
-            .getAsJsonArray();
+    JsonElement serializedChunkAsJson =
+        new LowLevelJsonSerialization()
+            .serializeToJsonElement(
+                LowLevelJsonSerialization.groupNodesIntoSerializationBlock(
+                    bulkImport.getNodes(), conf.getJsonSerialization().getLionWebVersion()));
+    JsonArray bodyNodes = serializedChunkAsJson.getAsJsonObject().get("nodes").getAsJsonArray();
     body.add("attachPoints", bodyAttachPoints);
     body.add("nodes", bodyNodes);
     String bodyJson = new Gson().toJson(body);

--- a/extensions/src/main/java/io/lionweb/repoclient/impl/ClientForAdditionalAPIs.java
+++ b/extensions/src/main/java/io/lionweb/repoclient/impl/ClientForAdditionalAPIs.java
@@ -114,6 +114,9 @@ public class ClientForAdditionalAPIs extends LionWebRepoClientImplHelper
             .getAsJsonObject()
             .get("nodes")
             .getAsJsonArray();
+    if (!bulkImport.getRawNodes().isEmpty()) {
+        throw new UnsupportedOperationException();
+    }
     body.add("attachPoints", bodyAttachPoints);
     body.add("nodes", bodyNodes);
     String bodyJson = new Gson().toJson(body);

--- a/extensions/src/main/java/io/lionweb/repoclient/impl/ClientForAdditionalAPIs.java
+++ b/extensions/src/main/java/io/lionweb/repoclient/impl/ClientForAdditionalAPIs.java
@@ -114,9 +114,6 @@ public class ClientForAdditionalAPIs extends LionWebRepoClientImplHelper
             .getAsJsonObject()
             .get("nodes")
             .getAsJsonArray();
-    if (!bulkImport.getRawNodes().isEmpty()) {
-        throw new UnsupportedOperationException();
-    }
     body.add("attachPoints", bodyAttachPoints);
     body.add("nodes", bodyNodes);
     String bodyJson = new Gson().toJson(body);

--- a/extensions/src/main/java/io/lionweb/serialization/extensions/BulkImport.java
+++ b/extensions/src/main/java/io/lionweb/serialization/extensions/BulkImport.java
@@ -37,7 +37,7 @@ public class BulkImport {
   public BulkImport(List<AttachPoint> attachPoints, List<ClassifierInstance<?>> nodes) {
     this.attachPoints = attachPoints;
     if (nodes.isEmpty()){
-      this.nodes = Collections.emptyList();
+      this.nodes = new LinkedList<>();
     } else {
       JsonSerialization jsonSerialization = getJsonSerialization(nodes.get(0).getClassifier().getLionWebVersion());
       this.nodes = jsonSerialization.serializeNodesToSerializationBlock(nodes).getClassifierInstances();

--- a/extensions/src/main/java/io/lionweb/serialization/extensions/BulkImport.java
+++ b/extensions/src/main/java/io/lionweb/serialization/extensions/BulkImport.java
@@ -7,15 +7,15 @@ import io.lionweb.lioncore.java.serialization.JsonSerialization;
 import io.lionweb.lioncore.java.serialization.SerializationProvider;
 import io.lionweb.lioncore.java.serialization.data.MetaPointer;
 import io.lionweb.lioncore.java.serialization.data.SerializedClassifierInstance;
-
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
 public class BulkImport {
 
-  private static JsonSerialization jsonSerialization2023_1 = SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
-  private static JsonSerialization jsonSerialization2024_1 = SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2024_1);
+  private static JsonSerialization jsonSerialization2023_1 =
+      SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
+  private static JsonSerialization jsonSerialization2024_1 =
+      SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2024_1);
 
   private static JsonSerialization getJsonSerialization(LionWebVersion lionWebVersion) {
     if (lionWebVersion == LionWebVersion.v2023_1) {
@@ -36,16 +36,19 @@ public class BulkImport {
 
   public BulkImport(List<AttachPoint> attachPoints, List<ClassifierInstance<?>> nodes) {
     this.attachPoints = attachPoints;
-    if (nodes.isEmpty()){
+    if (nodes.isEmpty()) {
       this.nodes = new LinkedList<>();
     } else {
-      JsonSerialization jsonSerialization = getJsonSerialization(nodes.get(0).getClassifier().getLionWebVersion());
-      this.nodes = jsonSerialization.serializeNodesToSerializationBlock(nodes).getClassifierInstances();
+      JsonSerialization jsonSerialization =
+          getJsonSerialization(nodes.get(0).getClassifier().getLionWebVersion());
+      this.nodes =
+          jsonSerialization.serializeNodesToSerializationBlock(nodes).getClassifierInstances();
     }
   }
 
   public void addNode(ClassifierInstance<?> classifierInstance) {
-    JsonSerialization jsonSerialization = getJsonSerialization(classifierInstance.getClassifier().getLionWebVersion());
+    JsonSerialization jsonSerialization =
+        getJsonSerialization(classifierInstance.getClassifier().getLionWebVersion());
     nodes.addAll(
         jsonSerialization
             .serializeNodesToSerializationBlock(classifierInstance)

--- a/extensions/src/main/java/io/lionweb/serialization/extensions/BulkImport.java
+++ b/extensions/src/main/java/io/lionweb/serialization/extensions/BulkImport.java
@@ -7,24 +7,18 @@ import io.lionweb.lioncore.java.serialization.JsonSerialization;
 import io.lionweb.lioncore.java.serialization.SerializationProvider;
 import io.lionweb.lioncore.java.serialization.data.MetaPointer;
 import io.lionweb.lioncore.java.serialization.data.SerializedClassifierInstance;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 public class BulkImport {
 
-  private static JsonSerialization jsonSerialization2023_1 =
-      SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
-  private static JsonSerialization jsonSerialization2024_1 =
-      SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2024_1);
+  private static final Map<LionWebVersion, JsonSerialization> jsonSerializations = new HashMap<>();
 
   private static JsonSerialization getJsonSerialization(LionWebVersion lionWebVersion) {
-    if (lionWebVersion == LionWebVersion.v2023_1) {
-      return jsonSerialization2023_1;
-    } else if (lionWebVersion == LionWebVersion.v2024_1) {
-      return jsonSerialization2024_1;
-    } else {
-      throw new IllegalStateException();
-    }
+    return jsonSerializations.computeIfAbsent(
+        lionWebVersion, SerializationProvider::getStandardJsonSerialization);
   }
 
   private final List<AttachPoint> attachPoints;

--- a/extensions/src/main/java/io/lionweb/serialization/extensions/BulkImport.java
+++ b/extensions/src/main/java/io/lionweb/serialization/extensions/BulkImport.java
@@ -2,26 +2,33 @@ package io.lionweb.serialization.extensions;
 
 import io.lionweb.lioncore.java.language.Containment;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
+import io.lionweb.lioncore.java.serialization.JsonSerialization;
+import io.lionweb.lioncore.java.serialization.SerializationProvider;
 import io.lionweb.lioncore.java.serialization.data.MetaPointer;
+import io.lionweb.lioncore.java.serialization.data.SerializedClassifierInstance;
+
 import java.util.LinkedList;
 import java.util.List;
 
 public class BulkImport {
 
+  private static JsonSerialization jsonSerialization = SerializationProvider.getStandardJsonSerialization();
+
   private final List<AttachPoint> attachPoints;
-  private final List<ClassifierInstance<?>> nodes;
+  private final List<SerializedClassifierInstance> nodes;
 
   public BulkImport() {
     this(new LinkedList<>(), new LinkedList<>());
   }
 
   public BulkImport(List<AttachPoint> attachPoints, List<ClassifierInstance<?>> nodes) {
+
     this.attachPoints = attachPoints;
-    this.nodes = nodes;
+    this.nodes = jsonSerialization.serializeNodesToSerializationBlock(nodes).getClassifierInstances();
   }
 
   public void addNode(ClassifierInstance<?> classifierInstance) {
-    nodes.add(classifierInstance);
+    nodes.addAll(jsonSerialization.serializeNodesToSerializationBlock(classifierInstance).getClassifierInstances());
   }
 
   public void addAttachPoint(AttachPoint attachPoint) {
@@ -32,12 +39,25 @@ public class BulkImport {
     return attachPoints;
   }
 
-  public List<ClassifierInstance<?>> getNodes() {
+  public List<SerializedClassifierInstance> getNodes() {
     return nodes;
+  }
+
+  public int numberOfNodes() {
+    return nodes.size();
   }
 
   public boolean isEmpty() {
     return nodes.isEmpty();
+  }
+
+  public void addNodes(List<SerializedClassifierInstance> classifierInstances) {
+    nodes.addAll(classifierInstances);
+  }
+
+  public void clear() {
+    attachPoints.clear();
+    nodes.clear();
   }
 
   public static class AttachPoint {

--- a/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraProtoBufSerialization.java
+++ b/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraProtoBufSerialization.java
@@ -26,7 +26,7 @@ public class ExtraProtoBufSerialization extends ProtoBufSerialization {
               bulkImportBuilder.addAttachPoints(attachPointBuilder.build());
             });
 
-    SerializedChunk serializedChunk = serializeNodesToSerializationBlock(bulkImport.getNodes());
+    SerializedChunk serializedChunk = groupNodesIntoSerializationBlock(bulkImport.getNodes());
 
     serializedChunk
         .getClassifierInstances()

--- a/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraProtoBufSerialization.java
+++ b/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraProtoBufSerialization.java
@@ -27,8 +27,9 @@ public class ExtraProtoBufSerialization extends ProtoBufSerialization {
               bulkImportBuilder.addAttachPoints(attachPointBuilder.build());
             });
 
-    SerializedChunk serializedChunk = LowLevelJsonSerialization.groupNodesIntoSerializationBlock(bulkImport.getNodes(),
-            getLionWebVersion());
+    SerializedChunk serializedChunk =
+        LowLevelJsonSerialization.groupNodesIntoSerializationBlock(
+            bulkImport.getNodes(), getLionWebVersion());
 
     serializedChunk
         .getClassifierInstances()

--- a/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraProtoBufSerialization.java
+++ b/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraProtoBufSerialization.java
@@ -1,5 +1,6 @@
 package io.lionweb.serialization.extensions;
 
+import io.lionweb.lioncore.java.serialization.LowLevelJsonSerialization;
 import io.lionweb.lioncore.java.serialization.ProtoBufSerialization;
 import io.lionweb.lioncore.java.serialization.data.SerializedChunk;
 import io.lionweb.lioncore.protobuf.PBAttachPoint;
@@ -26,7 +27,8 @@ public class ExtraProtoBufSerialization extends ProtoBufSerialization {
               bulkImportBuilder.addAttachPoints(attachPointBuilder.build());
             });
 
-    SerializedChunk serializedChunk = groupNodesIntoSerializationBlock(bulkImport.getNodes());
+    SerializedChunk serializedChunk = LowLevelJsonSerialization.groupNodesIntoSerializationBlock(bulkImport.getNodes(),
+            getLionWebVersion());
 
     serializedChunk
         .getClassifierInstances()

--- a/extensions/src/test/java/io/lionweb/repoclient/ExtraFlatbuffersSerializationTest.java
+++ b/extensions/src/test/java/io/lionweb/repoclient/ExtraFlatbuffersSerializationTest.java
@@ -1,3 +1,5 @@
+package io.lionweb.repoclient;
+
 import static org.junit.Assert.*;
 
 import io.lionweb.lioncore.java.language.*;

--- a/repo-client/src/functionalTest/java/io/lionweb/repoclient/LionWebRepoClientBulkApiFunctionalTest.java
+++ b/repo-client/src/functionalTest/java/io/lionweb/repoclient/LionWebRepoClientBulkApiFunctionalTest.java
@@ -43,7 +43,7 @@ public class LionWebRepoClientBulkApiFunctionalTest extends AbstractRepoClientFu
 
     // Create partition
     DynamicNode f1 = new DynamicNode("f1", PropertiesLanguage.propertiesPartition);
-    client.createPartitions(client.getJsonSerialization().serializeNodesToJsonString(f1));
+    client.rawCreatePartitions(client.getJsonSerialization().serializeNodesToJsonString(f1));
 
     // Check list
     List<Node> nodes1 = client.listPartitions();
@@ -55,7 +55,7 @@ public class LionWebRepoClientBulkApiFunctionalTest extends AbstractRepoClientFu
     // Create partitions
     DynamicNode f2 = new DynamicNode("f2", PropertiesLanguage.propertiesPartition);
     DynamicNode f3 = new DynamicNode("f3", PropertiesLanguage.propertiesPartition);
-    client.createPartitions(client.getJsonSerialization().serializeNodesToJsonString(f2, f3));
+    client.rawCreatePartitions(client.getJsonSerialization().serializeNodesToJsonString(f2, f3));
 
     // Check list
     List<Node> nodes2 = client.listPartitions();
@@ -93,7 +93,7 @@ public class LionWebRepoClientBulkApiFunctionalTest extends AbstractRepoClientFu
 
     // Create partition
     DynamicNode partition = new DynamicNode("partition", PropertiesLanguage.propertiesPartition);
-    client.createPartitions(client.getJsonSerialization().serializeNodesToJsonString(partition));
+    client.rawCreatePartitions(client.getJsonSerialization().serializeNodesToJsonString(partition));
 
     // Check list
     List<Node> nodes1 = client.listPartitions();
@@ -138,7 +138,7 @@ public class LionWebRepoClientBulkApiFunctionalTest extends AbstractRepoClientFu
     client.getJsonSerialization().registerLanguage(PropertiesLanguage.propertiesLanguage);
 
     DynamicNode p1 = new DynamicNode("p1", PropertiesLanguage.propertiesPartition);
-    client.createPartitions(client.getJsonSerialization().serializeNodesToJsonString(p1));
+    client.rawCreatePartitions(client.getJsonSerialization().serializeNodesToJsonString(p1));
 
     DynamicNode f1 = new DynamicNode("f1", PropertiesLanguage.propertiesFile);
     ClassifierInstanceUtils.setPropertyValueByName(f1, "path", "my-path-1.txt");

--- a/repo-client/src/functionalTest/java/io/lionweb/repoclient/LionWebRepoClientHistoryApiFunctionalTest.java
+++ b/repo-client/src/functionalTest/java/io/lionweb/repoclient/LionWebRepoClientHistoryApiFunctionalTest.java
@@ -37,7 +37,8 @@ public class LionWebRepoClientHistoryApiFunctionalTest extends AbstractRepoClien
     DynamicNode f1 = new DynamicNode("f1", PropertiesLanguage.propertiesPartition);
     DynamicNode f2 = new DynamicNode("f2", PropertiesLanguage.propertiesPartition);
     RepositoryVersionToken v1 =
-        client.createPartitions(client.getJsonSerialization().serializeNodesToJsonString(f1, f2));
+        client.rawCreatePartitions(
+            client.getJsonSerialization().serializeNodesToJsonString(f1, f2));
 
     // Delete partitions
     RepositoryVersionToken v2 = client.deletePartitions(Arrays.asList("f1"));
@@ -69,7 +70,7 @@ public class LionWebRepoClientHistoryApiFunctionalTest extends AbstractRepoClien
     // Create partition, initially empty
     DynamicNode p1 = new DynamicNode("p1", PropertiesLanguage.propertiesPartition);
     RepositoryVersionToken v0 =
-        client.createPartitions(client.getJsonSerialization().serializeNodesToJsonString(p1));
+        client.rawCreatePartitions(client.getJsonSerialization().serializeNodesToJsonString(p1));
 
     // Populate partition
     DynamicNode f1 = new DynamicNode("f1", PropertiesLanguage.propertiesFile);

--- a/repo-client/src/functionalTest/java/io/lionweb/repoclient/LionWebRepoClientInspectionApiFunctionalTest.java
+++ b/repo-client/src/functionalTest/java/io/lionweb/repoclient/LionWebRepoClientInspectionApiFunctionalTest.java
@@ -39,7 +39,7 @@ public class LionWebRepoClientInspectionApiFunctionalTest extends AbstractRepoCl
 
     // Add nodes
     DynamicNode p1 = new DynamicNode("p1", PropertiesLanguage.propertiesPartition);
-    client.createPartitions(client.getJsonSerialization().serializeNodesToJsonString(p1));
+    client.rawCreatePartitions(client.getJsonSerialization().serializeNodesToJsonString(p1));
 
     DynamicNode f1 = new DynamicNode("f1", PropertiesLanguage.propertiesFile);
     ClassifierInstanceUtils.setPropertyValueByName(f1, "path", "my-path-1.txt");
@@ -81,7 +81,7 @@ public class LionWebRepoClientInspectionApiFunctionalTest extends AbstractRepoCl
 
     // Add nodes
     DynamicNode p1 = new DynamicNode("p1", PropertiesLanguage.propertiesPartition);
-    client.createPartitions(client.getJsonSerialization().serializeNodesToJsonString(p1));
+    client.rawCreatePartitions(client.getJsonSerialization().serializeNodesToJsonString(p1));
 
     DynamicNode f1 = new DynamicNode("f1", PropertiesLanguage.propertiesFile);
     ClassifierInstanceUtils.setPropertyValueByName(f1, "path", "my-path-1.txt");

--- a/repo-client/src/main/java/io/lionweb/repoclient/LionWebRepoClient.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/LionWebRepoClient.java
@@ -229,6 +229,17 @@ public class LionWebRepoClient
     return bulkAPIs.retrieve(nodeIds, limit);
   }
 
+  @Nullable
+  @Override
+  public RepositoryVersionToken rawStore(String nodes) throws IOException {
+    return bulkAPIs.rawStore(nodes);
+  }
+
+  @Override
+  public String rawRetrieve(List<String> nodeIds, int limit) throws IOException {
+    return bulkAPIs.rawRetrieve(nodeIds, limit);
+  }
+
   //
   // DBAdmin APIs
   //

--- a/repo-client/src/main/java/io/lionweb/repoclient/LionWebRepoClient.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/LionWebRepoClient.java
@@ -192,7 +192,7 @@ public class LionWebRepoClient
   }
 
   public List<String> listPartitionsIDs() throws IOException {
-    return listPartitions().stream().map(n -> n.getID()).collect(Collectors.toList());
+    return listPartitions().stream().map(Node::getID).collect(Collectors.toList());
   }
 
   @Override

--- a/repo-client/src/main/java/io/lionweb/repoclient/LionWebRepoClient.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/LionWebRepoClient.java
@@ -16,7 +16,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class LionWebRepoClient
-    implements BulkAPIClient, DBAdminAPIClient, InspectionAPIClient, HistoryAPIClient {
+    implements RawBulkAPIClient,
+        BulkAPIClient,
+        DBAdminAPIClient,
+        InspectionAPIClient,
+        HistoryAPIClient {
 
   public class Builder {
     protected LionWebVersion lionWebVersion = LionWebVersion.currentVersion;
@@ -95,6 +99,7 @@ public class LionWebRepoClient
   private final ClientForInspectionAPIs inspectionAPIs;
   private final ClientForDBAdminAPIs dbAdminAPIs;
   private final ClientForBulkAPIs bulkAPIs;
+  private final ClientForRawBulkAPIs rawBulkAPIs;
   private final ClientForHistoryAPIs historyAPIs;
 
   //
@@ -138,6 +143,7 @@ public class LionWebRepoClient
     RepoClientConfiguration conf = buildRepositoryConfiguration();
     this.inspectionAPIs = new ClientForInspectionAPIs(conf);
     this.dbAdminAPIs = new ClientForDBAdminAPIs(conf);
+    this.rawBulkAPIs = new ClientForRawBulkAPIs(conf);
     this.bulkAPIs = new ClientForBulkAPIs(conf);
     this.historyAPIs = new ClientForHistoryAPIs(conf);
   }
@@ -163,6 +169,27 @@ public class LionWebRepoClient
   }
 
   //
+  // Raw Bulk APIs
+  //
+
+  public @Nullable RepositoryVersionToken rawCreatePartitions(@NotNull String data)
+      throws IOException {
+    return rawBulkAPIs.rawCreatePartitions(data);
+  }
+
+  @Override
+  @Nullable
+  public RepositoryVersionToken rawStore(@NotNull String nodes) throws IOException {
+    return rawBulkAPIs.rawStore(nodes);
+  }
+
+  @Override
+  @NotNull
+  public String rawRetrieve(@NotNull List<String> nodeIds, int limit) throws IOException {
+    return rawBulkAPIs.rawRetrieve(nodeIds, limit);
+  }
+
+  //
   // Bulk APIs
   //
 
@@ -175,10 +202,6 @@ public class LionWebRepoClient
   public @Nullable RepositoryVersionToken createPartition(@NotNull Node partition)
       throws IOException {
     return createPartitions(Collections.singletonList(partition));
-  }
-
-  public @Nullable RepositoryVersionToken createPartitions(String data) throws IOException {
-    return bulkAPIs.createPartitions(data);
   }
 
   @Override
@@ -227,17 +250,6 @@ public class LionWebRepoClient
   @Override
   public List<Node> retrieve(List<String> nodeIds, int limit) throws IOException {
     return bulkAPIs.retrieve(nodeIds, limit);
-  }
-
-  @Nullable
-  @Override
-  public RepositoryVersionToken rawStore(String nodes) throws IOException {
-    return bulkAPIs.rawStore(nodes);
-  }
-
-  @Override
-  public String rawRetrieve(List<String> nodeIds, int limit) throws IOException {
-    return bulkAPIs.rawRetrieve(nodeIds, limit);
   }
 
   @NotNull

--- a/repo-client/src/main/java/io/lionweb/repoclient/LionWebRepoClient.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/LionWebRepoClient.java
@@ -240,6 +240,12 @@ public class LionWebRepoClient
     return bulkAPIs.rawRetrieve(nodeIds, limit);
   }
 
+  @NotNull
+  @Override
+  public LionWebVersion getLionWebVersion() {
+    return buildRepositoryConfiguration().getJsonSerialization().getLionWebVersion();
+  }
+
   //
   // DBAdmin APIs
   //

--- a/repo-client/src/main/java/io/lionweb/repoclient/api/BulkAPIClient.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/api/BulkAPIClient.java
@@ -17,9 +17,6 @@ public interface BulkAPIClient {
   RepositoryVersionToken createPartitions(List<Node> partitions) throws IOException;
 
   @Nullable
-  RepositoryVersionToken createPartitions(String data) throws IOException;
-
-  @Nullable
   RepositoryVersionToken deletePartitions(List<String> ids) throws IOException;
 
   List<Node> listPartitions() throws IOException;
@@ -33,10 +30,5 @@ public interface BulkAPIClient {
   @Nullable
   RepositoryVersionToken store(List<Node> nodes) throws IOException;
 
-  @Nullable
-  RepositoryVersionToken rawStore(String nodes) throws IOException;
-
   List<Node> retrieve(List<String> nodeIds, int limit) throws IOException;
-
-  String rawRetrieve(List<String> nodeIds, int limit) throws IOException;
 }

--- a/repo-client/src/main/java/io/lionweb/repoclient/api/BulkAPIClient.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/api/BulkAPIClient.java
@@ -1,14 +1,24 @@
 package io.lionweb.repoclient.api;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.Node;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import io.lionweb.lioncore.java.serialization.data.SerializedChunk;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public interface BulkAPIClient {
+
+  @NotNull
+  LionWebVersion getLionWebVersion();
+
   @Nullable
   RepositoryVersionToken createPartitions(List<Node> partitions) throws IOException;
+
+  @Nullable RepositoryVersionToken createPartitions(String data) throws IOException;
 
   @Nullable
   RepositoryVersionToken deletePartitions(List<String> ids) throws IOException;

--- a/repo-client/src/main/java/io/lionweb/repoclient/api/BulkAPIClient.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/api/BulkAPIClient.java
@@ -5,8 +5,6 @@ import io.lionweb.lioncore.java.model.Node;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import io.lionweb.lioncore.java.serialization.data.SerializedChunk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -18,7 +16,8 @@ public interface BulkAPIClient {
   @Nullable
   RepositoryVersionToken createPartitions(List<Node> partitions) throws IOException;
 
-  @Nullable RepositoryVersionToken createPartitions(String data) throws IOException;
+  @Nullable
+  RepositoryVersionToken createPartitions(String data) throws IOException;
 
   @Nullable
   RepositoryVersionToken deletePartitions(List<String> ids) throws IOException;

--- a/repo-client/src/main/java/io/lionweb/repoclient/api/BulkAPIClient.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/api/BulkAPIClient.java
@@ -4,7 +4,6 @@ import io.lionweb.lioncore.java.model.Node;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.jetbrains.annotations.Nullable;
 
 public interface BulkAPIClient {
@@ -31,5 +30,4 @@ public interface BulkAPIClient {
   List<Node> retrieve(List<String> nodeIds, int limit) throws IOException;
 
   String rawRetrieve(List<String> nodeIds, int limit) throws IOException;
-
 }

--- a/repo-client/src/main/java/io/lionweb/repoclient/api/BulkAPIClient.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/api/BulkAPIClient.java
@@ -3,6 +3,8 @@ package io.lionweb.repoclient.api;
 import io.lionweb.lioncore.java.model.Node;
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import org.jetbrains.annotations.Nullable;
 
 public interface BulkAPIClient {
@@ -14,10 +16,20 @@ public interface BulkAPIClient {
 
   List<Node> listPartitions() throws IOException;
 
+  default List<String> listPartitionsIDs() throws IOException {
+    return listPartitions().stream().map(Node::getID).collect(Collectors.toList());
+  }
+
   List<String> ids(int count) throws IOException;
 
   @Nullable
   RepositoryVersionToken store(List<Node> nodes) throws IOException;
 
+  @Nullable
+  RepositoryVersionToken rawStore(String nodes) throws IOException;
+
   List<Node> retrieve(List<String> nodeIds, int limit) throws IOException;
+
+  String rawRetrieve(List<String> nodeIds, int limit) throws IOException;
+
 }

--- a/repo-client/src/main/java/io/lionweb/repoclient/api/RawBulkAPIClient.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/api/RawBulkAPIClient.java
@@ -1,0 +1,30 @@
+package io.lionweb.repoclient.api;
+
+import io.lionweb.lioncore.java.LionWebVersion;
+import java.io.IOException;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * In certain cases it is convenient to communicate with the repository without forcing a full
+ * serialization or de-serialization of the data received. This is useful for performance reasons or
+ * because we do not have the languages available, so we cannot proceed to a full deserialization.
+ */
+public interface RawBulkAPIClient {
+  @NotNull
+  LionWebVersion getLionWebVersion();
+
+  @Nullable
+  RepositoryVersionToken rawCreatePartitions(@NotNull String data) throws IOException;
+
+  @Nullable
+  RepositoryVersionToken rawStore(@NotNull String nodes) throws IOException;
+
+  @NotNull
+  String rawRetrieve(@Nullable List<String> nodeIds, int limit) throws IOException;
+
+  default @NotNull String rawRetrieve(@Nullable List<String> nodeIds) throws IOException {
+    return rawRetrieve(nodeIds, Integer.MAX_VALUE);
+  }
+}

--- a/repo-client/src/main/java/io/lionweb/repoclient/impl/ClientForBulkAPIs.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/impl/ClientForBulkAPIs.java
@@ -1,7 +1,6 @@
 package io.lionweb.repoclient.impl;
 
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.lionweb.lioncore.java.LionWebVersion;
@@ -9,30 +8,25 @@ import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.impl.ProxyNode;
 import io.lionweb.lioncore.java.utils.CommonChecks;
-import io.lionweb.repoclient.CompressionSupport;
 import io.lionweb.repoclient.RequestFailureException;
 import io.lionweb.repoclient.api.BulkAPIClient;
+import io.lionweb.repoclient.api.RawBulkAPIClient;
 import io.lionweb.repoclient.api.RepositoryVersionToken;
 import java.io.IOException;
-import java.net.ConnectException;
-import java.net.HttpURLConnection;
 import java.util.*;
 import java.util.stream.Collectors;
-import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import okhttp3.Response;
-import okio.Buffer;
-import okio.BufferedSink;
-import okio.GzipSink;
-import okio.Okio;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ClientForBulkAPIs extends LionWebRepoClientImplHelper implements BulkAPIClient {
 
+  private RawBulkAPIClient rawBulkAPIClient;
+
   public ClientForBulkAPIs(RepoClientConfiguration repoClientConfiguration) {
     super(repoClientConfiguration);
+    rawBulkAPIClient = new ClientForRawBulkAPIs(repoClientConfiguration);
   }
 
   @NotNull
@@ -44,14 +38,9 @@ public class ClientForBulkAPIs extends LionWebRepoClientImplHelper implements Bu
   @Override
   public @Nullable RepositoryVersionToken createPartitions(List<Node> partitions)
       throws IOException {
-    return createPartitions(
+    return rawBulkAPIClient.rawCreatePartitions(
         conf.getJsonSerialization()
             .serializeTreesToJsonString(partitions.toArray(new ClassifierInstance[0])));
-  }
-
-  @Override
-  public @Nullable RepositoryVersionToken createPartitions(String data) throws IOException {
-    return nodesStoringOperation(data, "createPartitions");
   }
 
   @Override
@@ -125,27 +114,7 @@ public class ClientForBulkAPIs extends LionWebRepoClientImplHelper implements Bu
     String json =
         conf.getJsonSerialization()
             .serializeTreesToJsonString(nodes.toArray(new ClassifierInstance<?>[0]));
-    return rawStore(json);
-  }
-
-  @Nullable
-  @Override
-  public RepositoryVersionToken rawStore(String json) throws IOException {
-    Request.Builder rq = buildRequest("/bulk/store");
-    rq = addGZipCompressionHeader(rq);
-    RequestBody uncompressedBody = RequestBody.create(json, JSON);
-    Request request = rq.post(gzipCompress(uncompressedBody)).build();
-    return performCall(
-        request,
-        (response, responseBody) -> {
-          JsonObject responseData = JsonParser.parseString(responseBody).getAsJsonObject();
-          boolean success = responseData.get("success").getAsBoolean();
-          if (!success) {
-            throw new RequestFailureException(
-                request.url().toString(), response.code(), responseBody);
-          }
-          return getRepoVersionFromResponse(responseBody);
-        });
+    return rawBulkAPIClient.rawStore(json);
   }
 
   @Override
@@ -194,118 +163,5 @@ public class ClientForBulkAPIs extends LionWebRepoClientImplHelper implements Bu
                               || !idsReturned.contains(n.getParent().getID())))
               .collect(Collectors.toList());
         });
-  }
-
-  @Override
-  public String rawRetrieve(List<String> nodeIds, int limit) throws IOException {
-    List<String> invalidIDs =
-        nodeIds.stream().filter(id -> !CommonChecks.isValidID(id)).collect(Collectors.toList());
-    if (!invalidIDs.isEmpty()) {
-      throw new IllegalArgumentException("IDs must all be valid. Invalid IDs found: " + invalidIDs);
-    }
-
-    String bodyJson =
-        "{\"ids\":["
-            + String.join(", ", nodeIds.stream().map(id -> "\"" + id + "\"").toArray(String[]::new))
-            + "]}";
-    Map<String, String> params = new HashMap<>();
-    params.put("depthLimit", String.valueOf(limit));
-    Request.Builder rq = buildRequest("/bulk/retrieve", true, true, true, params);
-    Request request = rq.post(RequestBody.create(bodyJson, JSON)).build();
-
-    return performCall(
-        request,
-        (response, responseBody) -> {
-          JsonObject responseData = JsonParser.parseString(responseBody).getAsJsonObject();
-          boolean success = responseData.get("success").getAsBoolean();
-          if (!success) {
-            throw new RequestFailureException(
-                request.url().toString(), response.code(), responseBody);
-          }
-          JsonElement chunkAsJson = responseData.get("chunk");
-          return gson.toJson(chunkAsJson);
-        });
-  }
-
-  private @Nullable RepositoryVersionToken nodesStoringOperation(
-      final String json, final String operation) {
-    // Build the request
-    Request.Builder rb = buildRequest("/bulk/" + operation);
-    rb = addGZipCompressionHeader(rb);
-    RequestBody body =
-        CompressionSupport.compress(
-            json); // assuming CompressUtil.compress(String) handles JSON compression
-    Request request = rb.post(body).build();
-
-    String url = request.url().toString();
-    try {
-      try (Response response = conf.getHttpClient().newCall(request).execute()) {
-        String responseBody = response.body() != null ? response.body().string() : null;
-        if (response.code() != HttpURLConnection.HTTP_OK) {
-          throw new RequestFailureException(url, response.code(), responseBody);
-        } else {
-          return getRepoVersionFromResponse(responseBody);
-        }
-      }
-    } catch (ConnectException e) {
-      String jsonExcerpt = json.length() > 10000 ? json.substring(0, 1000) + "..." : json;
-      throw new RuntimeException(
-          "Cannot get answer from the client when contacting at URL "
-              + url
-              + ". Body: "
-              + jsonExcerpt,
-          e);
-    } catch (IOException e) {
-      throw new RuntimeException("IO error while contacting URL " + url, e);
-    }
-  }
-
-  private RequestBody gzipCompress(RequestBody original) throws IOException {
-    Buffer buffer = new Buffer();
-    original.writeTo(buffer);
-
-    RequestBody gzippedBody =
-        new RequestBody() {
-          @Override
-          public MediaType contentType() {
-            return original.contentType();
-          }
-
-          @Override
-          public long contentLength() {
-            return -1; // unknown
-          }
-
-          @Override
-          public void writeTo(BufferedSink sink) throws IOException {
-            GzipSink gzipSink = new GzipSink(sink);
-            BufferedSink compressedSink = Okio.buffer(gzipSink);
-            buffer.copyTo(compressedSink.buffer(), 0, buffer.size());
-            compressedSink.close();
-          }
-        };
-
-    return gzippedBody;
-  }
-
-  private @Nullable RepositoryVersionToken getRepoVersionFromResponse(String responseBody) {
-    JsonArray data =
-        JsonParser.parseString(responseBody).getAsJsonObject().get("messages").getAsJsonArray();
-    Optional<JsonElement> repoVersionMessage =
-        data.asList().stream()
-            .filter(e -> e.getAsJsonObject().get("kind").getAsString().equals("RepoVersion"))
-            .findFirst();
-    if (!repoVersionMessage.isPresent()) {
-      return null;
-    }
-    long version =
-        repoVersionMessage
-            .get()
-            .getAsJsonObject()
-            .get("data")
-            .getAsJsonObject()
-            .get("version")
-            .getAsLong();
-    return new RepositoryVersionToken(Long.toString(version));
   }
 }

--- a/repo-client/src/main/java/io/lionweb/repoclient/impl/ClientForBulkAPIs.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/impl/ClientForBulkAPIs.java
@@ -4,9 +4,11 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.impl.ProxyNode;
+import io.lionweb.lioncore.java.serialization.data.SerializedChunk;
 import io.lionweb.lioncore.java.utils.CommonChecks;
 import io.lionweb.repoclient.CompressionSupport;
 import io.lionweb.repoclient.RequestFailureException;
@@ -25,6 +27,7 @@ import okio.Buffer;
 import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ClientForBulkAPIs extends LionWebRepoClientImplHelper implements BulkAPIClient {
@@ -33,7 +36,13 @@ public class ClientForBulkAPIs extends LionWebRepoClientImplHelper implements Bu
     super(repoClientConfiguration);
   }
 
-  @Override
+    @NotNull
+    @Override
+    public LionWebVersion getLionWebVersion() {
+        return conf.getJsonSerialization().getLionWebVersion();
+    }
+
+    @Override
   public @Nullable RepositoryVersionToken createPartitions(List<Node> partitions)
       throws IOException {
     return createPartitions(
@@ -41,6 +50,7 @@ public class ClientForBulkAPIs extends LionWebRepoClientImplHelper implements Bu
             .serializeTreesToJsonString(partitions.toArray(new ClassifierInstance[0])));
   }
 
+  @Override
   public @Nullable RepositoryVersionToken createPartitions(String data) throws IOException {
     return nodesStoringOperation(data, "createPartitions");
   }

--- a/repo-client/src/main/java/io/lionweb/repoclient/impl/ClientForBulkAPIs.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/impl/ClientForBulkAPIs.java
@@ -8,7 +8,6 @@ import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.impl.ProxyNode;
-import io.lionweb.lioncore.java.serialization.data.SerializedChunk;
 import io.lionweb.lioncore.java.utils.CommonChecks;
 import io.lionweb.repoclient.CompressionSupport;
 import io.lionweb.repoclient.RequestFailureException;
@@ -36,13 +35,13 @@ public class ClientForBulkAPIs extends LionWebRepoClientImplHelper implements Bu
     super(repoClientConfiguration);
   }
 
-    @NotNull
-    @Override
-    public LionWebVersion getLionWebVersion() {
-        return conf.getJsonSerialization().getLionWebVersion();
-    }
+  @NotNull
+  @Override
+  public LionWebVersion getLionWebVersion() {
+    return conf.getJsonSerialization().getLionWebVersion();
+  }
 
-    @Override
+  @Override
   public @Nullable RepositoryVersionToken createPartitions(List<Node> partitions)
       throws IOException {
     return createPartitions(

--- a/repo-client/src/main/java/io/lionweb/repoclient/impl/ClientForRawBulkAPIs.java
+++ b/repo-client/src/main/java/io/lionweb/repoclient/impl/ClientForRawBulkAPIs.java
@@ -1,0 +1,157 @@
+package io.lionweb.repoclient.impl;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.lionweb.lioncore.java.LionWebVersion;
+import io.lionweb.lioncore.java.utils.CommonChecks;
+import io.lionweb.repoclient.CompressionSupport;
+import io.lionweb.repoclient.RequestFailureException;
+import io.lionweb.repoclient.api.RawBulkAPIClient;
+import io.lionweb.repoclient.api.RepositoryVersionToken;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.util.*;
+import java.util.stream.Collectors;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okio.Buffer;
+import okio.BufferedSink;
+import okio.GzipSink;
+import okio.Okio;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ClientForRawBulkAPIs extends LionWebRepoClientImplHelper implements RawBulkAPIClient {
+
+  public ClientForRawBulkAPIs(RepoClientConfiguration repoClientConfiguration) {
+    super(repoClientConfiguration);
+  }
+
+  @NotNull
+  @Override
+  public LionWebVersion getLionWebVersion() {
+    return conf.getJsonSerialization().getLionWebVersion();
+  }
+
+  @Override
+  public @Nullable RepositoryVersionToken rawCreatePartitions(@NotNull String data)
+      throws IOException {
+    return nodesStoringOperation(data, "createPartitions");
+  }
+
+  @Nullable
+  @Override
+  public RepositoryVersionToken rawStore(@NotNull String json) throws IOException {
+    Request.Builder rq = buildRequest("/bulk/store");
+    rq = addGZipCompressionHeader(rq);
+    RequestBody uncompressedBody = RequestBody.create(json, JSON);
+    Request request = rq.post(gzipCompress(uncompressedBody)).build();
+    return performCall(
+        request,
+        (response, responseBody) -> {
+          JsonObject responseData = JsonParser.parseString(responseBody).getAsJsonObject();
+          boolean success = responseData.get("success").getAsBoolean();
+          if (!success) {
+            throw new RequestFailureException(
+                request.url().toString(), response.code(), responseBody);
+          }
+          return getRepoVersionFromResponse(responseBody);
+        });
+  }
+
+  @Override
+  public String rawRetrieve(@NotNull List<String> nodeIds, int limit) throws IOException {
+    List<String> invalidIDs =
+        nodeIds.stream().filter(id -> !CommonChecks.isValidID(id)).collect(Collectors.toList());
+    if (!invalidIDs.isEmpty()) {
+      throw new IllegalArgumentException("IDs must all be valid. Invalid IDs found: " + invalidIDs);
+    }
+
+    String bodyJson =
+        "{\"ids\":["
+            + String.join(", ", nodeIds.stream().map(id -> "\"" + id + "\"").toArray(String[]::new))
+            + "]}";
+    Map<String, String> params = new HashMap<>();
+    params.put("depthLimit", String.valueOf(limit));
+    Request.Builder rq = buildRequest("/bulk/retrieve", true, true, true, params);
+    Request request = rq.post(RequestBody.create(bodyJson, JSON)).build();
+
+    return performCall(
+        request,
+        (response, responseBody) -> {
+          JsonObject responseData = JsonParser.parseString(responseBody).getAsJsonObject();
+          boolean success = responseData.get("success").getAsBoolean();
+          if (!success) {
+            throw new RequestFailureException(
+                request.url().toString(), response.code(), responseBody);
+          }
+          JsonElement chunkAsJson = responseData.get("chunk");
+          return gson.toJson(chunkAsJson);
+        });
+  }
+
+  private @Nullable RepositoryVersionToken nodesStoringOperation(
+      final String json, final String operation) {
+    // Build the request
+    Request.Builder rb = buildRequest("/bulk/" + operation);
+    rb = addGZipCompressionHeader(rb);
+    RequestBody body =
+        CompressionSupport.compress(
+            json); // assuming CompressUtil.compress(String) handles JSON compression
+    Request request = rb.post(body).build();
+
+    String url = request.url().toString();
+    try {
+      try (Response response = conf.getHttpClient().newCall(request).execute()) {
+        String responseBody = response.body() != null ? response.body().string() : null;
+        if (response.code() != HttpURLConnection.HTTP_OK) {
+          throw new RequestFailureException(url, response.code(), responseBody);
+        } else {
+          return getRepoVersionFromResponse(responseBody);
+        }
+      }
+    } catch (ConnectException e) {
+      String jsonExcerpt = json.length() > 10000 ? json.substring(0, 1000) + "..." : json;
+      throw new RuntimeException(
+          "Cannot get answer from the client when contacting at URL "
+              + url
+              + ". Body: "
+              + jsonExcerpt,
+          e);
+    } catch (IOException e) {
+      throw new RuntimeException("IO error while contacting URL " + url, e);
+    }
+  }
+
+  private RequestBody gzipCompress(RequestBody original) throws IOException {
+    Buffer buffer = new Buffer();
+    original.writeTo(buffer);
+
+    RequestBody gzippedBody =
+        new RequestBody() {
+          @Override
+          public MediaType contentType() {
+            return original.contentType();
+          }
+
+          @Override
+          public long contentLength() {
+            return -1; // unknown
+          }
+
+          @Override
+          public void writeTo(BufferedSink sink) throws IOException {
+            GzipSink gzipSink = new GzipSink(sink);
+            BufferedSink compressedSink = Okio.buffer(gzipSink);
+            buffer.copyTo(compressedSink.buffer(), 0, buffer.size());
+            compressedSink.close();
+          }
+        };
+
+    return gzippedBody;
+  }
+}


### PR DESCRIPTION
For backup/restore use cases it is useful to have a command to download an entire repository to a directory or as a zip and then reupload it from there. This feature is introduced into the extensions.

Changes are made to expose lower level operations (besides the existing "normal" operations) which permits to communicate with the repository without being forced to always deserialize nodes (e.g., we can the nodes serialized and we can save them on file, we can then load them from file and, without deserializing them, send them to the repository).