### PR TITLE
Adapting to the LionWeb Repository being renamed to LionWeb Server

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ jvmVersion=1.8
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 SONATYPE_CONNECT_TIMEOUT_SECONDS=200
 SONATYPE_CLOSE_TIMEOUT_SECONDS=2000
-lionwebRepositoryCommitID=bf8f361aead20b317da0a28fae3ad7a7b1e5b7b1
+lionwebServerCommitID=6a6fd368e1292c81a75ff906ab2792014f9d09ff

--- a/repo-client-testing/build.gradle.kts
+++ b/repo-client-testing/build.gradle.kts
@@ -41,12 +41,12 @@ dependencies {
     runtimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
 }
 
-val lionwebRepositoryCommitID = extra["lionwebRepositoryCommitID"]
+val lionwebServerCommitID = extra["lionwebServerCommitID"]
 
 buildConfig {
     sourceSets.getByName("main") {
         packageName("io.lionweb.repoclient.testing")
-        buildConfigField("String", "LIONWEB_REPOSITORY_COMMIT_ID", "\"${lionwebRepositoryCommitID}\"")
+        buildConfigField("String", "LIONWEB_SERVER_COMMIT_ID", "\"${lionwebServerCommitID}\"")
         useJavaOutput()
     }
 }

--- a/repo-client-testing/src/main/java/io/lionweb/repoclient/testing/AbstractRepoClientFunctionalTest.java
+++ b/repo-client-testing/src/main/java/io/lionweb/repoclient/testing/AbstractRepoClientFunctionalTest.java
@@ -58,11 +58,10 @@ public class AbstractRepoClientFunctionalTest {
         new GenericContainer<>(
                 new ImageFromDockerfile()
                     .withFileFromClasspath(
-                        "Dockerfile", "repoclienttesting-lionweb-repository-Dockerfile")
+                        "Dockerfile", "repoclienttesting-lionweb-server-Dockerfile")
                     .withFileFromClasspath(
                         "server-config.template.json", "server-config.template.json")
-                    .withBuildArg(
-                        "lionwebRepositoryCommitId", BuildConfig.LIONWEB_REPOSITORY_COMMIT_ID))
+                    .withBuildArg("lionwebServerCommitID", BuildConfig.LIONWEB_SERVER_COMMIT_ID))
             .withReuse(true)
             .dependsOn(db)
             .withNetwork(network)

--- a/repo-client-testing/src/main/resources/repoclienttesting-lionweb-server-Dockerfile
+++ b/repo-client-testing/src/main/resources/repoclienttesting-lionweb-server-Dockerfile
@@ -1,10 +1,10 @@
 FROM nikolaik/python-nodejs:python3.12-nodejs22
-ARG lionwebRepositoryCommitId=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ARG lionwebServerCommitID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 RUN apt-get update && apt-get install -y gettext-base
-RUN mkdir lionweb-repository
-WORKDIR lionweb-repository
+RUN mkdir lionweb-server
+WORKDIR lionweb-server
 RUN git init
-RUN git fetch --depth 1 https://github.com/LionWeb-io/lionweb-repository.git ${lionwebRepositoryCommitId}
+RUN git fetch --depth 1 https://github.com/LionWeb-io/lionweb-server.git ${lionwebServerCommitID}
 RUN git checkout FETCH_HEAD
 ADD server-config.template.json packages/server
 RUN npm install

--- a/repo-client/build.gradle.kts
+++ b/repo-client/build.gradle.kts
@@ -13,14 +13,14 @@ repositories {
     mavenCentral()
 }
 
-val lionwebRepositoryCommitID: String by project
+val lionwebServerCommitID: String by project
 
 val jvmVersion = extra["jvmVersion"] as String
 val specsVersion = extra["specsVersion"] as String
 
 tasks.withType<Jar>().configureEach {
     manifest {
-        attributes["lionwebRepositoryCommitID"] = lionwebRepositoryCommitID
+        attributes["lionwebServerCommitID"] = lionwebServerCommitID
     }
 }
 

--- a/website/docs/Guides/working-with-repository.md
+++ b/website/docs/Guides/working-with-repository.md
@@ -5,9 +5,9 @@ sidebar_position: 44
 
 # Working with the LionWeb Repository
 
-Working with the [LionWeb Repository](https://github.com/LionWeb-io/lionweb-repository) we can store and retrieve nodes. It is also a mean to exchange models with other LionWeb-compliant components. You can refer to the website of the LionWeb Repository to learn how to start it. 
+Working with the [LionWeb Server](https://github.com/LionWeb-io/lionweb-server) we can store and retrieve nodes. It is also a mean to exchange models with other LionWeb-compliant components. You can refer to the website of the LionWeb Server to learn how to start it. 
 
-This page provides an overview of how to interact with the repository using the provided Java client and outlines the basic concepts involved.
+This page provides an overview of how to interact with the server using the provided Java client and outlines the basic concepts involved.
 
 ## Using Gradle
 


### PR DESCRIPTION
The LionWeb Repository is being renamed to LionWeb Server, therefore we need to adapt some references.

Fix #223 