### PR TITLE
Flatbuffers and Protobuffer support for multiple LionWeb versions

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/FlatBuffersSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/FlatBuffersSerialization.java
@@ -237,7 +237,7 @@ public class FlatBuffersSerialization extends AbstractSerialization {
             FBProperty.createFBProperty(
                 builder,
                 offsetForMetaPointer(el.getMetaPointer()),
-                    nullableStringOffset(builder, el.getValue()));
+                nullableStringOffset(builder, el.getValue()));
       }
       return props;
     }
@@ -279,8 +279,8 @@ public class FlatBuffersSerialization extends AbstractSerialization {
           values[k] =
               FBReferenceValue.createFBReferenceValue(
                   builder,
-                      nullableStringOffset(builder, el.getValue().get(k).getResolveInfo()),
-                      nullableStringOffset(builder, el.getValue().get(k).getReference()));
+                  nullableStringOffset(builder, el.getValue().get(k).getResolveInfo()),
+                  nullableStringOffset(builder, el.getValue().get(k).getReference()));
         }
         refs[j] =
             FBReference.createFBReference(

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/FlatBuffersSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/FlatBuffersSerialization.java
@@ -17,6 +17,14 @@ public class FlatBuffersSerialization extends AbstractSerialization {
 
   private static final String NULL_CONSTANT = "NULL";
 
+  public FlatBuffersSerialization() {
+    super();
+  }
+
+  public FlatBuffersSerialization(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
+  }
+
   public List<io.lionweb.lioncore.java.model.Node> deserializeToNodes(byte[] bytes)
       throws IOException {
     ByteBuffer bb = ByteBuffer.wrap(bytes);
@@ -43,7 +51,8 @@ public class FlatBuffersSerialization extends AbstractSerialization {
 
   private static class DeserializationHelper {
 
-    private final HashMap<FBMetaPointer, MetaPointer> metaPointersCache = new HashMap<>();
+    private final IdentityHashMap<FBMetaPointer, MetaPointer> metaPointersCache =
+        new IdentityHashMap<>();
 
     public MetaPointer deserialize(FBMetaPointer classifier) {
       if (classifier == null) {
@@ -131,14 +140,6 @@ public class FlatBuffersSerialization extends AbstractSerialization {
     }
     ;
     return serializedChunk;
-  }
-
-  public FlatBuffersSerialization() {
-    super();
-  }
-
-  public FlatBuffersSerialization(@Nonnull LionWebVersion lionWebVersion) {
-    super(lionWebVersion);
   }
 
   public byte[] serializeTreesToByteArray(ClassifierInstance<?>... roots) {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/FlatBuffersSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/FlatBuffersSerialization.java
@@ -1,6 +1,7 @@
 package io.lionweb.lioncore.java.serialization;
 
 import com.google.flatbuffers.FlatBufferBuilder;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.*;
 import io.lionweb.lioncore.java.model.impl.ProxyNode;
 import io.lionweb.lioncore.java.serialization.data.*;
@@ -10,6 +11,7 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 public class FlatBuffersSerialization extends AbstractSerialization {
 
@@ -124,6 +126,14 @@ public class FlatBuffersSerialization extends AbstractSerialization {
     }
     ;
     return serializedChunk;
+  }
+
+  public FlatBuffersSerialization() {
+    super();
+  }
+
+  public FlatBuffersSerialization(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
   }
 
   public byte[] serializeTreesToByteArray(ClassifierInstance<?>... roots) {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/FlatBuffersSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/FlatBuffersSerialization.java
@@ -41,9 +41,9 @@ public class FlatBuffersSerialization extends AbstractSerialization {
     return deserializeSerializationChunk(FBChunk.getRootAsFBChunk(bb));
   }
 
-  private class DeserializationHelper {
+  private static class DeserializationHelper {
 
-    private IdentityHashMap<FBMetaPointer, MetaPointer> metaPointersCache = new IdentityHashMap<>();
+    private final HashMap<FBMetaPointer, MetaPointer> metaPointersCache = new HashMap<>();
 
     public MetaPointer deserialize(FBMetaPointer classifier) {
       if (classifier == null) {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/ProtoBufSerialization.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/ProtoBufSerialization.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.serialization;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.model.impl.ProxyNode;
 import io.lionweb.lioncore.java.serialization.data.*;
@@ -8,12 +9,26 @@ import io.lionweb.lioncore.protobuf.*;
 import java.io.*;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 public class ProtoBufSerialization extends AbstractSerialization {
+
+  public ProtoBufSerialization() {
+    super();
+  }
+
+  public ProtoBufSerialization(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
+  }
 
   public List<io.lionweb.lioncore.java.model.Node> deserializeToNodes(byte[] bytes)
       throws IOException {
     return deserializeToNodes(new ByteArrayInputStream(bytes));
+  }
+
+  public SerializedChunk deserializeToChunk(byte[] bytes) throws IOException {
+    PBChunk pbChunk = PBChunk.parseFrom(new ByteArrayInputStream(bytes));
+    return deserializeSerializationChunk(pbChunk);
   }
 
   public List<io.lionweb.lioncore.java.model.Node> deserializeToNodes(File file)

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationProvider.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationProvider.java
@@ -33,10 +33,22 @@ public class SerializationProvider {
   }
 
   /** This has specific support for LionCore or LionCoreBuiltins. */
-  public static ProtoBufSerialization getStandardProtoBufSerialization() {
-    ProtoBufSerialization serialization = new ProtoBufSerialization();
+  public static ProtoBufSerialization getStandardProtoBufSerialization(
+      @Nonnull LionWebVersion lionWebVersion) {
+    ProtoBufSerialization serialization = new ProtoBufSerialization(lionWebVersion);
     standardInitialization(serialization);
     return serialization;
+  }
+
+  /** This has specific support for LionCore or LionCoreBuiltins. */
+  public static ProtoBufSerialization getStandardProtoBufSerialization() {
+    return getStandardProtoBufSerialization(LionWebVersion.currentVersion);
+  }
+
+  /** This has no specific support for LionCore or LionCoreBuiltins. */
+  public static ProtoBufSerialization getBasicProtoBufSerialization(
+      @Nonnull LionWebVersion lionWebVersion) {
+    return new ProtoBufSerialization(lionWebVersion);
   }
 
   /** This has no specific support for LionCore or LionCoreBuiltins. */
@@ -60,6 +72,12 @@ public class SerializationProvider {
   /** This has no specific support for LionCore or LionCoreBuiltins. */
   public static FlatBuffersSerialization getBasicFlatBuffersSerialization() {
     return new FlatBuffersSerialization();
+  }
+
+  /** This has no specific support for LionCore or LionCoreBuiltins. */
+  public static FlatBuffersSerialization getBasicFlatBuffersSerialization(
+      @Nonnull LionWebVersion lionWebVersion) {
+    return new FlatBuffersSerialization(lionWebVersion);
   }
 
   protected static void standardInitialization(AbstractSerialization serialization) {

--- a/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationProvider.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/serialization/SerializationProvider.java
@@ -46,7 +46,13 @@ public class SerializationProvider {
 
   /** This has specific support for LionCore or LionCoreBuiltins. */
   public static FlatBuffersSerialization getStandardFlatBuffersSerialization() {
-    FlatBuffersSerialization serialization = new FlatBuffersSerialization();
+    return getStandardFlatBuffersSerialization(LionWebVersion.currentVersion);
+  }
+
+  public static FlatBuffersSerialization getStandardFlatBuffersSerialization(
+      @Nonnull LionWebVersion lionWebVersion) {
+    Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
+    FlatBuffersSerialization serialization = new FlatBuffersSerialization(lionWebVersion);
     standardInitialization(serialization);
     return serialization;
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/utils/ModelComparator.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/utils/ModelComparator.java
@@ -145,6 +145,12 @@ public class ModelComparator {
     }
   }
 
+  public static boolean areEquivalent(ClassifierInstance<?> a, ClassifierInstance<?> b) {
+    ModelComparator modelComparator = new ModelComparator();
+    ModelComparator.ComparisonResult comparisonResult = modelComparator.compare(a, b);
+    return comparisonResult.areEquivalent();
+  }
+
   public ComparisonResult compare(Node nodeA, Node nodeB) {
     ComparisonResult comparisonResult = new ComparisonResult();
     compare(nodeA, nodeB, comparisonResult, "<root>");

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/FlatbuffersSerializationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/FlatbuffersSerializationTest.java
@@ -4,10 +4,7 @@ import static org.junit.Assert.*;
 
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.*;
-import io.lionweb.lioncore.java.model.AnnotationInstance;
-import io.lionweb.lioncore.java.model.ClassifierInstance;
-import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
-import io.lionweb.lioncore.java.model.Node;
+import io.lionweb.lioncore.java.model.*;
 import io.lionweb.lioncore.java.model.impl.DynamicAnnotationInstance;
 import io.lionweb.lioncore.java.model.impl.DynamicNode;
 import io.lionweb.lioncore.java.serialization.data.*;
@@ -262,16 +259,7 @@ public class FlatbuffersSerializationTest extends SerializationTest {
     List<ClassifierInstance<?>> deserialized =
         flatBuffersSerialization.deserializeSerializationBlock(serializedChunk);
     assertEquals(4, deserialized.size());
-    assertInstancesAreEquals(a1_1, deserialized.get(1));
-    assertEquals(deserialized.get(0), deserialized.get(1).getParent());
-    assertInstancesAreEquals(a1_2, deserialized.get(2));
-    assertEquals(deserialized.get(0), deserialized.get(2).getParent());
-    assertInstancesAreEquals(a2_3, deserialized.get(3));
-    assertEquals(deserialized.get(0), deserialized.get(3).getParent());
     assertInstancesAreEquals(n1, deserialized.get(0));
-    assertEquals(
-        Arrays.asList(deserialized.get(1), deserialized.get(2), deserialized.get(3)),
-        deserialized.get(0).getAnnotations());
   }
 
   @Test
@@ -306,16 +294,7 @@ public class FlatbuffersSerializationTest extends SerializationTest {
     List<ClassifierInstance<?>> deserialized =
         flatBuffersSerialization.deserializeSerializationBlock(serializedChunk);
     assertEquals(4, deserialized.size());
-    assertInstancesAreEquals(a1_1, deserialized.get(1));
-    assertEquals(deserialized.get(0), deserialized.get(1).getParent());
-    assertInstancesAreEquals(a1_2, deserialized.get(2));
-    assertEquals(deserialized.get(0), deserialized.get(2).getParent());
-    assertInstancesAreEquals(a2_3, deserialized.get(3));
-    assertEquals(deserialized.get(0), deserialized.get(3).getParent());
     assertInstancesAreEquals(n1, deserialized.get(0));
-    assertEquals(
-        Arrays.asList(deserialized.get(1), deserialized.get(2), deserialized.get(3)),
-        deserialized.get(0).getAnnotations());
   }
 
   @Test
@@ -451,6 +430,27 @@ public class FlatbuffersSerializationTest extends SerializationTest {
     assertEquals(2, serializedChunk.getLanguages().size());
     assertSerializedChunkContainsLanguage(serializedChunk, l);
     assertSerializedChunkContainsLanguage(serializedChunk, LionCoreBuiltins.getInstance());
+  }
+
+  @Test
+  public void serializationWithNullReferencesAndProperties() throws IOException {
+    Language myLanguage = new Language();
+    myLanguage.setID("myLanguage");
+    myLanguage.setName(null);
+    myLanguage.setKey("myLanguage-key");
+    myLanguage.setVersion("3");
+    Concept myConcept = new Concept();
+    myConcept.setID("myConcept");
+    myConcept.addImplementedInterface(LionCoreBuiltins.getINamed());
+    myConcept.setReferenceValues(
+        myConcept.getClassifier().getReferenceByName("extends"),
+        Arrays.asList(new ReferenceValue(null, null)));
+    myLanguage.addElement(myConcept);
+
+    FlatBuffersSerialization flatBuffersSerialization =
+        SerializationProvider.getStandardFlatBuffersSerialization();
+    byte[] bytes = flatBuffersSerialization.serializeTree(myLanguage);
+    assertInstancesAreEquals(myLanguage, flatBuffersSerialization.deserializeToNodes(bytes).get(0));
   }
 
   private void assertSerializedChunkContainsLanguage(

--- a/core/src/test/java/io/lionweb/lioncore/java/serialization/FlatbuffersSerializationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/serialization/FlatbuffersSerializationTest.java
@@ -2,6 +2,7 @@ package io.lionweb.lioncore.java.serialization;
 
 import static org.junit.Assert.*;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.AnnotationInstance;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
@@ -274,6 +275,50 @@ public class FlatbuffersSerializationTest extends SerializationTest {
   }
 
   @Test
+  public void serializeAnnotationsUsingLW2023_1() {
+    Language l = new Language(LionWebVersion.v2023_1, "l");
+    l.setKey("l");
+    l.setID("l");
+    l.setVersion("1");
+    Annotation a1 = new Annotation(l, "a1", "a1", "a1");
+    Annotation a2 = new Annotation(l, "a2", "a2", "a2");
+    Concept c = new Concept(l, "c", "c", "c");
+
+    DynamicNode n1 = new DynamicNode("n1", c);
+    AnnotationInstance a1_1 = new DynamicAnnotationInstance("a1_1", a1, n1);
+    AnnotationInstance a1_2 = new DynamicAnnotationInstance("a1_2", a1, n1);
+    AnnotationInstance a2_3 = new DynamicAnnotationInstance("a2_3", a2, n1);
+
+    FlatBuffersSerialization flatBuffersSerialization =
+        SerializationProvider.getStandardFlatBuffersSerialization(LionWebVersion.v2023_1);
+    flatBuffersSerialization.enableDynamicNodes();
+    SerializedChunk serializedChunk =
+        flatBuffersSerialization.serializeNodesToSerializationBlock(n1);
+
+    assertEquals(4, serializedChunk.getClassifierInstances().size());
+    SerializedClassifierInstance serializedN1 = serializedChunk.getClassifierInstances().get(0);
+    assertEquals("n1", serializedN1.getID());
+    assertNull(serializedN1.getParentNodeID());
+    assertEquals(Arrays.asList("a1_1", "a1_2", "a2_3"), serializedN1.getAnnotations());
+    SerializedClassifierInstance serializedA1_1 = serializedChunk.getClassifierInstances().get(1);
+    assertEquals("n1", serializedA1_1.getParentNodeID());
+
+    List<ClassifierInstance<?>> deserialized =
+        flatBuffersSerialization.deserializeSerializationBlock(serializedChunk);
+    assertEquals(4, deserialized.size());
+    assertInstancesAreEquals(a1_1, deserialized.get(1));
+    assertEquals(deserialized.get(0), deserialized.get(1).getParent());
+    assertInstancesAreEquals(a1_2, deserialized.get(2));
+    assertEquals(deserialized.get(0), deserialized.get(2).getParent());
+    assertInstancesAreEquals(a2_3, deserialized.get(3));
+    assertEquals(deserialized.get(0), deserialized.get(3).getParent());
+    assertInstancesAreEquals(n1, deserialized.get(0));
+    assertEquals(
+        Arrays.asList(deserialized.get(1), deserialized.get(2), deserialized.get(3)),
+        deserialized.get(0).getAnnotations());
+  }
+
+  @Test
   public void serializeLanguage() {
     Language metaLang = new Language("metaLang", "metaLang", "metaLang", "1");
     Annotation metaAnn = new Annotation(metaLang, "metaAnn", "metaAnn", "metaAnn");
@@ -310,6 +355,80 @@ public class FlatbuffersSerializationTest extends SerializationTest {
     assertInstancesAreEquals(ann, deserializedAnn);
     assertEquals(deserializedC, deserializedAnn.getParent());
     assertEquals(Arrays.asList(deserializedAnn), deserializedC.getAnnotations());
+  }
+
+  @Test
+  public void serializeLanguage2023_1() {
+    Language metaLang = new Language(LionWebVersion.v2023_1, "metaLang");
+    metaLang.setID("metaLang");
+    metaLang.setKey("metaLang");
+    metaLang.setVersion("1");
+    Annotation metaAnn = new Annotation(metaLang, "metaAnn", "metaAnn", "metaAnn");
+
+    Language l = new Language(LionWebVersion.v2023_1, "l");
+    l.setKey("l");
+    l.setID("l");
+    l.setVersion("1");
+    Annotation a1 = new Annotation(l, "a1", "a1", "a1");
+    Annotation a2 = new Annotation(l, "a2", "a2", "a2");
+    Concept c = new Concept(l, "c", "c", "c");
+    DynamicAnnotationInstance ann = new DynamicAnnotationInstance("metaAnn_1", metaAnn, c);
+    c.addAnnotation(ann);
+
+    FlatBuffersSerialization flatBuffersSerialization =
+        SerializationProvider.getStandardFlatBuffersSerialization(LionWebVersion.v2023_1);
+    flatBuffersSerialization.enableDynamicNodes();
+    SerializedChunk serializedChunk = flatBuffersSerialization.serializeTreeToSerializationBlock(l);
+
+    assertEquals(5, serializedChunk.getClassifierInstances().size());
+    SerializedClassifierInstance serializedL = serializedChunk.getClassifierInstances().get(0);
+    assertEquals("l", serializedL.getID());
+    assertNull(serializedL.getParentNodeID());
+
+    SerializedClassifierInstance serializedC = serializedChunk.getInstanceByID("c");
+    assertEquals("c", serializedC.getID());
+    assertEquals(Arrays.asList("metaAnn_1"), serializedC.getAnnotations());
+
+    flatBuffersSerialization.registerLanguage(metaLang);
+    List<ClassifierInstance<?>> deserialized =
+        flatBuffersSerialization.deserializeSerializationBlock(serializedChunk);
+    assertEquals(5, deserialized.size());
+    ClassifierInstance<?> deserializedC = deserialized.get(3);
+    assertInstancesAreEquals(c, deserializedC);
+    assertEquals(deserialized.get(0), deserializedC.getParent());
+    ClassifierInstance<?> deserializedAnn = deserialized.get(4);
+    assertInstancesAreEquals(ann, deserializedAnn);
+    assertEquals(deserializedC, deserializedAnn.getParent());
+    assertEquals(Arrays.asList(deserializedAnn), deserializedC.getAnnotations());
+  }
+
+  @Test
+  public void deserializeLanguageToChunk() {
+    Language metaLang = new Language(LionWebVersion.v2023_1, "metaLang");
+    metaLang.setID("metaLang");
+    metaLang.setKey("metaLang");
+    metaLang.setVersion("1");
+    Annotation metaAnn = new Annotation(metaLang, "metaAnn", "metaAnn", "metaAnn");
+
+    Language l = new Language(LionWebVersion.v2023_1, "l");
+    l.setKey("l");
+    l.setID("l");
+    l.setVersion("1");
+    Annotation a1 = new Annotation(l, "a1", "a1", "a1");
+    Annotation a2 = new Annotation(l, "a2", "a2", "a2");
+    Concept c = new Concept(l, "c", "c", "c");
+    DynamicAnnotationInstance ann = new DynamicAnnotationInstance("metaAnn_1", metaAnn, c);
+    c.addAnnotation(ann);
+
+    FlatBuffersSerialization flatBuffersSerialization =
+        SerializationProvider.getStandardFlatBuffersSerialization(LionWebVersion.v2023_1);
+    flatBuffersSerialization.enableDynamicNodes();
+    SerializedChunk serializedChunk = flatBuffersSerialization.serializeTreeToSerializationBlock(l);
+
+    byte[] bytes = flatBuffersSerialization.serialize(serializedChunk);
+    SerializedChunk deserializedChunk = flatBuffersSerialization.deserializeToChunk(bytes);
+
+    assertEquals(serializedChunk, deserializedChunk);
   }
 
   @Test

--- a/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraFlatBuffersSerialization.java
+++ b/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraFlatBuffersSerialization.java
@@ -1,15 +1,25 @@
 package io.lionweb.serialization.extensions;
 
 import com.google.flatbuffers.FlatBufferBuilder;
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.serialization.FlatBuffersSerialization;
 import io.lionweb.lioncore.java.serialization.data.*;
 import io.lionweb.serialization.flatbuffers.gen.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 /** It contains the logic to serialize non-standard messages. */
 public class ExtraFlatBuffersSerialization extends FlatBuffersSerialization {
+
+  public ExtraFlatBuffersSerialization() {
+    super();
+  }
+
+  public ExtraFlatBuffersSerialization(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
+  }
 
   public byte[] serializeBulkImport(BulkImport bulkImport) {
     FlatBufferBuilder builder = new FlatBufferBuilder(1024);

--- a/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraProtoBufSerialization.java
+++ b/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraProtoBufSerialization.java
@@ -8,6 +8,7 @@ import io.lionweb.lioncore.protobuf.PBAttachPoint;
 import io.lionweb.lioncore.protobuf.PBBulkImport;
 import io.lionweb.lioncore.protobuf.PBMetaPointer;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /** It contains the logic to serialize non-standard messages. */
@@ -21,7 +22,8 @@ public class ExtraProtoBufSerialization extends ProtoBufSerialization {
     super(lionWebVersion);
   }
 
-  public PBBulkImport serializeBulkImport(BulkImport bulkImport) {
+  public PBBulkImport serializeBulkImport(@Nonnull BulkImport bulkImport) {
+    Objects.requireNonNull(bulkImport);
     PBBulkImport.Builder bulkImportBuilder = PBBulkImport.newBuilder();
     SerializeHelper serializeHelper = new SerializeHelper();
 
@@ -63,5 +65,10 @@ public class ExtraProtoBufSerialization extends ProtoBufSerialization {
                         .setVersion(serializeHelper.stringIndexer(entry.getKey().getVersion()))
                         .build()));
     return bulkImportBuilder.build();
+  }
+
+  public byte[] serializeBulkImportToBytes(@Nonnull BulkImport bulkImport) {
+    PBBulkImport pbBulkImport = serializeBulkImport(bulkImport);
+    return pbBulkImport.toByteArray();
   }
 }

--- a/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraProtoBufSerialization.java
+++ b/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraProtoBufSerialization.java
@@ -1,5 +1,6 @@
 package io.lionweb.serialization.extensions;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.serialization.LowLevelJsonSerialization;
 import io.lionweb.lioncore.java.serialization.ProtoBufSerialization;
 import io.lionweb.lioncore.java.serialization.data.SerializedChunk;
@@ -7,9 +8,18 @@ import io.lionweb.lioncore.protobuf.PBAttachPoint;
 import io.lionweb.lioncore.protobuf.PBBulkImport;
 import io.lionweb.lioncore.protobuf.PBMetaPointer;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 /** It contains the logic to serialize non-standard messages. */
 public class ExtraProtoBufSerialization extends ProtoBufSerialization {
+
+  public ExtraProtoBufSerialization() {
+    super();
+  }
+
+  public ExtraProtoBufSerialization(@Nonnull LionWebVersion lionWebVersion) {
+    super(lionWebVersion);
+  }
 
   public PBBulkImport serializeBulkImport(BulkImport bulkImport) {
     PBBulkImport.Builder bulkImportBuilder = PBBulkImport.newBuilder();

--- a/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraSerializationProvider.java
+++ b/extensions/src/main/java/io/lionweb/serialization/extensions/ExtraSerializationProvider.java
@@ -1,6 +1,8 @@
 package io.lionweb.serialization.extensions;
 
+import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.serialization.SerializationProvider;
+import javax.annotation.Nonnull;
 
 public class ExtraSerializationProvider extends SerializationProvider {
   public static ExtraFlatBuffersSerialization getExtraStandardFlatBuffersSerialization() {
@@ -9,8 +11,22 @@ public class ExtraSerializationProvider extends SerializationProvider {
     return serialization;
   }
 
+  public static ExtraFlatBuffersSerialization getExtraStandardFlatBuffersSerialization(
+      @Nonnull LionWebVersion lionWebVersion) {
+    ExtraFlatBuffersSerialization serialization = new ExtraFlatBuffersSerialization(lionWebVersion);
+    standardInitialization(serialization);
+    return serialization;
+  }
+
   public static ExtraProtoBufSerialization getExtraStandardProtoBufSerialization() {
     ExtraProtoBufSerialization serialization = new ExtraProtoBufSerialization();
+    standardInitialization(serialization);
+    return serialization;
+  }
+
+  public static ExtraProtoBufSerialization getExtraStandardProtoBufSerialization(
+      @Nonnull LionWebVersion lionWebVersion) {
+    ExtraProtoBufSerialization serialization = new ExtraProtoBufSerialization(lionWebVersion);
     standardInitialization(serialization);
     return serialization;
   }

--- a/extensions/src/test/java/io/lionweb/repoclient/ExtraProtoBufSerializationTest.java
+++ b/extensions/src/test/java/io/lionweb/repoclient/ExtraProtoBufSerializationTest.java
@@ -1,14 +1,17 @@
 package io.lionweb.repoclient;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import io.lionweb.lioncore.java.LionWebVersion;
-import io.lionweb.lioncore.java.language.*;
+import io.lionweb.lioncore.java.language.Concept;
+import io.lionweb.lioncore.java.language.Language;
+import io.lionweb.lioncore.java.language.LionCoreBuiltins;
+import io.lionweb.lioncore.java.language.Property;
 import io.lionweb.lioncore.java.model.ClassifierInstanceUtils;
 import io.lionweb.lioncore.java.model.impl.DynamicNode;
-import io.lionweb.lioncore.java.serialization.data.*;
+import io.lionweb.lioncore.java.serialization.data.MetaPointer;
 import io.lionweb.serialization.extensions.BulkImport;
-import io.lionweb.serialization.extensions.ExtraFlatBuffersSerialization;
+import io.lionweb.serialization.extensions.ExtraProtoBufSerialization;
 import io.lionweb.serialization.extensions.ExtraSerializationProvider;
 import io.lionweb.serialization.flatbuffers.gen.FBAttachPoint;
 import io.lionweb.serialization.flatbuffers.gen.FBBulkImport;
@@ -17,8 +20,8 @@ import io.lionweb.serialization.flatbuffers.gen.FBNode;
 import java.nio.ByteBuffer;
 import org.junit.Test;
 
-/** Testing various functionalities of FlatBuffersSerialization. */
-public class ExtraFlatbuffersSerializationTest {
+/** Testing various functionalities of ProtoBufSerialization. */
+public class ExtraProtoBufSerializationTest {
 
   @Test
   public void bulkImportSerialization() {
@@ -37,9 +40,9 @@ public class ExtraFlatbuffersSerializationTest {
     bulkImport.addAttachPoint(
         new BulkImport.AttachPoint("n2", new MetaPointer("Foo", "1", "c-key"), "n1"));
 
-    ExtraFlatBuffersSerialization flatBuffersSerialization =
-        ExtraSerializationProvider.getExtraStandardFlatBuffersSerialization();
-    byte[] bytes = flatBuffersSerialization.serializeBulkImport(bulkImport);
+    ExtraProtoBufSerialization serialization =
+        ExtraSerializationProvider.getExtraStandardProtoBufSerialization();
+    byte[] bytes = serialization.serializeBulkImportToBytes(bulkImport);
 
     ByteBuffer bb = ByteBuffer.wrap(bytes);
     FBBulkImport fbBulkImport = FBBulkImport.getRootAsFBBulkImport(bb);
@@ -83,9 +86,9 @@ public class ExtraFlatbuffersSerializationTest {
     bulkImport.addAttachPoint(
         new BulkImport.AttachPoint("n2", new MetaPointer("Foo", "1", "c-key"), "n1"));
 
-    ExtraFlatBuffersSerialization flatBuffersSerialization =
-        ExtraSerializationProvider.getExtraStandardFlatBuffersSerialization(LionWebVersion.v2023_1);
-    byte[] bytes = flatBuffersSerialization.serializeBulkImport(bulkImport);
+    ExtraProtoBufSerialization serialization =
+        ExtraSerializationProvider.getExtraStandardProtoBufSerialization(LionWebVersion.v2023_1);
+    byte[] bytes = serialization.serializeBulkImportToBytes(bulkImport);
 
     ByteBuffer bb = ByteBuffer.wrap(bytes);
     FBBulkImport fbBulkImport = FBBulkImport.getRootAsFBBulkImport(bb);
@@ -128,9 +131,9 @@ public class ExtraFlatbuffersSerializationTest {
     BulkImport bulkImport = new BulkImport();
     bulkImport.addNode(n1);
 
-    ExtraFlatBuffersSerialization flatBuffersSerialization =
-        ExtraSerializationProvider.getExtraStandardFlatBuffersSerialization();
-    byte[] bytes = flatBuffersSerialization.serializeBulkImport(bulkImport);
+    ExtraProtoBufSerialization serialization =
+        ExtraSerializationProvider.getExtraStandardProtoBufSerialization();
+    byte[] bytes = serialization.serializeBulkImportToBytes(bulkImport);
 
     ByteBuffer bb = ByteBuffer.wrap(bytes);
     FBBulkImport fbBulkImport = FBBulkImport.getRootAsFBBulkImport(bb);


### PR DESCRIPTION
We fix the possibility to instantiate from SerializationProvider the FlatBuffersSerialization or the ProtobufferSerialization specifying the LionWeb version of interest.

We also expose methods for a partial deserialization from bytes to SerializationChunk.

Finally in FlatBuffers we correct the handling of null property or reference values.