### PR TITLE
LanguageValidator verifies consistency of LionWeb Version usages

### DIFF
--- a/core/src/main/java/io/lionweb/language/Property.java
+++ b/core/src/main/java/io/lionweb/language/Property.java
@@ -25,7 +25,7 @@ public class Property extends Feature<Property> {
   public static Property createOptional(
       @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable DataType<?> type) {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
-    Property property = new Property(lionWebVersion, name, null);
+    Property property = new Property(lionWebVersion, name);
     property.setOptional(true);
     property.setType(type);
     return property;
@@ -41,7 +41,7 @@ public class Property extends Feature<Property> {
   public static Property createRequired(
       @Nonnull LionWebVersion lionWebVersion, @Nullable String name, @Nullable DataType<?> type) {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
-    Property property = new Property(lionWebVersion, name, null);
+    Property property = new Property(lionWebVersion, name);
     property.setOptional(false);
     property.setType(type);
     return property;
@@ -105,11 +105,8 @@ public class Property extends Feature<Property> {
     super(lionWebVersion);
   }
 
-  public Property(
-      @Nonnull LionWebVersion lionWebVersion,
-      @Nullable String name,
-      @Nullable Classifier<?> container) {
-    super(lionWebVersion, name, container);
+  public Property(@Nonnull LionWebVersion lionWebVersion, @Nullable String name) {
+    super(lionWebVersion, name, (Classifier<?>) null);
   }
 
   public Property(@Nullable String name, @Nullable Classifier<?> container) {

--- a/core/src/main/java/io/lionweb/utils/LanguageValidator.java
+++ b/core/src/main/java/io/lionweb/utils/LanguageValidator.java
@@ -1,8 +1,10 @@
 package io.lionweb.utils;
 
+import io.lionweb.LionWebVersion;
 import io.lionweb.language.*;
 import io.lionweb.language.Enumeration;
 import io.lionweb.model.Node;
+import io.lionweb.model.impl.M3Node;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -87,6 +89,17 @@ public class LanguageValidator extends Validator<Language> {
     }
   }
 
+  private void validateLWVersionConsistency(Language language, ValidationResult result) {
+    Set<LionWebVersion> lwVersionsUsed =
+        language.thisAndAllDescendants().stream()
+            .filter(n -> n instanceof M3Node<?>)
+            .map(n -> ((M3Node<?>) n).getLionWebVersion())
+            .collect(Collectors.toSet());
+    if (lwVersionsUsed.size() > 1) {
+      result.addError("Inconsistent LionWeb Versions used", language);
+    }
+  }
+
   @Override
   public ValidationResult validate(Language language) {
     // Given languages are also valid node trees, we check against errors for node trees
@@ -97,6 +110,7 @@ public class LanguageValidator extends Validator<Language> {
     validateNamesAreUnique(language.getElements(), result);
     validateKeysAreNotNull(language, result);
     validateKeysAreUnique(language, result);
+    validateLWVersionConsistency(language, result);
 
     // TODO once we implement the Node interface we could navigate the tree differently
 

--- a/core/src/test/java/io/lionweb/utils/LanguageValidatorTest.java
+++ b/core/src/test/java/io/lionweb/utils/LanguageValidatorTest.java
@@ -2,6 +2,7 @@ package io.lionweb.utils;
 
 import static org.junit.Assert.*;
 
+import io.lionweb.LionWebVersion;
 import io.lionweb.language.*;
 import io.lionweb.lioncore.LionCore;
 import java.util.Arrays;
@@ -411,5 +412,35 @@ public class LanguageValidatorTest {
     assertTrue(LanguageValidator.isCircular(sdtC));
     assertTrue(LanguageValidator.isCircular(sdtD));
     assertTrue(LanguageValidator.isCircular(sdtE));
+  }
+
+  @Test
+  public void signalLWVersionInconsistencyOnConcept() {
+    Language l = new Language(LionWebVersion.v2024_1, "MyLanguage").setID("l-id").setKey("l-key");
+    Concept c = new Concept(LionWebVersion.v2023_1, "MyConcept").setID("c-id").setKey("c-key");
+    l.addElement(c);
+
+    ValidationResult validationResult = new LanguageValidator().validate(l);
+    assertFalse(validationResult.isSuccessful());
+    assertEquals(1, validationResult.getIssues().size());
+    assertEquals(
+        new Issue(IssueSeverity.Error, "Inconsistent LionWeb Versions used", l),
+        validationResult.getIssues().iterator().next());
+  }
+
+  @Test
+  public void signalLWVersionInconsistencyOnFeature() {
+    Language l = new Language(LionWebVersion.v2024_1, "MyLanguage").setID("l-id").setKey("l-key");
+    Concept c = new Concept(LionWebVersion.v2024_1, "MyConcept").setID("c-id").setKey("c-key");
+    l.addElement(c);
+    Property p = new Property(LionWebVersion.v2023_1, "MyProperty").setID("p-id").setKey("p-key");
+    c.addFeature(p);
+
+    ValidationResult validationResult = new LanguageValidator().validate(l);
+    assertFalse(validationResult.isSuccessful());
+    assertEquals(1, validationResult.getIssues().size());
+    assertEquals(
+        new Issue(IssueSeverity.Error, "Inconsistent LionWeb Versions used", l),
+        validationResult.getIssues().iterator().next());
   }
 }

--- a/extensions/src/functionalTest/java/io/lionweb/repoclient/PropertiesLanguage.java
+++ b/extensions/src/functionalTest/java/io/lionweb/repoclient/PropertiesLanguage.java
@@ -28,7 +28,7 @@ public class PropertiesLanguage {
     // Register concept features
     propertiesPartition.setPartition(true);
     addContainment(propertiesPartition, "files", propertiesFile, Multiplicity.ZERO_TO_MANY);
-    Property filePath = new Property(LionWebVersion.v2023_1, "path", propertiesFile);
+    Property filePath = new Property("path", propertiesFile);
     filePath.setID(propertiesFile.getID() + "-path");
     filePath.setKey(propertiesFile.getKey() + "-path");
     filePath.setType(LionCoreBuiltins.getString(lionWebVersionUsed));

--- a/repo-client/src/functionalTest/java/io/lionweb/repoclient/languages/PropertiesLanguage.java
+++ b/repo-client/src/functionalTest/java/io/lionweb/repoclient/languages/PropertiesLanguage.java
@@ -28,7 +28,7 @@ public class PropertiesLanguage {
     // Register concept features
     propertiesPartition.setPartition(true);
     addContainment(propertiesPartition, "files", propertiesFile, Multiplicity.ZERO_TO_MANY);
-    Property filePath = new Property(LionWebVersion.v2023_1, "path", propertiesFile);
+    Property filePath = new Property("path", propertiesFile);
     filePath.setID(propertiesFile.getID() + "-path");
     filePath.setKey(propertiesFile.getKey() + "-path");
     filePath.setType(LionCoreBuiltins.getString(lionWebVersionUsed));


### PR DESCRIPTION
Fix #180 

Now the LanguageValidator will report an issue if not all elements of a language have a consistent LionWeb Version