### PR TITLE
Make it possible to remove features from Concept

### DIFF
--- a/core/src/main/java/io/lionweb/lioncore/java/language/Classifier.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Classifier.java
@@ -129,6 +129,14 @@ public abstract class Classifier<T extends M3Node> extends LanguageEntity<T>
     return (T) this;
   }
 
+  public void removeFeature(@Nonnull Feature<?> feature) {
+    Objects.requireNonNull(feature, "feature should not be null");
+    if (!getFeatures().contains(feature)) {
+      throw new IllegalArgumentException("The given feature does not belong to this concept");
+    }
+    this.removeChild(feature);
+  }
+
   @Override
   public String namespaceQualifier() {
     return this.qualifiedName();

--- a/core/src/main/java/io/lionweb/lioncore/java/language/Concept.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/Concept.java
@@ -23,9 +23,6 @@ import javax.annotation.Nullable;
  * @see org.jetbrains.mps.openapi.language.SConcept MPS equivalent <i>SConcept</i> in SModel
  */
 public class Concept extends Classifier<Concept> {
-  // DOUBT: would extended be null only for BaseConcept? Would this be null for all Concept that do
-  // not explicitly extend
-  //        another concept?
 
   public Concept() {
     super();

--- a/core/src/main/java/io/lionweb/lioncore/java/language/EnumerationLiteral.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/EnumerationLiteral.java
@@ -37,7 +37,7 @@ public class EnumerationLiteral extends M3Node<EnumerationLiteral>
   }
 
   public @Nullable Enumeration getEnumeration() {
-    Node parent = getParent();
+    Node parent = (Node) getParent();
     if (parent == null) {
       return null;
     } else if (parent instanceof Enumeration) {

--- a/core/src/main/java/io/lionweb/lioncore/java/language/EnumerationLiteral.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/language/EnumerationLiteral.java
@@ -1,7 +1,7 @@
 package io.lionweb.lioncore.java.language;
 
 import io.lionweb.lioncore.java.LionWebVersion;
-import io.lionweb.lioncore.java.model.Node;
+import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.model.impl.M3Node;
 import io.lionweb.lioncore.java.self.LionCore;
 import javax.annotation.Nonnull;
@@ -37,7 +37,7 @@ public class EnumerationLiteral extends M3Node<EnumerationLiteral>
   }
 
   public @Nullable Enumeration getEnumeration() {
-    Node parent = (Node) getParent();
+    ClassifierInstance<?> parent = getParent();
     if (parent == null) {
       return null;
     } else if (parent instanceof Enumeration) {

--- a/core/src/main/java/io/lionweb/lioncore/java/model/ClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/ClassifierInstance.java
@@ -6,6 +6,7 @@ import io.lionweb.lioncore.java.model.impl.ProxyNode;
 import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public interface ClassifierInstance<T extends Classifier<T>> extends HasFeatureValues {
   /** Return all the annotations associated to this ClassifierInstance. */
@@ -35,7 +36,7 @@ public interface ClassifierInstance<T extends Classifier<T>> extends HasFeatureV
   T getClassifier();
 
   /** The immediate parent of the Node. This should be null only for root nodes. */
-  ClassifierInstance<?> getParent();
+  @Nullable ClassifierInstance<?> getParent();
 
   /** Collects `self` and all its descendants into `result`. */
   static <T extends ClassifierInstance<?>> void collectSelfAndDescendants(

--- a/core/src/main/java/io/lionweb/lioncore/java/model/ClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/ClassifierInstance.java
@@ -36,7 +36,8 @@ public interface ClassifierInstance<T extends Classifier<T>> extends HasFeatureV
   T getClassifier();
 
   /** The immediate parent of the Node. This should be null only for root nodes. */
-  @Nullable ClassifierInstance<?> getParent();
+  @Nullable
+  ClassifierInstance<?> getParent();
 
   /** Collects `self` and all its descendants into `result`. */
   static <T extends ClassifierInstance<?>> void collectSelfAndDescendants(

--- a/core/src/main/java/io/lionweb/lioncore/java/model/HasSettableParent.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/HasSettableParent.java
@@ -7,5 +7,11 @@ import javax.annotation.Nullable;
  * node into a containment.
  */
 public interface HasSettableParent {
+  /**
+   * Set a new parent.
+   *
+   * @param parent the new parent to be assigned
+   * @return the element itself
+   */
   ClassifierInstance<?> setParent(@Nullable ClassifierInstance<?> parent);
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/HasSettableParent.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/HasSettableParent.java
@@ -1,5 +1,6 @@
 package io.lionweb.lioncore.java.model;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -13,5 +14,6 @@ public interface HasSettableParent {
    * @param parent the new parent to be assigned
    * @return the element itself
    */
+  @Nonnull
   ClassifierInstance<?> setParent(@Nullable ClassifierInstance<?> parent);
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/HasSettableParent.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/HasSettableParent.java
@@ -7,5 +7,5 @@ import javax.annotation.Nullable;
  * node into a containment.
  */
 public interface HasSettableParent {
-  void setParent(@Nullable ClassifierInstance<?> parent);
+  ClassifierInstance<?> setParent(@Nullable ClassifierInstance<?> parent);
 }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
@@ -64,7 +64,19 @@ public interface Node extends ClassifierInstance<Concept> {
    *     href="https://download.eclipse.org/modeling/emf/emf/javadoc/2.6.0/org/eclipse/emf/ecore/EObject.html#eContainingFeature()">Ecore
    *     equivalent <i>EObject.eContainingFeature</i> in documentation</a>.
    */
-  Containment getContainmentFeature();
+  @Nullable
+  default Containment getContainmentFeature() {
+    ClassifierInstance<?> parent = getParent();
+    if (parent == null) {
+      return null;
+    }
+    for (Containment containment : parent.getClassifier().allContainments()) {
+      if (parent.getChildren(containment).stream().anyMatch(it -> it == this)) {
+        return containment;
+      }
+    }
+    throw new IllegalStateException("Unable to find the containment feature");
+  }
 
   /**
    * Return a list containing this node and all its descendants. Does <i>not</i> include

--- a/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
@@ -63,7 +63,6 @@ public interface Node extends ClassifierInstance<Concept> {
    * @see <a
    *     href="https://download.eclipse.org/modeling/emf/emf/javadoc/2.6.0/org/eclipse/emf/ecore/EObject.html#eContainingFeature()">Ecore
    *     equivalent <i>EObject.eContainingFeature</i> in documentation</a>.
-   *
    * @return the Containment holding the Node. Or null, if the Node has no parent
    */
   @Nullable

--- a/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/Node.java
@@ -63,6 +63,8 @@ public interface Node extends ClassifierInstance<Concept> {
    * @see <a
    *     href="https://download.eclipse.org/modeling/emf/emf/javadoc/2.6.0/org/eclipse/emf/ecore/EObject.html#eContainingFeature()">Ecore
    *     equivalent <i>EObject.eContainingFeature</i> in documentation</a>.
+   *
+   * @return the Containment holding the Node. Or null, if the Node has no parent
    */
   @Nullable
   default Containment getContainmentFeature() {

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
@@ -8,7 +8,6 @@ import io.lionweb.lioncore.java.model.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * DynamicNode can be used to represent Node of any Concept. The drawback is that this class expose
@@ -44,22 +43,9 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
   }
 
   @Override
-  @Nullable
-  public Containment getContainmentFeature() {
-    if (parent == null) {
-      return null;
-    }
-    for (Containment containment : parent.getClassifier().allContainments()) {
-      if (parent.getChildren(containment).stream().anyMatch(it -> it == this)) {
-        return containment;
-      }
-    }
-    throw new IllegalStateException("Unable to find the containment feature");
-  }
-
-  @Override
-  public void setParent(ClassifierInstance<?> parent) {
+  public DynamicNode setParent(ClassifierInstance<?> parent) {
     this.parent = parent;
+    return this;
   }
 
   @Override

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/DynamicNode.java
@@ -8,6 +8,7 @@ import io.lionweb.lioncore.java.model.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * DynamicNode can be used to represent Node of any Concept. The drawback is that this class expose
@@ -43,7 +44,7 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
   }
 
   @Override
-  public DynamicNode setParent(ClassifierInstance<?> parent) {
+  public DynamicNode setParent(@Nullable ClassifierInstance<?> parent) {
     this.parent = parent;
     return this;
   }

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
@@ -1,17 +1,18 @@
 package io.lionweb.lioncore.java.model.impl;
 
-import static io.lionweb.lioncore.java.model.ClassifierInstanceUtils.*;
-
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.model.HasSettableParent;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.ReferenceValue;
-import java.util.*;
-import java.util.stream.Collectors;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static io.lionweb.lioncore.java.model.ClassifierInstanceUtils.*;
 
 /**
  * Base class to help implements Node in the language package.
@@ -58,6 +59,7 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
   }
 
   @Override
+  @Nullable
   public ClassifierInstance<?> getParent() {
     return parent;
   }
@@ -129,6 +131,14 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
       throw new IllegalArgumentException(
           "Cannot remove the given child, as this node it is not its parent");
     }
+    /*
+     * Note that, if the parent of the child is equal to this, it means the parent
+     * is not null, and therefore child.getContainmentFeature should not be null.
+     * Most implementation of the method (including the default one in Node) would
+     * either return a proper value or throw an exception to signal the inconsistency,
+     * so the extra check for feature not to be null is out of caution and to report
+     * the inconsistency, if somehow this has not been done by getContainmentFeature
+     */
     Feature<?> feature = child.getContainmentFeature();
     if (feature == null) {
       throw new IllegalStateException(

--- a/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
+++ b/core/src/main/java/io/lionweb/lioncore/java/model/impl/M3Node.java
@@ -1,18 +1,17 @@
 package io.lionweb.lioncore.java.model.impl;
 
+import static io.lionweb.lioncore.java.model.ClassifierInstanceUtils.*;
+
 import io.lionweb.lioncore.java.LionWebVersion;
 import io.lionweb.lioncore.java.language.*;
 import io.lionweb.lioncore.java.model.ClassifierInstance;
 import io.lionweb.lioncore.java.model.HasSettableParent;
 import io.lionweb.lioncore.java.model.Node;
 import io.lionweb.lioncore.java.model.ReferenceValue;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static io.lionweb.lioncore.java.model.ClassifierInstanceUtils.*;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Base class to help implements Node in the language package.

--- a/core/src/test/java/io/lionweb/lioncore/java/language/ConceptTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/language/ConceptTest.java
@@ -1,7 +1,9 @@
 package io.lionweb.lioncore.java.language;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
+import io.lionweb.lioncore.java.self.LionCore;
 import org.junit.Test;
 
 public class ConceptTest {
@@ -52,5 +54,43 @@ public class ConceptTest {
     assertEquals(1, c.inheritedFeatures().size());
     assertEquals(1, d.allFeatures().size());
     assertEquals(0, d.inheritedFeatures().size());
+  }
+
+  @Test
+  public void removingFeature() {
+    Language l = new Language("MyLanguage", "l-id", "l-key", "123");
+    Concept a = new Concept(l, "A", "a-id", "a-key");
+    Property p1 = new Property("p1", a, "p1-id");
+    assertEquals(0, a.getFeatures().size());
+    a.addFeature(p1);
+    assertEquals(1, a.getFeatures().size());
+    assertEquals(a, p1.getParent());
+    assertEquals(LionCore.getClassifier().getFeatureByName("features"), p1.getContainmentFeature());
+
+    a.removeChild(p1);
+    assertEquals(0, a.getFeatures().size());
+    assertNull(p1.getParent());
+    assertNull(p1.getContainmentFeature());
+
+    a.addFeature(p1);
+    assertEquals(1, a.getFeatures().size());
+    assertEquals(a, p1.getParent());
+    assertEquals(LionCore.getClassifier().getFeatureByName("features"), p1.getContainmentFeature());
+
+    a.removeFeature(p1);
+    assertEquals(0, a.getFeatures().size());
+    assertNull(p1.getParent());
+    assertNull(p1.getContainmentFeature());
+  }
+
+  @Test
+  public void containingFeature() {
+    Language l = new Language("MyLanguage", "l-id", "l-key", "123");
+    Concept a = new Concept(l, "A", "a-id", "a-key");
+    Property p1 = new Property("p1", a, "p1-id");
+    a.addFeature(p1);
+    assertNull(l.getContainmentFeature());
+    assertEquals(LionCore.getLanguage().getFeatureByName("entities"), a.getContainmentFeature());
+    assertEquals(LionCore.getClassifier().getFeatureByName("features"), p1.getContainmentFeature());
   }
 }

--- a/core/src/test/java/io/lionweb/lioncore/java/language/ConceptTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/java/language/ConceptTest.java
@@ -1,7 +1,6 @@
 package io.lionweb.lioncore.java.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 import io.lionweb.lioncore.java.self.LionCore;
 import org.junit.Test;
@@ -92,5 +91,21 @@ public class ConceptTest {
     assertNull(l.getContainmentFeature());
     assertEquals(LionCore.getLanguage().getFeatureByName("entities"), a.getContainmentFeature());
     assertEquals(LionCore.getClassifier().getFeatureByName("features"), p1.getContainmentFeature());
+  }
+
+  @Test
+  public void removingInheritedFeature() {
+    Language l = new Language("MyLanguage", "l-id", "l-key", "123");
+    Concept a = new Concept(l, "A", "a-id", "a-key");
+    Property p1 = new Property("p1", a, "p1-id");
+    Concept b = new Concept(l, "B", "b-id", "b-key");
+    b.setExtendedConcept(a);
+    assertEquals(0, a.getFeatures().size());
+    a.addFeature(p1);
+    assertEquals(1, a.getFeatures().size());
+    assertEquals(a, p1.getParent());
+    assertEquals(LionCore.getClassifier().getFeatureByName("features"), p1.getContainmentFeature());
+
+    assertThrows(IllegalArgumentException.class, () -> b.removeFeature(p1));
   }
 }


### PR DESCRIPTION
Fix #222 by adding the possibility of removing children for M3Nodes.

The implementation of getContainmentFeature has been moved from DynamicNode to Node to make it more reusable.

M3Node now implements HasSettableParent.