### PR TITLE
#241 uniformly use `getID()` to access node IDs

### DIFF
--- a/core/src/main/java/io/lionweb/model/impl/DynamicAnnotationInstance.java
+++ b/core/src/main/java/io/lionweb/model/impl/DynamicAnnotationInstance.java
@@ -36,7 +36,7 @@ public class DynamicAnnotationInstance extends DynamicClassifierInstance<Annotat
     }
     DynamicAnnotationInstance that = (DynamicAnnotationInstance) o;
     return Objects.equals(annotation, that.annotation)
-        && Objects.equals(id, that.id)
+        && Objects.equals(getID(), that.getID())
         && Objects.equals(annotated, that.annotated)
         && Objects.equals(propertyValues, that.propertyValues)
         && Objects.equals(
@@ -56,7 +56,7 @@ public class DynamicAnnotationInstance extends DynamicClassifierInstance<Annotat
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, annotation, annotated);
+    return Objects.hash(getID(), annotation, annotated);
   }
 
   public void setAnnotation(Annotation annotation) {

--- a/core/src/main/java/io/lionweb/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/model/impl/DynamicNode.java
@@ -58,7 +58,7 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
       return false;
     }
     DynamicNode that = (DynamicNode) o;
-    return Objects.equals(id, that.id)
+    return Objects.equals(getID(), that.getID())
         && shallowClassifierInstanceEquality(parent, that.parent)
         && shallowClassifierInstanceEquality(concept, that.getClassifier())
         && Objects.equals(propertyValues, that.propertyValues)
@@ -113,7 +113,7 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
 
   @Override
   public int hashCode() {
-    return Objects.hash(id);
+    return Objects.hash(getID());
   }
 
   @Override
@@ -147,7 +147,7 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
 
     return "DynamicNode{"
         + "id='"
-        + id
+        + getID()
         + '\''
         + ", parent="
         + (parent == null ? "null" : parent.getID())


### PR DESCRIPTION
This fixes #241 