### PR TITLE
Make creation of languages more convenient

### DIFF
--- a/core/src/main/java/io/lionweb/language/Concept.java
+++ b/core/src/main/java/io/lionweb/language/Concept.java
@@ -92,16 +92,26 @@ public class Concept extends Classifier<Concept> {
     return this.getPropertyValue("abstract", Boolean.class, false);
   }
 
-  public void setAbstract(boolean value) {
+  public @Nonnull Concept setAbstract(boolean value) {
     this.setPropertyValue("abstract", value);
+    return this;
+  }
+
+  public @Nonnull Concept makeAbstract() {
+    return setAbstract(true);
   }
 
   public boolean isPartition() {
     return this.getPropertyValue("partition", Boolean.class, false);
   }
 
-  public void setPartition(boolean value) {
+  public @Nonnull Concept setPartition(boolean value) {
     this.setPropertyValue("partition", value);
+    return this;
+  }
+
+  public @Nonnull Concept makePartition() {
+    return setPartition(true);
   }
 
   // TODO should this return BaseConcept when extended is equal null?

--- a/core/src/main/java/io/lionweb/language/Concept.java
+++ b/core/src/main/java/io/lionweb/language/Concept.java
@@ -97,7 +97,7 @@ public class Concept extends Classifier<Concept> {
     return this;
   }
 
-  public @Nonnull Concept makeAbstract() {
+  public @Nonnull Concept setAbstract() {
     return setAbstract(true);
   }
 
@@ -110,7 +110,7 @@ public class Concept extends Classifier<Concept> {
     return this;
   }
 
-  public @Nonnull Concept makePartition() {
+  public @Nonnull Concept setPartition() {
     return setPartition(true);
   }
 

--- a/core/src/main/java/io/lionweb/language/Link.java
+++ b/core/src/main/java/io/lionweb/language/Link.java
@@ -78,6 +78,30 @@ public abstract class Link<T extends M3Node> extends Feature<T> {
     return (T) this;
   }
 
+  public T makeZeroToMany() {
+    setOptional(true);
+    setMultiple(true);
+    return (T) this;
+  }
+
+  public T makeOneToMany() {
+    setOptional(false);
+    setMultiple(true);
+    return (T) this;
+  }
+
+  public T makeZeroToOne() {
+    setOptional(true);
+    setMultiple(false);
+    return (T) this;
+  }
+
+  public T makeExactlyOne() {
+    setOptional(false);
+    setMultiple(false);
+    return (T) this;
+  }
+
   @Override
   public String toString() {
     return super.toString()

--- a/core/src/main/java/io/lionweb/language/assigners/CommonIDAssigners.java
+++ b/core/src/main/java/io/lionweb/language/assigners/CommonIDAssigners.java
@@ -1,0 +1,51 @@
+package io.lionweb.language.assigners;
+
+import io.lionweb.language.INamed;
+import io.lionweb.language.Language;
+import io.lionweb.model.ClassifierInstance;
+import io.lionweb.model.ClassifierInstanceUtils;
+import io.lionweb.model.HasSettableID;
+import io.lionweb.model.Node;
+import io.lionweb.utils.IdUtils;
+import javax.annotation.Nonnull;
+
+public class CommonIDAssigners {
+
+  public static final IDAssigner qualifiedIDAssigner =
+      new IDAssigner() {
+        @Override
+        public void assignIDs(@Nonnull Language language) {
+          assignIDsToNode(language);
+        }
+
+        private void assignIDsToNode(@Nonnull Node node) {
+          if (!(node instanceof HasSettableID)) {
+            throw new IllegalArgumentException(
+                "Cannot assign the ID of " + node + " has it is not an instance of HasSettableID");
+          }
+          if (node.getID() == null) {
+            ClassifierInstance<?> parent = node.getParent();
+            if (!(node instanceof INamed)) {
+              throw new IllegalStateException(
+                  "Cannot assign ID to node which is not instance of INamed");
+            }
+            String name = ((INamed) node).getName();
+            if (name == null) {
+              throw new IllegalStateException(
+                  "Cannot auto assign id to " + node + " has it has a null name");
+            }
+            if (parent == null) {
+              ((HasSettableID) node).setID(IdUtils.cleanString(name));
+            } else {
+              String parentID = parent.getID();
+              if (parentID == null) {
+                throw new IllegalStateException(
+                    "Cannot auto assign ID to " + node + " as it has a parent with a null ID");
+              }
+              ((HasSettableID) node).setID(parentID + "-" + IdUtils.cleanString(name));
+            }
+          }
+          ClassifierInstanceUtils.getChildren(node).forEach(this::assignIDsToNode);
+        }
+      };
+}

--- a/core/src/main/java/io/lionweb/language/assigners/CommonIDAssigners.java
+++ b/core/src/main/java/io/lionweb/language/assigners/CommonIDAssigners.java
@@ -9,8 +9,20 @@ import io.lionweb.model.Node;
 import io.lionweb.utils.IdUtils;
 import javax.annotation.Nonnull;
 
+/**
+ * IDs can be assigned following a few common policies. For this reason it is useful to create them
+ * and reuse them, so that we can avoid writing a lot of boilerplate to assign Node IDs.
+ *
+ * <p>Notably, a common policy to assign IDs would be to use IDs obtained from the server. This
+ * policy is not implemented here as here we do not have access to the Client.
+ */
 public class CommonIDAssigners {
 
+  /**
+   * This IDAssigner set the ID of a node as the id of the parent followed by the name of this node,
+   * separated by dashes. Note that this work only for nodes implementing both HasSettableID and
+   * INamed.
+   */
   public static final IDAssigner qualifiedIDAssigner =
       new IDAssigner() {
         @Override

--- a/core/src/main/java/io/lionweb/language/assigners/CommonKeyAssigners.java
+++ b/core/src/main/java/io/lionweb/language/assigners/CommonKeyAssigners.java
@@ -1,0 +1,47 @@
+package io.lionweb.language.assigners;
+
+import io.lionweb.language.*;
+import io.lionweb.model.ClassifierInstance;
+import io.lionweb.model.ClassifierInstanceUtils;
+import io.lionweb.model.Node;
+import io.lionweb.utils.IdUtils;
+import javax.annotation.Nonnull;
+
+public class CommonKeyAssigners {
+
+  public static final KeyAssigner qualifiedKeyAssigner =
+      new KeyAssigner() {
+        @Override
+        public void assignKeys(@Nonnull Language language) {
+          assignKeysToIKeyed(language);
+        }
+
+        private void assignKeysToIKeyed(@Nonnull IKeyed<?> keyed) {
+          if (keyed.getKey() == null) {
+            ClassifierInstance<?> parent = ((Node) keyed).getParent();
+            String name = keyed.getName();
+            if (name == null) {
+              throw new IllegalStateException(
+                  "Cannot auto assign key to " + keyed + " has it has a null name");
+            }
+            if (parent == null || parent instanceof Language) {
+              // Keys must be unique within a language, so we do not include the language when
+              // calculating
+              // the key
+              keyed.setKey(IdUtils.cleanString(name));
+            } else {
+              String parentKey = ((IKeyed<?>) parent).getKey();
+              if (parentKey == null) {
+                throw new IllegalStateException(
+                    "Cannot auto assign key to " + keyed + " as it has a parent with a null key");
+              }
+              keyed.setKey(parentKey + "-" + IdUtils.cleanString(name));
+            }
+          }
+          ClassifierInstanceUtils.getChildren((Node) keyed).stream()
+              .filter(n -> n instanceof IKeyed<?>)
+              .map(n -> (IKeyed<?>) n)
+              .forEach(this::assignKeysToIKeyed);
+        }
+      };
+}

--- a/core/src/main/java/io/lionweb/language/assigners/CommonKeyAssigners.java
+++ b/core/src/main/java/io/lionweb/language/assigners/CommonKeyAssigners.java
@@ -7,8 +7,16 @@ import io.lionweb.model.Node;
 import io.lionweb.utils.IdUtils;
 import javax.annotation.Nonnull;
 
+/**
+ * Keys can be assigned following a few common policies. For this reason it is useful to create them
+ * and reuse them, so that we can avoid writing a lot of boilerplate to assign keys.
+ */
 public class CommonKeyAssigners {
 
+  /**
+   * This KeyAssigner set the key of a node as the key of the parent followed by the name of this
+   * node, separated by dashes.
+   */
   public static final KeyAssigner qualifiedKeyAssigner =
       new KeyAssigner() {
         @Override
@@ -26,8 +34,7 @@ public class CommonKeyAssigners {
             }
             if (parent == null || parent instanceof Language) {
               // Keys must be unique within a language, so we do not include the language when
-              // calculating
-              // the key
+              // calculating the key
               keyed.setKey(IdUtils.cleanString(name));
             } else {
               String parentKey = ((IKeyed<?>) parent).getKey();

--- a/core/src/main/java/io/lionweb/language/assigners/IDAssigner.java
+++ b/core/src/main/java/io/lionweb/language/assigners/IDAssigner.java
@@ -1,0 +1,8 @@
+package io.lionweb.language.assigners;
+
+import io.lionweb.language.Language;
+import javax.annotation.Nonnull;
+
+public interface IDAssigner {
+  void assignIDs(@Nonnull Language language);
+}

--- a/core/src/main/java/io/lionweb/language/assigners/KeyAssigner.java
+++ b/core/src/main/java/io/lionweb/language/assigners/KeyAssigner.java
@@ -1,0 +1,8 @@
+package io.lionweb.language.assigners;
+
+import io.lionweb.language.Language;
+import javax.annotation.Nonnull;
+
+public interface KeyAssigner {
+  void assignKeys(@Nonnull Language language);
+}

--- a/core/src/main/java/io/lionweb/model/HasSettableID.java
+++ b/core/src/main/java/io/lionweb/model/HasSettableID.java
@@ -1,0 +1,16 @@
+package io.lionweb.model;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Certain nodes have an ID that can be set. */
+public interface HasSettableID {
+  /**
+   * Set a new ID.
+   *
+   * @param id the new UD to be assigned
+   * @return the element itself
+   */
+  @Nonnull
+  ClassifierInstance<?> setID(@Nullable String id);
+}

--- a/core/src/main/java/io/lionweb/model/HasSettableID.java
+++ b/core/src/main/java/io/lionweb/model/HasSettableID.java
@@ -1,7 +1,6 @@
 package io.lionweb.model;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /** Certain nodes have an ID that can be set. */
 public interface HasSettableID {
@@ -12,5 +11,5 @@ public interface HasSettableID {
    * @return the element itself
    */
   @Nonnull
-  ClassifierInstance<?> setID(@Nullable String id);
+  ClassifierInstance<?> setID(@Nonnull String id);
 }

--- a/core/src/main/java/io/lionweb/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/model/impl/DynamicClassifierInstance.java
@@ -21,8 +21,12 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
     return id;
   }
 
-  /** The ID can be _temporarily_ set to null, but _eventually_ it should be not null. */
-  public @Nonnull DynamicClassifierInstance<T> setID(@Nullable String id) {
+  /**
+   * The ID can be _temporarily_ left to null, but _eventually_ it should be not null, so we are
+   * preventing assigning null to it (see https://github.com/LionWeb-io/lionweb-java/pull/234).
+   */
+  public @Nonnull DynamicClassifierInstance<T> setID(@Nonnull String id) {
+    Objects.requireNonNull(id);
     this.id = id;
     return this;
   }

--- a/core/src/main/java/io/lionweb/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/model/impl/DynamicClassifierInstance.java
@@ -1,16 +1,13 @@
 package io.lionweb.model.impl;
 
 import io.lionweb.language.*;
-import io.lionweb.model.ClassifierInstance;
-import io.lionweb.model.HasSettableParent;
-import io.lionweb.model.Node;
-import io.lionweb.model.ReferenceValue;
+import io.lionweb.model.*;
 import java.util.*;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public abstract class DynamicClassifierInstance<T extends Classifier<T>>
-    extends AbstractClassifierInstance<T> implements ClassifierInstance<T> {
+    extends AbstractClassifierInstance<T> implements ClassifierInstance<T>, HasSettableID {
   /** The ID should _eventually_ be not null. */
   protected @Nullable String id;
 
@@ -25,8 +22,9 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
   }
 
   /** The ID can be _temporarily_ set to null, but _eventually_ it should be not null. */
-  public void setID(@Nullable String id) {
+  public @Nonnull DynamicClassifierInstance<T> setID(@Nullable String id) {
     this.id = id;
+    return this;
   }
 
   // Public methods for properties

--- a/core/src/main/java/io/lionweb/model/impl/M3Node.java
+++ b/core/src/main/java/io/lionweb/model/impl/M3Node.java
@@ -4,10 +4,7 @@ import static io.lionweb.model.ClassifierInstanceUtils.*;
 
 import io.lionweb.LionWebVersion;
 import io.lionweb.language.*;
-import io.lionweb.model.ClassifierInstance;
-import io.lionweb.model.HasSettableParent;
-import io.lionweb.model.Node;
-import io.lionweb.model.ReferenceValue;
+import io.lionweb.model.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -25,7 +22,7 @@ import javax.annotation.Nullable;
  * differently depending on the version of LionWeb they are representing.
  */
 public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstance<Concept>
-    implements Node, HasSettableParent {
+    implements Node, HasSettableParent, HasSettableID {
   private final @Nonnull LionWebVersion lionWebVersion;
   private @Nullable String id;
   private @Nullable ClassifierInstance<?> parent;
@@ -47,7 +44,7 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
     this.lionWebVersion = lionWebVersion;
   }
 
-  public T setID(String id) {
+  public @Nonnull T setID(@Nullable String id) {
     this.id = id;
     return (T) this;
   }

--- a/core/src/main/java/io/lionweb/model/impl/M3Node.java
+++ b/core/src/main/java/io/lionweb/model/impl/M3Node.java
@@ -44,7 +44,12 @@ public abstract class M3Node<T extends M3Node> extends AbstractClassifierInstanc
     this.lionWebVersion = lionWebVersion;
   }
 
-  public @Nonnull T setID(@Nullable String id) {
+  /**
+   * The ID can be _temporarily_ left to null, but _eventually_ it should be not null, so we are
+   * preventing assigning null to it (see https://github.com/LionWeb-io/lionweb-java/pull/234).
+   */
+  public @Nonnull T setID(@Nonnull String id) {
+    Objects.requireNonNull(id);
     this.id = id;
     return (T) this;
   }

--- a/core/src/test/java/io/lionweb/language/LanguageTest.java
+++ b/core/src/test/java/io/lionweb/language/LanguageTest.java
@@ -1,8 +1,10 @@
 package io.lionweb.language;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.junit.Assert.assertNull;
 
+import io.lionweb.language.assigners.CommonIDAssigners;
+import io.lionweb.language.assigners.CommonKeyAssigners;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Test;
@@ -40,5 +42,59 @@ public class LanguageTest {
 
     assertNull(l3.getAnnotationByName("A1"));
     assertEquals(a2inM3, l3.getAnnotationByName("A2"));
+  }
+
+  @Test
+  public void languageCreation() {
+    // Define the 'TaskList' concept
+    Concept taskListConcept = new Concept("TaskList").makePartition();
+
+    // Define the 'Task' concept
+    Concept taskConcept = new Concept("Task");
+
+    // Add a 'tasks' containment
+    Containment tasksContainment =
+        new Containment().setName("tasks").makeOneToMany().setType(taskConcept);
+    taskListConcept.addFeature(tasksContainment);
+
+    // Add a 'name' property
+    Property nameProperty = new Property().setName("name").setType(LionCoreBuiltins.getString());
+    taskConcept.addFeature(nameProperty);
+
+    // Define the language container
+    Language taskLanguage = new Language().setName("Task Language").setVersion("1.0");
+    taskLanguage.addElement(taskListConcept);
+    taskLanguage.addElement(taskConcept);
+
+    CommonKeyAssigners.qualifiedKeyAssigner.assignKeys(taskLanguage);
+    CommonIDAssigners.qualifiedIDAssigner.assignIDs(taskLanguage);
+
+    assertEquals("Task-Language-TaskList", taskListConcept.getID());
+    assertEquals("TaskList", taskListConcept.getKey());
+    assertEquals("TaskList", taskListConcept.getName());
+    assertFalse(taskListConcept.isAbstract());
+    assertTrue(taskListConcept.isPartition());
+
+    assertEquals("Task", taskConcept.getName());
+    assertEquals("Task-Language-Task", taskConcept.getID());
+    assertEquals("Task", taskConcept.getName());
+    assertFalse(taskConcept.isAbstract());
+
+    assertEquals("tasks", tasksContainment.getName());
+    assertEquals("Task-Language-TaskList-tasks", tasksContainment.getID());
+    assertEquals("TaskList-tasks", tasksContainment.getKey());
+    assertFalse(tasksContainment.isOptional());
+    assertTrue(tasksContainment.isMultiple());
+
+    assertEquals("name", nameProperty.getName());
+    assertEquals("Task-Language-Task-name", nameProperty.getID());
+    assertEquals("Task-name", nameProperty.getKey());
+    assertEquals(LionCoreBuiltins.getString(), nameProperty.getType());
+    assertFalse(nameProperty.isOptional());
+
+    assertEquals("Task Language", taskLanguage.getName());
+    assertEquals("Task-Language", taskLanguage.getID());
+    assertEquals("Task-Language", taskLanguage.getKey());
+    assertEquals("1.0", taskLanguage.getVersion());
   }
 }

--- a/core/src/test/java/io/lionweb/language/LanguageTest.java
+++ b/core/src/test/java/io/lionweb/language/LanguageTest.java
@@ -47,7 +47,7 @@ public class LanguageTest {
   @Test
   public void languageCreation() {
     // Define the 'TaskList' concept
-    Concept taskListConcept = new Concept("TaskList").makePartition();
+    Concept taskListConcept = new Concept("TaskList").setPartition();
 
     // Define the 'Task' concept
     Concept taskConcept = new Concept("Task");


### PR DESCRIPTION
Fix #212 

We do that by facilitating the chaining of setters and adding additional setters. We also introduce the possibility of defining policies for assigning IDs and Keys to a language and its descendant, without having to set all of them explicitly.