### PR TITLE
Avoid allocations when no annotations or references are present

### DIFF
--- a/core/src/main/java/io/lionweb/model/ClassifierInstanceUtils.java
+++ b/core/src/main/java/io/lionweb/model/ClassifierInstanceUtils.java
@@ -307,10 +307,15 @@ public class ClassifierInstanceUtils {
 
   public static boolean shallowAnnotationsEquality(
       List<AnnotationInstance> annotations1, List<AnnotationInstance> annotations2) {
-    return annotations1.size() == annotations2.size()
-        && IntStream.range(0, annotations1.size())
-            .allMatch(
-                i -> shallowClassifierInstanceEquality(annotations1.get(i), annotations2.get(i)));
+    int size1 = annotations1 == null ? 0 : annotations1.size();
+    int size2 = annotations2 == null ? 0 : annotations2.size();
+    return size1 == size2
+        && (size1 == 0
+            || IntStream.range(0, annotations1.size())
+                .allMatch(
+                    i ->
+                        shallowClassifierInstanceEquality(
+                            annotations1.get(i), annotations2.get(i))));
   }
 
   public static boolean shallowContainmentEquality(

--- a/core/src/main/java/io/lionweb/model/impl/DynamicAnnotationInstance.java
+++ b/core/src/main/java/io/lionweb/model/impl/DynamicAnnotationInstance.java
@@ -39,9 +39,19 @@ public class DynamicAnnotationInstance extends DynamicClassifierInstance<Annotat
         && Objects.equals(id, that.id)
         && Objects.equals(annotated, that.annotated)
         && Objects.equals(propertyValues, that.propertyValues)
-        && Objects.equals(containmentValues, that.containmentValues)
-        && Objects.equals(referenceValues, that.referenceValues)
-        && Objects.equals(annotations, that.annotations);
+        && Objects.equals(
+            containmentValues == null || containmentValues.isEmpty() ? null : containmentValues,
+            that.containmentValues == null || that.containmentValues.isEmpty()
+                ? null
+                : that.containmentValues)
+        && Objects.equals(
+            referenceValues == null || referenceValues.isEmpty() ? null : referenceValues,
+            that.referenceValues == null || that.referenceValues.isEmpty()
+                ? null
+                : that.referenceValues)
+        && Objects.equals(
+            annotations == null || annotations.isEmpty() ? null : annotations,
+            that.annotations == null || that.annotations.isEmpty() ? null : that.annotations);
   }
 
   @Override

--- a/core/src/main/java/io/lionweb/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/model/impl/DynamicClassifierInstance.java
@@ -216,9 +216,7 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
     if (!getClassifier().allReferences().contains(reference)) {
       throw new IllegalArgumentException("Reference not belonging to this classifier");
     }
-    if (referenceValues == null) {
-      referenceValues = new HashMap<>();
-    }
+    initReferences();
     referenceValues.put(reference.getKey(), (List<ReferenceValue>) values);
   }
 
@@ -254,15 +252,19 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
 
   // Private methods for references
 
+  private void initReferences() {
+    if (referenceValues == null) {
+      referenceValues = new HashMap<>();
+    }
+  }
+
   private void setReferenceSingleValue(Reference link, ReferenceValue value) {
     if (value == null) {
       if (referenceValues != null) {
         referenceValues.remove(link.getKey());
       }
     } else {
-      if (referenceValues == null) {
-        referenceValues = new HashMap<>();
-      }
+      initReferences();
       referenceValues.put(link.getKey(), new ArrayList(Arrays.asList(value)));
     }
   }
@@ -275,9 +277,7 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
     if (referenceValues != null && referenceValues.containsKey(link.getKey())) {
       referenceValues.get(link.getKey()).add(referenceValue);
     } else {
-      if (referenceValues == null) {
-        referenceValues = new HashMap<>();
-      }
+      initReferences();
       referenceValues.put(link.getKey(), new ArrayList(Arrays.asList(referenceValue)));
     }
   }

--- a/core/src/main/java/io/lionweb/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/model/impl/DynamicNode.java
@@ -69,6 +69,12 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
 
   private static boolean shallowReferenceEquality(
       Map<String, List<ReferenceValue>> reference1, Map<String, List<ReferenceValue>> reference2) {
+    if (reference1 == null && reference2 == null) {
+      return true;
+    }
+    if (reference1 == null || reference2 == null) {
+      return false;
+    }
     if (!reference1.keySet().equals(reference2.keySet())) {
       return false;
     }
@@ -109,6 +115,14 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
       qualifiedName = "<cannot be calculated>";
     }
 
+    String referenceValuesStr = "<null>";
+    if (referenceValues != null) {
+      referenceValuesStr =
+          referenceValues.entrySet().stream()
+              .map(e -> e.getKey() + "=" + e.getValue())
+              .collect(Collectors.joining(", "));
+    }
+
     return "DynamicNode{"
         + "id='"
         + id
@@ -131,9 +145,7 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
                 })
             .collect(Collectors.joining(", "))
         + "}, referenceValues={"
-        + referenceValues.entrySet().stream()
-            .map(e -> e.getKey() + "=" + e.getValue())
-            .collect(Collectors.joining(", "))
+        + referenceValuesStr
         + "}, annotations={"
         + annotations
         + "} }";

--- a/core/src/main/java/io/lionweb/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/model/impl/DynamicNode.java
@@ -69,11 +69,13 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
 
   private static boolean shallowReferenceEquality(
       Map<String, List<ReferenceValue>> reference1, Map<String, List<ReferenceValue>> reference2) {
-    if (reference1 == null && reference2 == null) {
-      return true;
-    }
-    if (reference1 == null || reference2 == null) {
+    boolean empty1 = reference1 == null || reference1.isEmpty();
+    boolean empty2 = reference2 == null || reference2.isEmpty();
+    if (empty1 != empty2) {
       return false;
+    }
+    if (empty1 && empty2) {
+      return true;
     }
     if (!reference1.keySet().equals(reference2.keySet())) {
       return false;
@@ -89,6 +91,14 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
 
   private static boolean shallowContainmentsEquality(
       Map<String, List<Node>> containments1, Map<String, List<Node>> containments2) {
+    boolean empty1 = containments1 == null || containments1.isEmpty();
+    boolean empty2 = containments2 == null || containments2.isEmpty();
+    if (empty1 != empty2) {
+      return false;
+    }
+    if (empty1 && empty2) {
+      return true;
+    }
     if (!containments1.keySet().equals(containments2.keySet())) {
       return false;
     }
@@ -123,6 +133,18 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
               .collect(Collectors.joining(", "));
     }
 
+    String containmentValueStr = "<null>";
+    if (containmentValues != null) {
+      containmentValues.entrySet().stream()
+          .map(
+              e -> {
+                String childrenRepr =
+                    e.getValue().stream().map(c -> c.getID()).collect(Collectors.joining(", "));
+                return e.getKey() + "=" + childrenRepr;
+              })
+          .collect(Collectors.joining(", "));
+    }
+
     return "DynamicNode{"
         + "id='"
         + id
@@ -136,14 +158,7 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
             .map(e -> e.getKey() + "=" + e.getValue())
             .collect(Collectors.joining(", "))
         + "}, containmentValues={"
-        + containmentValues.entrySet().stream()
-            .map(
-                e -> {
-                  String childrenRepr =
-                      e.getValue().stream().map(c -> c.getID()).collect(Collectors.joining(", "));
-                  return e.getKey() + "=" + childrenRepr;
-                })
-            .collect(Collectors.joining(", "))
+        + containmentValueStr
         + "}, referenceValues={"
         + referenceValuesStr
         + "}, annotations={"

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedClassifierInstance.java
@@ -18,8 +18,13 @@ public class SerializedClassifierInstance {
 
   private final List<SerializedPropertyValue> properties = new ArrayList<>();
   private final List<SerializedContainmentValue> containments = new ArrayList<>();
-  private final List<SerializedReferenceValue> references = new ArrayList<>();
-  private final List<String> annotations = new ArrayList<>();
+
+  /** Given most nodes have no references, we avoid the instantiation, unless it is necessary. */
+  private @Nullable List<SerializedReferenceValue> references;
+
+  /** Given most nodes have no annotations, we avoid the instantiation, unless it is necessary. */
+  private @Nullable List<String> annotations;
+
   private String parentNodeID;
 
   public String getParentNodeID() {
@@ -56,10 +61,16 @@ public class SerializedClassifierInstance {
   }
 
   public List<SerializedReferenceValue> getReferences() {
+    if (this.references == null) {
+      return Collections.emptyList();
+    }
     return Collections.unmodifiableList(this.references);
   }
 
   public List<String> getAnnotations() {
+    if (this.annotations == null) {
+      return Collections.emptyList();
+    }
     return Collections.unmodifiableList(this.annotations);
   }
 
@@ -76,6 +87,9 @@ public class SerializedClassifierInstance {
   }
 
   public void addReferenceValue(SerializedReferenceValue referenceValue) {
+    if (this.references == null) {
+      this.references = new ArrayList<>(1);
+    }
     this.references.add(referenceValue);
   }
 
@@ -106,6 +120,9 @@ public class SerializedClassifierInstance {
 
   public void addReferenceValue(
       MetaPointer reference, List<SerializedReferenceValue.Entry> referenceValues) {
+    if (this.references == null) {
+      this.references = new ArrayList<>(1);
+    }
     this.references.add(new SerializedReferenceValue(reference, referenceValues));
   }
 
@@ -161,11 +178,18 @@ public class SerializedClassifierInstance {
   }
 
   public void setAnnotations(List<String> annotationIDs) {
-    this.annotations.clear();
+    if (this.annotations == null) {
+      this.annotations = new ArrayList<>(annotationIDs.size());
+    } else {
+      this.annotations.clear();
+    }
     this.annotations.addAll(annotationIDs);
   }
 
   public void addAnnotation(String annotationID) {
+    if (this.annotations == null) {
+      this.annotations = new ArrayList<>(1);
+    }
     this.annotations.add(annotationID);
   }
 
@@ -179,14 +203,14 @@ public class SerializedClassifierInstance {
         && Objects.equals(parentNodeID, that.parentNodeID)
         && Objects.equals(properties, that.properties)
         && Objects.equals(containments, that.containments)
-        && Objects.equals(references, that.references)
-        && Objects.equals(annotations, that.annotations);
+        && Objects.equals(getReferences(), that.getReferences())
+        && Objects.equals(getAnnotations(), that.getAnnotations());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        id, classifier, parentNodeID, properties, containments, references, annotations);
+        id, classifier, parentNodeID, properties, containments, getReferences(), getAnnotations());
   }
 
   @Override
@@ -205,9 +229,9 @@ public class SerializedClassifierInstance {
         + ", containments="
         + containments
         + ", references="
-        + references
+        + getReferences()
         + ", annotations="
-        + annotations
+        + getAnnotations()
         + '}';
   }
 }


### PR DESCRIPTION
When allocating millions of nodes, they tend to take a lot of space in memory. However the space can be reduced by avoiding unnecessary allocations for references maps and annotations list, which are empty for most nodes