### PR TITLE
LanguageValidator verifies language dependencies

### DIFF
--- a/core/src/main/java/io/lionweb/language/Language.java
+++ b/core/src/main/java/io/lionweb/language/Language.java
@@ -216,4 +216,25 @@ public class Language extends M3Node<Language> implements NamespaceProvider, IKe
         .map(e -> (StructuredDataType) e)
         .collect(Collectors.toList());
   }
+
+  public @Nonnull List<Concept> getConcepts() {
+    return getElements().stream()
+        .filter(e -> e instanceof Concept)
+        .map(e -> (Concept) e)
+        .collect(Collectors.toList());
+  }
+
+  public @Nonnull List<Interface> getInterfaces() {
+    return getElements().stream()
+        .filter(e -> e instanceof Interface)
+        .map(e -> (Interface) e)
+        .collect(Collectors.toList());
+  }
+
+  public @Nonnull List<Annotation> getAnnotationDefinitions() {
+    return getElements().stream()
+        .filter(e -> e instanceof Annotation)
+        .map(e -> (Annotation) e)
+        .collect(Collectors.toList());
+  }
 }

--- a/core/src/main/java/io/lionweb/lioncore/LionCore.java
+++ b/core/src/main/java/io/lionweb/lioncore/LionCore.java
@@ -171,7 +171,7 @@ public class LionCore {
     }
     if (!INSTANCES.containsKey(lionWebVersion)) {
       final Language instance = new Language(lionWebVersion, "LionCore_M3");
-      // instance.addDependency(LionCoreBuiltins.getInstance(lionWebVersion));
+      // Note the LionCore does not depend on LionCore Builtins, despite using elements from it
       instance.setID("-id-LionCore-M3" + versionIDSuffix);
       instance.setKey("LionCore-M3");
       instance.setVersion(lionWebVersion.getVersionString());

--- a/core/src/main/java/io/lionweb/lioncore/LionCore.java
+++ b/core/src/main/java/io/lionweb/lioncore/LionCore.java
@@ -171,7 +171,7 @@ public class LionCore {
     }
     if (!INSTANCES.containsKey(lionWebVersion)) {
       final Language instance = new Language(lionWebVersion, "LionCore_M3");
-      instance.addDependency(LionCoreBuiltins.getInstance(lionWebVersion));
+      // instance.addDependency(LionCoreBuiltins.getInstance(lionWebVersion));
       instance.setID("-id-LionCore-M3" + versionIDSuffix);
       instance.setKey("LionCore-M3");
       instance.setVersion(lionWebVersion.getVersionString());

--- a/core/src/main/java/io/lionweb/lioncore/LionCore.java
+++ b/core/src/main/java/io/lionweb/lioncore/LionCore.java
@@ -171,6 +171,7 @@ public class LionCore {
     }
     if (!INSTANCES.containsKey(lionWebVersion)) {
       final Language instance = new Language(lionWebVersion, "LionCore_M3");
+      instance.addDependency(LionCoreBuiltins.getInstance(lionWebVersion));
       instance.setID("-id-LionCore-M3" + versionIDSuffix);
       instance.setKey("LionCore-M3");
       instance.setVersion(lionWebVersion.getVersionString());

--- a/core/src/main/java/io/lionweb/utils/LanguageValidator.java
+++ b/core/src/main/java/io/lionweb/utils/LanguageValidator.java
@@ -3,6 +3,7 @@ package io.lionweb.utils;
 import io.lionweb.LionWebVersion;
 import io.lionweb.language.*;
 import io.lionweb.language.Enumeration;
+import io.lionweb.lioncore.LionCore;
 import io.lionweb.model.Node;
 import io.lionweb.model.impl.M3Node;
 import java.util.*;
@@ -184,6 +185,14 @@ public class LanguageValidator extends Validator<Language> {
   }
 
   private void validateLanguageDependencies(Language language, ValidationResult result) {
+    // LionCore seems not to follow normal rules...
+    // see https://github.com/LionWeb-io/specification/issues/380
+    if (language == LionCore.getInstance(LionWebVersion.v2023_1)) {
+      return;
+    } else if (language == LionCore.getInstance(LionWebVersion.v2024_1)) {
+      return;
+    }
+
     Set<Language> usedLanguages = new HashSet<>();
     for (Concept concept : language.getConcepts()) {
       Concept extended = concept.getExtendedConcept();

--- a/core/src/main/java/io/lionweb/utils/LanguageValidator.java
+++ b/core/src/main/java/io/lionweb/utils/LanguageValidator.java
@@ -185,11 +185,11 @@ public class LanguageValidator extends Validator<Language> {
   }
 
   private void validateLanguageDependencies(Language language, ValidationResult result) {
-    // LionCore seems not to follow normal rules...
-    // see https://github.com/LionWeb-io/specification/issues/380
-    if (language == LionCore.getInstance(LionWebVersion.v2023_1)) {
-      return;
-    } else if (language == LionCore.getInstance(LionWebVersion.v2024_1)) {
+    // LionCore does not respect this rule.
+    // See https://github.com/LionWeb-io/specification/issues/380 but it actually applies to v2024_1
+    // too
+    if (language == LionCore.getInstance(LionWebVersion.v2023_1)
+        || language == LionCore.getInstance(LionWebVersion.v2024_1)) {
       return;
     }
 

--- a/core/src/test/java/io/lionweb/language/AnnotationTest.java
+++ b/core/src/test/java/io/lionweb/language/AnnotationTest.java
@@ -121,7 +121,7 @@ public class AnnotationTest extends BaseTest {
 
   @Test
   public void containmentLinks() {
-    Language language = new Language("LangFoo", "lf", "lf");
+    Language language = new Language("LangFoo", "lf", "lf").setVersion("1");
     Concept myConcept = new Concept(language, "MyConcept", "c", "c");
 
     Annotation annotation = new Annotation(language, "MyAnnotation", "MyAnnotation-ID", "ma");

--- a/core/src/test/java/io/lionweb/lioncore/CorrespondanceWithDocumentationTest.java
+++ b/core/src/test/java/io/lionweb/lioncore/CorrespondanceWithDocumentationTest.java
@@ -53,8 +53,6 @@ public class CorrespondanceWithDocumentationTest {
     assertTrue(comparison.toString(), comparison.areEquivalent());
   }
 
-  // This is failing pending the resolution of
-  // https://github.com/LionWeb-io/specification/issues/324
   @Test
   public void lioncoreIsTheSameAsInTheOrganizationRepo2024_1() throws IOException {
     JsonSerialization jsonSer = getStandardJsonSerialization(LionWebVersion.v2024_1);

--- a/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
@@ -149,8 +149,10 @@ public class SerializationOfLionCoreTest extends SerializationTest {
                     "-id-Reference-2024-1",
                     "-id-StructuredDataType-2024-1"))),
         LionCore_M3.getContainments());
-    // This is the case because any Language depends (at least transitively and implicitly) on built-ins elements, a
-    // Language CAN declare a dependency on builtins but does not need to and for LionCore we decided NOT to
+    // This is the case because any Language depends (at least transitively and implicitly) on
+    // built-ins elements, a
+    // Language CAN declare a dependency on builtins but does not need to and for LionCore we
+    // decided NOT to
     // list the dependency on LionCore-Builtins
     assertEquals(
         Collections.singletonList(

--- a/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
@@ -149,16 +149,14 @@ public class SerializationOfLionCoreTest extends SerializationTest {
                     "-id-Reference-2024-1",
                     "-id-StructuredDataType-2024-1"))),
         LionCore_M3.getContainments());
+    // This is the case because any Language depends (at least transitively and implicitly) on built-ins elements, a
+    // Language CAN declare a dependency on builtins but does not need to and for LionCore we decided NOT to
+    // list the dependency on LionCore-Builtins
     assertEquals(
         Collections.singletonList(
             new SerializedReferenceValue(
                 new MetaPointer("LionCore-M3", "2024.1", "Language-dependsOn"),
-                // This feels wrong, see https://github.com/LionWeb-io/specification/issues/380
-                Collections.emptyList()
-                /* Collections.singletonList(
-                new SerializedReferenceValue.Entry(
-                    LionCoreBuiltins.getInstance(LionWebVersion.v2024_1).getID(),
-                    LionCoreBuiltins.getInstance(LionWebVersion.v2024_1).getName()))*/ )),
+                Collections.emptyList())),
         LionCore_M3.getReferences());
 
     SerializedClassifierInstance LionCore_M3_Interface_extends =

--- a/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
@@ -80,10 +80,13 @@ public class SerializationOfLionCoreTest extends SerializationTest {
                     "-id-Reference"))),
         LionCore_M3.getContainments());
     assertEquals(
-        Arrays.asList(
+        Collections.singletonList(
             new SerializedReferenceValue(
                 new MetaPointer("LionCore-M3", "2023.1", "Language-dependsOn"),
-                Collections.emptyList())),
+                Collections.singletonList(
+                    new SerializedReferenceValue.Entry(
+                        LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).getID(),
+                        LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).getName())))),
         LionCore_M3.getReferences());
 
     SerializedClassifierInstance LionCore_M3_Interface_extends =
@@ -148,10 +151,13 @@ public class SerializationOfLionCoreTest extends SerializationTest {
                     "-id-StructuredDataType-2024-1"))),
         LionCore_M3.getContainments());
     assertEquals(
-        Arrays.asList(
+        Collections.singletonList(
             new SerializedReferenceValue(
-                new MetaPointer("LionCore-M3", "2024.1", "Language-dependsOn"),
-                Collections.emptyList())),
+                new MetaPointer("LionCore-M3", "2023.1", "Language-dependsOn"),
+                Collections.singletonList(
+                    new SerializedReferenceValue.Entry(
+                        LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).getID(),
+                        LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).getName())))),
         LionCore_M3.getReferences());
 
     SerializedClassifierInstance LionCore_M3_Interface_extends =

--- a/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
@@ -83,12 +83,9 @@ public class SerializationOfLionCoreTest extends SerializationTest {
         Collections.singletonList(
             new SerializedReferenceValue(
                 new MetaPointer("LionCore-M3", "2023.1", "Language-dependsOn"),
-                // This feels wrong, see https://github.com/LionWeb-io/specification/issues/380
-                Collections.emptyList()
-                /* Collections.singletonList(
-                new SerializedReferenceValue.Entry(
-                    LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).getID(),
-                    LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).getName()))*/ )),
+                // This is wrong but see https://github.com/LionWeb-io/specification/issues/380
+                // to understand the reason
+                Collections.emptyList())),
         LionCore_M3.getReferences());
 
     SerializedClassifierInstance LionCore_M3_Interface_extends =

--- a/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
@@ -83,10 +83,12 @@ public class SerializationOfLionCoreTest extends SerializationTest {
         Collections.singletonList(
             new SerializedReferenceValue(
                 new MetaPointer("LionCore-M3", "2023.1", "Language-dependsOn"),
-                Collections.singletonList(
-                    new SerializedReferenceValue.Entry(
-                        LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).getID(),
-                        LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).getName())))),
+                // This feels wrong, see https://github.com/LionWeb-io/specification/issues/380
+                Collections.emptyList()
+                /* Collections.singletonList(
+                new SerializedReferenceValue.Entry(
+                    LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).getID(),
+                    LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).getName()))*/ )),
         LionCore_M3.getReferences());
 
     SerializedClassifierInstance LionCore_M3_Interface_extends =
@@ -153,11 +155,13 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     assertEquals(
         Collections.singletonList(
             new SerializedReferenceValue(
-                new MetaPointer("LionCore-M3", "2023.1", "Language-dependsOn"),
-                Collections.singletonList(
-                    new SerializedReferenceValue.Entry(
-                        LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).getID(),
-                        LionCoreBuiltins.getInstance(LionWebVersion.v2023_1).getName())))),
+                new MetaPointer("LionCore-M3", "2024.1", "Language-dependsOn"),
+                // This feels wrong, see https://github.com/LionWeb-io/specification/issues/380
+                Collections.emptyList()
+                /* Collections.singletonList(
+                new SerializedReferenceValue.Entry(
+                    LionCoreBuiltins.getInstance(LionWebVersion.v2024_1).getID(),
+                    LionCoreBuiltins.getInstance(LionWebVersion.v2024_1).getName()))*/ )),
         LionCore_M3.getReferences());
 
     SerializedClassifierInstance LionCore_M3_Interface_extends =


### PR DESCRIPTION
We verify that the language dependencies are properly set, however this PR is not yet finalized as I am not sure about what to do with LionCore and LionCore-Builtins.

Should LionCore depend on itself? And on LionCore-Builtins?

Should LionCore-Builtins depend on LionCore?

Fix #182 