### PR TITLE
Reducing memory occupation and serialization size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,3 +131,7 @@ Introducing support for LionWeb 2024.1
 ### Version 1.0.1
 
 * DynamicNode: uniformly use getID() to access node IDs
+
+### Version 1.0.2
+
+* Internaling MetaPointers and most of SerializedPropertyValues

--- a/client/src/test/java/io/lionweb/client/inmemory/RepositoryDataTest.java
+++ b/client/src/test/java/io/lionweb/client/inmemory/RepositoryDataTest.java
@@ -22,7 +22,7 @@ public class RepositoryDataTest {
     assertEquals(Collections.emptySet(), repositoryData.nodesByID.keySet());
 
     SerializedClassifierInstance n1 =
-        new SerializedClassifierInstance("n1", new MetaPointer("l1", "1.0", "c1"));
+        new SerializedClassifierInstance("n1", MetaPointer.get("l1", "1.0", "c1"));
 
     repositoryData.partitionIDs.add("n1");
     repositoryData.store(Collections.singletonList(n1));
@@ -35,15 +35,15 @@ public class RepositoryDataTest {
         new RepositoryData(
             new RepositoryConfiguration("repo1", LionWebVersion.v2023_1, HistorySupport.DISABLED));
     SerializedClassifierInstance n1 =
-        new SerializedClassifierInstance("n1", new MetaPointer("l1", "1.0", "c1"));
+        new SerializedClassifierInstance("n1", MetaPointer.get("l1", "1.0", "c1"));
     SerializedClassifierInstance n2 =
-        new SerializedClassifierInstance("n2", new MetaPointer("l1", "1.0", "c1"));
+        new SerializedClassifierInstance("n2", MetaPointer.get("l1", "1.0", "c1"));
     SerializedClassifierInstance n3 =
-        new SerializedClassifierInstance("n3", new MetaPointer("l1", "1.0", "c1"));
+        new SerializedClassifierInstance("n3", MetaPointer.get("l1", "1.0", "c1"));
     SerializedClassifierInstance n4 =
-        new SerializedClassifierInstance("n4", new MetaPointer("l1", "1.0", "c1"));
-    n1.addChildren(new MetaPointer("l1", "1.0", "containmentA"), Collections.singletonList("n2"));
-    n2.addChildren(new MetaPointer("l1", "1.0", "containmentA"), Arrays.asList("n3", "n4"));
+        new SerializedClassifierInstance("n4", MetaPointer.get("l1", "1.0", "c1"));
+    n1.addChildren(MetaPointer.get("l1", "1.0", "containmentA"), Collections.singletonList("n2"));
+    n2.addChildren(MetaPointer.get("l1", "1.0", "containmentA"), Arrays.asList("n3", "n4"));
     n2.setParentNodeID("n1");
     n3.setParentNodeID("n2");
     n4.setParentNodeID("n2");
@@ -60,15 +60,15 @@ public class RepositoryDataTest {
         new RepositoryData(
             new RepositoryConfiguration("repo1", LionWebVersion.v2023_1, HistorySupport.DISABLED));
     SerializedClassifierInstance n1 =
-        new SerializedClassifierInstance("n1", new MetaPointer("l1", "1.0", "c1"));
+        new SerializedClassifierInstance("n1", MetaPointer.get("l1", "1.0", "c1"));
     SerializedClassifierInstance n2 =
-        new SerializedClassifierInstance("n2", new MetaPointer("l1", "1.0", "c1"));
+        new SerializedClassifierInstance("n2", MetaPointer.get("l1", "1.0", "c1"));
     SerializedClassifierInstance n3 =
-        new SerializedClassifierInstance("n3", new MetaPointer("l1", "1.0", "c1"));
+        new SerializedClassifierInstance("n3", MetaPointer.get("l1", "1.0", "c1"));
     SerializedClassifierInstance n4 =
-        new SerializedClassifierInstance("n4", new MetaPointer("l1", "1.0", "c1"));
-    n1.addChildren(new MetaPointer("l1", "1.0", "containmentA"), Collections.singletonList("n2"));
-    n2.addChildren(new MetaPointer("l1", "1.0", "containmentA"), Arrays.asList("n3", "n4"));
+        new SerializedClassifierInstance("n4", MetaPointer.get("l1", "1.0", "c1"));
+    n1.addChildren(MetaPointer.get("l1", "1.0", "containmentA"), Collections.singletonList("n2"));
+    n2.addChildren(MetaPointer.get("l1", "1.0", "containmentA"), Arrays.asList("n3", "n4"));
     n2.setParentNodeID("n1");
     n3.setParentNodeID("n2");
     n4.setParentNodeID("n2");
@@ -79,12 +79,12 @@ public class RepositoryDataTest {
         new HashSet<>(Arrays.asList("n1", "n2", "n3", "n4")), repositoryData.nodesByID.keySet());
 
     SerializedClassifierInstance n1b =
-        new SerializedClassifierInstance("n1", new MetaPointer("l1", "1.0", "c1"));
+        new SerializedClassifierInstance("n1", MetaPointer.get("l1", "1.0", "c1"));
     SerializedClassifierInstance n3b =
-        new SerializedClassifierInstance("n3", new MetaPointer("l1", "1.0", "c1"));
+        new SerializedClassifierInstance("n3", MetaPointer.get("l1", "1.0", "c1"));
     SerializedClassifierInstance n5b =
-        new SerializedClassifierInstance("n5", new MetaPointer("l1", "1.0", "c1"));
-    n1b.addChildren(new MetaPointer("l1", "1.0", "containmentA"), Arrays.asList("n3", "n5"));
+        new SerializedClassifierInstance("n5", MetaPointer.get("l1", "1.0", "c1"));
+    n1b.addChildren(MetaPointer.get("l1", "1.0", "containmentA"), Arrays.asList("n3", "n5"));
     n3b.setParentNodeID("n1");
     n5b.setParentNodeID("n1");
     repositoryData.store(Arrays.asList(n1b, n3b, n5b));

--- a/core/src/experiments/java/io/lionweb/experiments/SerializationAndDeserializationExperiment.java
+++ b/core/src/experiments/java/io/lionweb/experiments/SerializationAndDeserializationExperiment.java
@@ -12,9 +12,11 @@ import java.io.*;
 public class SerializationAndDeserializationExperiment {
 
   public static void main(String[] args) throws IOException {
+    long gen0 = System.currentTimeMillis();
     TreeGenerator treeGenerator = new TreeGenerator(1);
     Node tree = treeGenerator.generate(100_000);
-    System.out.println("Tree generated");
+    long gen1 = System.currentTimeMillis();
+    System.out.println("Tree generated in " + (gen1 - gen0) + " ms");
 
     SerializedChunk chunk =
         SerializationProvider.getStandardJsonSerialization()

--- a/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
@@ -268,11 +268,7 @@ public abstract class AbstractSerialization {
         .allReferences(classifierInstance.getClassifier())
         .forEach(
             reference -> {
-              SerializedReferenceValue referenceValue = new SerializedReferenceValue();
-              referenceValue.setMetaPointer(
-                  MetaPointer.from(
-                      reference, ((LanguageEntity<?>) reference.getContainer()).getLanguage()));
-              referenceValue.setValue(
+              List<SerializedReferenceValue.Entry> entries =
                   classifierInstance.getReferenceValues(reference).stream()
                       .map(
                           rv -> {
@@ -285,8 +281,15 @@ public abstract class AbstractSerialization {
                             return new SerializedReferenceValue.Entry(
                                 referredID, rv.getResolveInfo());
                           })
-                      .collect(Collectors.toList()));
-              serializedClassifierInstance.addReferenceValue(referenceValue);
+                      .collect(Collectors.toList());
+              if (!entries.isEmpty()) {
+                MetaPointer metaPointer =
+                    MetaPointer.from(
+                        reference, ((LanguageEntity<?>) reference.getContainer()).getLanguage());
+                SerializedReferenceValue referenceValue =
+                    new SerializedReferenceValue(metaPointer, entries);
+                serializedClassifierInstance.addReferenceValue(referenceValue);
+              }
             });
   }
 
@@ -299,15 +302,20 @@ public abstract class AbstractSerialization {
         .allContainments(classifierInstance.getClassifier())
         .forEach(
             containment -> {
-              SerializedContainmentValue containmentValue = new SerializedContainmentValue();
-              containmentValue.setMetaPointer(
-                  MetaPointer.from(
-                      containment, ((LanguageEntity<?>) containment.getContainer()).getLanguage()));
-              containmentValue.setValue(
+              List<String> value =
                   classifierInstance.getChildren(containment).stream()
                       .map(Node::getID)
-                      .collect(Collectors.toList()));
-              serializedClassifierInstance.addContainmentValue(containmentValue);
+                      .collect(Collectors.toList());
+              // We can avoid serializing empty values
+              if (!value.isEmpty()) {
+                MetaPointer metaPointer =
+                    MetaPointer.from(
+                        containment,
+                        ((LanguageEntity<?>) containment.getContainer()).getLanguage());
+                SerializedContainmentValue containmentValue =
+                    new SerializedContainmentValue(metaPointer, value);
+                serializedClassifierInstance.addContainmentValue(containmentValue);
+              }
             });
   }
 

--- a/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
@@ -319,13 +319,12 @@ public abstract class AbstractSerialization {
         .allProperties(classifierInstance.getClassifier())
         .forEach(
             property -> {
-              SerializedPropertyValue propertyValue = new SerializedPropertyValue();
-              propertyValue.setMetaPointer(
-                  MetaPointer.from(
-                      property, ((LanguageEntity<?>) property.getContainer()).getLanguage()));
-              propertyValue.setValue(
-                  serializePropertyValue(
-                      property.getType(), classifierInstance.getPropertyValue(property)));
+              SerializedPropertyValue propertyValue =
+                  SerializedPropertyValue.get(
+                      MetaPointer.from(
+                          property, ((LanguageEntity<?>) property.getContainer()).getLanguage()),
+                      serializePropertyValue(
+                          property.getType(), classifierInstance.getPropertyValue(property)));
               serializedClassifierInstance.addPropertyValue(propertyValue);
             });
   }

--- a/core/src/main/java/io/lionweb/serialization/FlatBuffersSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/FlatBuffersSerialization.java
@@ -315,9 +315,8 @@ public class FlatBuffersSerialization extends AbstractSerialization {
       sci.setClassifier(helper.deserialize(n.classifier()));
       for (int j = 0; j < n.propertiesLength(); j++) {
         FBProperty p = n.properties(j);
-        SerializedPropertyValue spv = new SerializedPropertyValue();
-        spv.setValue(p.value());
-        spv.setMetaPointer(helper.deserialize(p.metaPointer()));
+        SerializedPropertyValue spv =
+            SerializedPropertyValue.get(helper.deserialize(p.metaPointer()), p.value());
         sci.addPropertyValue(spv);
       }
 

--- a/core/src/main/java/io/lionweb/serialization/FlatBuffersSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/FlatBuffersSerialization.java
@@ -271,10 +271,8 @@ public class FlatBuffersSerialization extends AbstractSerialization {
       return metaPointersCache.computeIfAbsent(
           classifier,
           fbMetaPointer -> {
-            MetaPointer metaPointer = new MetaPointer();
-            metaPointer.setKey(classifier.key());
-            metaPointer.setLanguage(classifier.language());
-            metaPointer.setVersion(classifier.version());
+            MetaPointer metaPointer =
+                MetaPointer.get(classifier.language(), classifier.version(), classifier.key());
             return metaPointer;
           });
     }

--- a/core/src/main/java/io/lionweb/serialization/LowLevelJsonSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/LowLevelJsonSerialization.java
@@ -268,7 +268,7 @@ public class LowLevelJsonSerialization {
           property -> {
             JsonObject propertyJO = property.getAsJsonObject();
             serializedClassifierInstance.addPropertyValue(
-                new SerializedPropertyValue(
+                SerializedPropertyValue.get(
                     SerializationUtils.tryToGetMetaPointerProperty(propertyJO, "property"),
                     SerializationUtils.tryToGetStringProperty(propertyJO, "value")));
           });

--- a/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
@@ -92,9 +92,10 @@ public class ProtoBufSerialization extends AbstractSerialization {
               n.getPropertiesList()
                   .forEach(
                       p -> {
-                        SerializedPropertyValue spv = new SerializedPropertyValue();
-                        spv.setValue(stringsMap.get(p.getValue()));
-                        spv.setMetaPointer(metapointersMap.get(p.getMetaPointerIndex()));
+                        SerializedPropertyValue spv =
+                            SerializedPropertyValue.get(
+                                metapointersMap.get(p.getMetaPointerIndex()),
+                                stringsMap.get(p.getValue()));
                         sci.addPropertyValue(spv);
                       });
               n.getContainmentsList()

--- a/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
@@ -101,22 +101,27 @@ public class ProtoBufSerialization extends AbstractSerialization {
               n.getContainmentsList()
                   .forEach(
                       c -> {
-                        SerializedContainmentValue scv = new SerializedContainmentValue();
                         if (c.getChildrenList().stream().anyMatch(el -> el < 0)) {
                           throw new DeserializationException(
                               "Unable to deserialize child identified by Null ID");
                         }
-                        scv.setValue(
+                        List<String> children =
                             c.getChildrenList().stream()
                                 .map(el -> stringsMap.get(el))
-                                .collect(Collectors.toList()));
-                        scv.setMetaPointer(metapointersMap.get(c.getMetaPointerIndex()));
-                        sci.addContainmentValue(scv);
+                                .collect(Collectors.toList());
+                        if (!children.isEmpty()) {
+                          SerializedContainmentValue scv =
+                              new SerializedContainmentValue(
+                                  metapointersMap.get(c.getMetaPointerIndex()), children);
+                          sci.addContainmentValue(scv);
+                        }
                       });
               n.getReferencesList()
                   .forEach(
                       r -> {
-                        SerializedReferenceValue srv = new SerializedReferenceValue();
+                        SerializedReferenceValue srv =
+                            new SerializedReferenceValue(
+                                metapointersMap.get(r.getMetaPointerIndex()));
                         r.getValuesList()
                             .forEach(
                                 rv -> {
@@ -126,8 +131,9 @@ public class ProtoBufSerialization extends AbstractSerialization {
                                   entry.setResolveInfo(stringsMap.get(rv.getResolveInfo()));
                                   srv.addValue(entry);
                                 });
-                        srv.setMetaPointer(metapointersMap.get(r.getMetaPointerIndex()));
-                        sci.addReferenceValue(srv);
+                        if (!srv.getValue().isEmpty()) {
+                          sci.addReferenceValue(srv);
+                        }
                       });
               n.getAnnotationsList().forEach(a -> sci.addAnnotation(stringsMap.get(a)));
               serializedChunk.addClassifierInstance(sci);

--- a/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
@@ -60,10 +60,11 @@ public class ProtoBufSerialization extends AbstractSerialization {
     Map<Integer, MetaPointer> metapointersMap = new HashMap<>();
     for (int i = 0; i < chunk.getMetaPointersCount(); i++) {
       PBMetaPointer mp = chunk.getMetaPointers(i);
-      MetaPointer metaPointer = new MetaPointer();
-      metaPointer.setKey(stringsMap.get(mp.getKey()));
-      metaPointer.setLanguage(stringsMap.get(mp.getLanguage()));
-      metaPointer.setVersion(stringsMap.get(mp.getVersion()));
+      MetaPointer metaPointer =
+          MetaPointer.get(
+              stringsMap.get(mp.getLanguage()),
+              stringsMap.get(mp.getVersion()),
+              stringsMap.get(mp.getKey()));
       metapointersMap.put(i, metaPointer);
     }
     ;

--- a/core/src/main/java/io/lionweb/serialization/SerializationUtils.java
+++ b/core/src/main/java/io/lionweb/serialization/SerializationUtils.java
@@ -46,7 +46,7 @@ class SerializationUtils {
     JsonElement value = jsonObject.get(propertyName);
     if (value.isJsonObject()) {
       JsonObject valueJO = value.getAsJsonObject();
-      return new MetaPointer(
+      return MetaPointer.get(
           tryToGetStringProperty(valueJO, "language"),
           tryToGetStringProperty(valueJO, "version"),
           tryToGetStringProperty(valueJO, "key"));

--- a/core/src/main/java/io/lionweb/serialization/SerializedJsonComparisonUtils.java
+++ b/core/src/main/java/io/lionweb/serialization/SerializedJsonComparisonUtils.java
@@ -96,13 +96,13 @@ public class SerializedJsonComparisonUtils {
           assertEquals("(" + context + ") different id", expected.get("id"), actual.get("id"));
           break;
         case "references":
-          assertEquivalentUnorderedArrays(
+          assertEquivalentReferences(
               expected.getAsJsonArray("references"),
               actual.getAsJsonArray("references"),
               "References of " + context);
           break;
         case "containments":
-          assertEquivalentUnorderedArrays(
+          assertEquivalentContainments(
               expected.getAsJsonArray("containments"),
               actual.getAsJsonArray("containments"),
               "Children of " + context);
@@ -123,6 +123,36 @@ public class SerializedJsonComparisonUtils {
           throw new AssertionError("(" + context + ") unexpected top-level key found: " + key);
       }
     }
+  }
+
+  private static void assertEquivalentReferences(
+      JsonArray expected, JsonArray actual, String context) {
+    assertEquivalentFilteringForEmpty(expected, actual, context, "targets");
+  }
+
+  private static void assertEquivalentContainments(
+      JsonArray expected, JsonArray actual, String context) {
+    assertEquivalentFilteringForEmpty(expected, actual, context, "children");
+  }
+
+  private static void assertEquivalentFilteringForEmpty(
+      JsonArray expected, JsonArray actual, String context, String keyToCheck) {
+    // Containments and references may or may not contain empty elements
+    JsonArray filteredExpected = new JsonArray();
+    expected.forEach(
+        e -> {
+          if (!e.getAsJsonObject().get(keyToCheck).getAsJsonArray().isEmpty()) {
+            filteredExpected.add(e);
+          }
+        });
+    JsonArray filteredActual = new JsonArray();
+    actual.forEach(
+        e -> {
+          if (!e.getAsJsonObject().get(keyToCheck).getAsJsonArray().isEmpty()) {
+            filteredActual.add(e);
+          }
+        });
+    assertEquivalentUnorderedArrays(filteredExpected, filteredActual, context);
   }
 
   private static void assertEquivalentUnorderedArrays(

--- a/core/src/main/java/io/lionweb/serialization/data/MetaPointer.java
+++ b/core/src/main/java/io/lionweb/serialization/data/MetaPointer.java
@@ -1,5 +1,7 @@
 package io.lionweb.serialization.data;
 
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import io.lionweb.language.Feature;
 import io.lionweb.language.IKeyed;
 import io.lionweb.language.Language;
@@ -14,11 +16,12 @@ import java.util.*;
  * coincides for this class.
  */
 public class MetaPointer {
-  private static final Map<String, Set<MetaPointer>> INSTANCES_BY_KEY = new HashMap<>();
+  private static final Multimap<String, MetaPointer> INSTANCES_BY_KEY =
+      Multimaps.newSetMultimap(new WeakHashMap<>(), HashSet::new);
 
   /** Provide a MetaPointer with the given value, avoid allocations if unnecessary. */
   public static MetaPointer get(String language, String version, String key) {
-    Set<MetaPointer> entryForKey = INSTANCES_BY_KEY.computeIfAbsent(key, k -> new HashSet<>());
+    Collection<MetaPointer> entryForKey = INSTANCES_BY_KEY.get(key);
     Optional<MetaPointer> match =
         entryForKey.stream()
             .filter(

--- a/core/src/main/java/io/lionweb/serialization/data/MetaPointer.java
+++ b/core/src/main/java/io/lionweb/serialization/data/MetaPointer.java
@@ -4,67 +4,58 @@ import io.lionweb.language.Feature;
 import io.lionweb.language.IKeyed;
 import io.lionweb.language.Language;
 import io.lionweb.language.LanguageEntity;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * A MetaPointer is the combination of the pair Language and Version with a Key, which identify one
  * element within that language.
  */
 public class MetaPointer {
+  private static Map<String, MetaPointer> INSTANCES = new HashMap<>();
+
+  public static MetaPointer get(String language, String version, String key) {
+    String hashKey = language + ":" + version + ":" + key;
+    if (!INSTANCES.containsKey(hashKey)) {
+      INSTANCES.put(hashKey, new MetaPointer(language, version, key));
+    }
+    return INSTANCES.get(hashKey);
+  }
+
   private String key;
   private String version;
   private String language;
 
-  public MetaPointer(String language, String version, String key) {
+  private MetaPointer(String language, String version, String key) {
     this.key = key;
     this.version = version;
     this.language = language;
   }
-
-  public MetaPointer() {}
 
   public static MetaPointer from(Feature<?> feature) {
     return from(feature, feature.getDeclaringLanguage());
   }
 
   public static MetaPointer from(LanguageEntity<?> languageEntity) {
-    MetaPointer metaPointer = new MetaPointer();
-    metaPointer.setKey(languageEntity.getKey());
-    if (languageEntity.getLanguage() != null) {
-      metaPointer.setLanguage(languageEntity.getLanguage().getKey());
-      if (languageEntity.getLanguage().getVersion() != null) {
-        metaPointer.setVersion(languageEntity.getLanguage().getVersion());
-      }
-    }
-    return metaPointer;
+    return MetaPointer.get(
+        languageEntity.getLanguage().getKey(),
+        languageEntity.getLanguage().getVersion(),
+        languageEntity.getKey());
   }
 
   public static MetaPointer from(IKeyed<?> elementWithKey, Language language) {
-    MetaPointer metaPointer = new MetaPointer();
-    metaPointer.setKey(elementWithKey.getKey());
-    if (language != null) {
-      metaPointer.setLanguage(language.getKey());
-      if (language.getVersion() != null) {
-        metaPointer.setVersion(language.getVersion());
-      }
-    }
-    return metaPointer;
+
+    return MetaPointer.get(
+        language == null ? null : language.getKey(),
+        language == null ? null : language.getVersion(),
+        elementWithKey.getKey());
   }
 
   public String getLanguage() {
     return language;
   }
 
-  public void setLanguage(String language) {
-    this.language = language;
-  }
-
   public String getKey() {
     return key;
-  }
-
-  public void setKey(String key) {
-    this.key = key;
   }
 
   public String getVersion() {
@@ -84,10 +75,6 @@ public class MetaPointer {
   @Override
   public int hashCode() {
     return Objects.hash(key, version, language);
-  }
-
-  public void setVersion(String version) {
-    this.version = version;
   }
 
   @Override

--- a/core/src/main/java/io/lionweb/serialization/data/MetaPointer.java
+++ b/core/src/main/java/io/lionweb/serialization/data/MetaPointer.java
@@ -1,7 +1,5 @@
 package io.lionweb.serialization.data;
 
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import io.lionweb.language.Feature;
 import io.lionweb.language.IKeyed;
 import io.lionweb.language.Language;
@@ -16,24 +14,15 @@ import java.util.*;
  * coincides for this class.
  */
 public class MetaPointer {
-  private static final Multimap<String, MetaPointer> INSTANCES_BY_KEY =
-      Multimaps.newSetMultimap(new WeakHashMap<>(), HashSet::new);
+  private static final Map<String, Map<String, WeakHashMap<String, MetaPointer>>>
+      INSTANCES_BY_KEY_LANGUAGE_VERSION = new HashMap<>();
 
   /** Provide a MetaPointer with the given value, avoid allocations if unnecessary. */
   public static MetaPointer get(String language, String version, String key) {
-    Collection<MetaPointer> entryForKey = INSTANCES_BY_KEY.get(key);
-    Optional<MetaPointer> match =
-        entryForKey.stream()
-            .filter(
-                mp -> Objects.equals(mp.language, language) && Objects.equals(mp.version, version))
-            .findFirst();
-    if (match.isPresent()) {
-      return match.get();
-    } else {
-      MetaPointer metaPointer = new MetaPointer(language, version, key);
-      entryForKey.add(metaPointer);
-      return metaPointer;
-    }
+    return INSTANCES_BY_KEY_LANGUAGE_VERSION
+        .computeIfAbsent(key, k -> new HashMap<>())
+        .computeIfAbsent(language, l -> new WeakHashMap<>())
+        .computeIfAbsent(version, v -> new MetaPointer(language, version, key));
   }
 
   private final String key;

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedClassifierInstance.java
@@ -161,7 +161,7 @@ public class SerializedClassifierInstance {
   }
 
   public void setPropertyValue(MetaPointer property, String serializedValue) {
-    this.properties.add(new SerializedPropertyValue(property, serializedValue));
+    this.properties.add(SerializedPropertyValue.get(property, serializedValue));
   }
 
   public void addChildren(MetaPointer containment, List<String> childrenIds) {

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedContainmentValue.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedContainmentValue.java
@@ -7,12 +7,8 @@ import java.util.Objects;
 
 /** This represents the serialization of the values of a containment link in a Node. */
 public class SerializedContainmentValue {
-  private MetaPointer metaPointer;
+  private final MetaPointer metaPointer;
   private final List<String> value;
-
-  public SerializedContainmentValue() {
-    this.value = new ArrayList<>();
-  }
 
   public SerializedContainmentValue(MetaPointer metaPointer, List<String> value) {
     this.metaPointer = metaPointer;
@@ -21,10 +17,6 @@ public class SerializedContainmentValue {
 
   public MetaPointer getMetaPointer() {
     return metaPointer;
-  }
-
-  public void setMetaPointer(MetaPointer metaPointer) {
-    this.metaPointer = metaPointer;
   }
 
   /** This returns the list of Node-IDs contained. */

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedPropertyValue.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedPropertyValue.java
@@ -3,6 +3,7 @@ package io.lionweb.serialization.data;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.WeakHashMap;
 
 /**
  * This represents the serialization of the value of a property in a Node. This class is immutable
@@ -11,20 +12,20 @@ import java.util.Objects;
  */
 public class SerializedPropertyValue {
   private static final int THRESHOLD = 128;
-  private static final Map<MetaPointer, Map<String, SerializedPropertyValue>>
+  private static final Map<MetaPointer, WeakHashMap<String, SerializedPropertyValue>>
       INSTANCES_BY_METAPOINTER = new HashMap<>();
 
   /** This will avoid most unnecessary duplicate instantiations, but this is not guaranteed. */
   public static SerializedPropertyValue get(MetaPointer metaPointer, String value) {
     // Large values are expected to be more rarely reused, therefore we do not prevent their
-    // duplication
+    // duplication.
     // We are interested in preventing the duplication of very common values like "false", "true",
     // "0", "1", etc.
     if (value != null && value.length() >= THRESHOLD) {
       return new SerializedPropertyValue(metaPointer, value);
     }
     Map<String, SerializedPropertyValue> valuesForMetaPointer =
-        INSTANCES_BY_METAPOINTER.computeIfAbsent(metaPointer, k -> new HashMap<>());
+        INSTANCES_BY_METAPOINTER.computeIfAbsent(metaPointer, k -> new WeakHashMap<>());
     return valuesForMetaPointer.computeIfAbsent(
         value, v -> new SerializedPropertyValue(metaPointer, v));
   }
@@ -58,6 +59,8 @@ public class SerializedPropertyValue {
 
   @Override
   public boolean equals(Object o) {
+    // Note that Identity will correspond to Equality for common values but not for all values,
+    // so we need to inspect the actual values
     if (this == o) return true;
     if (!(o instanceof SerializedPropertyValue)) return false;
     SerializedPropertyValue that = (SerializedPropertyValue) o;
@@ -66,6 +69,8 @@ public class SerializedPropertyValue {
 
   @Override
   public int hashCode() {
+    // Note that Identity will correspond to Equality for common values but not for all values,
+    // therefore we cannot use System.identityHashCode()
     return Objects.hash(metaPointer, value);
   }
 }

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedPropertyValue.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedPropertyValue.java
@@ -1,15 +1,43 @@
 package io.lionweb.serialization.data;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /** This represents the serialization of the value of a property in a Node. */
 public class SerializedPropertyValue {
-  private MetaPointer metaPointer;
-  private String value;
+  private static final int THRESHOLD = 128;
+  private static final Map<String, SerializedPropertyValue> INSTANCES = new HashMap<>();
+  private static final Map<MetaPointer, SerializedPropertyValue> NULL_INSTANCES = new HashMap<>();
 
-  public SerializedPropertyValue() {}
+  public static SerializedPropertyValue get(MetaPointer metaPointer, String value) {
+    if (value == null) {
+      if (!NULL_INSTANCES.containsKey(metaPointer)) {
+        NULL_INSTANCES.put(metaPointer, new SerializedPropertyValue(metaPointer, null));
+      }
+      return NULL_INSTANCES.get(metaPointer);
+    } else if (value.length() < THRESHOLD) {
+      String key =
+          metaPointer.getLanguage()
+              + ":"
+              + metaPointer.getVersion()
+              + ":"
+              + metaPointer.getKey()
+              + ":"
+              + value;
+      if (!INSTANCES.containsKey(key)) {
+        INSTANCES.put(key, new SerializedPropertyValue(metaPointer, value));
+      }
+      return INSTANCES.get(key);
+    } else {
+      return new SerializedPropertyValue(metaPointer, value);
+    }
+  }
 
-  public SerializedPropertyValue(MetaPointer metaPointer, String value) {
+  private final MetaPointer metaPointer;
+  private final String value;
+
+  private SerializedPropertyValue(MetaPointer metaPointer, String value) {
     this.metaPointer = metaPointer;
     this.value = value;
   }
@@ -18,16 +46,8 @@ public class SerializedPropertyValue {
     return metaPointer;
   }
 
-  public void setMetaPointer(MetaPointer metaPointer) {
-    this.metaPointer = metaPointer;
-  }
-
   public String getValue() {
     return value;
-  }
-
-  public void setValue(String value) {
-    this.value = value;
   }
 
   @Override

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedReferenceValue.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedReferenceValue.java
@@ -62,10 +62,11 @@ public class SerializedReferenceValue {
     }
   }
 
-  private MetaPointer metaPointer;
+  private final MetaPointer metaPointer;
   private final List<Entry> value;
 
-  public SerializedReferenceValue() {
+  public SerializedReferenceValue(MetaPointer metaPointer) {
+    this.metaPointer = metaPointer;
     value = new ArrayList<>();
   }
 
@@ -76,10 +77,6 @@ public class SerializedReferenceValue {
 
   public MetaPointer getMetaPointer() {
     return metaPointer;
-  }
-
-  public void setMetaPointer(MetaPointer metaPointer) {
-    this.metaPointer = metaPointer;
   }
 
   public List<Entry> getValue() {

--- a/core/src/test/java/io/lionweb/serialization/FlatbuffersSerializationTest.java
+++ b/core/src/test/java/io/lionweb/serialization/FlatbuffersSerializationTest.java
@@ -226,7 +226,7 @@ public class FlatbuffersSerializationTest extends SerializationTest {
     assertEquals(1, serializedClassifierInstance.getProperties().size());
     SerializedPropertyValue serializedName = serializedClassifierInstance.getProperties().get(0);
     assertEquals(
-        new MetaPointer("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
+        MetaPointer.get("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
         serializedName.getMetaPointer());
   }
 

--- a/core/src/test/java/io/lionweb/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/io/lionweb/serialization/JsonSerializationTest.java
@@ -684,7 +684,7 @@ public class JsonSerializationTest extends SerializationTest {
     assertEquals(1, serializedClassifierInstance.getProperties().size());
     SerializedPropertyValue serializedName = serializedClassifierInstance.getProperties().get(0);
     assertEquals(
-        new MetaPointer("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
+        MetaPointer.get("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
         serializedName.getMetaPointer());
   }
 

--- a/core/src/test/java/io/lionweb/serialization/LowLevelJsonSerializationTest.java
+++ b/core/src/test/java/io/lionweb/serialization/LowLevelJsonSerializationTest.java
@@ -36,7 +36,7 @@ public class LowLevelJsonSerializationTest extends SerializationTest {
         serializedChunk.getClassifierInstances();
 
     SerializedClassifierInstance lioncore = deserializedSerializedClassifierInstanceData.get(0);
-    assertEquals(new MetaPointer("LionCore-M3", "2023.1", "Language"), lioncore.getClassifier());
+    assertEquals(MetaPointer.get("LionCore-M3", "2023.1", "Language"), lioncore.getClassifier());
     assertEquals("-id-LionCore-M3", lioncore.getID());
     assertEquals("LionCore_M3", lioncore.getPropertyValue("LionCore-builtins-INamed-name"));
     assertEquals(

--- a/core/src/test/java/io/lionweb/serialization/ProtobufSerializationTest.java
+++ b/core/src/test/java/io/lionweb/serialization/ProtobufSerializationTest.java
@@ -220,7 +220,7 @@ public class ProtobufSerializationTest extends SerializationTest {
     assertEquals(1, serializedClassifierInstance.getProperties().size());
     SerializedPropertyValue serializedName = serializedClassifierInstance.getProperties().get(0);
     assertEquals(
-        new MetaPointer("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
+        MetaPointer.get("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
         serializedName.getMetaPointer());
   }
 

--- a/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
@@ -46,21 +46,21 @@ public class SerializationOfLionCoreTest extends SerializationTest {
             .findFirst()
             .get();
     assertEquals("-id-LionCore-M3", LionCore_M3.getID());
-    assertEquals(new MetaPointer("LionCore-M3", "2023.1", "Language"), LionCore_M3.getClassifier());
+    assertEquals(MetaPointer.get("LionCore-M3", "2023.1", "Language"), LionCore_M3.getClassifier());
     assertEquals(
         Arrays.asList(
             new SerializedPropertyValue(
-                new MetaPointer("LionCore-M3", "2023.1", "Language-version"), "2023.1"),
+                MetaPointer.get("LionCore-M3", "2023.1", "Language-version"), "2023.1"),
             new SerializedPropertyValue(
-                new MetaPointer("LionCore-M3", "2023.1", "IKeyed-key"), "LionCore-M3"),
+                MetaPointer.get("LionCore-M3", "2023.1", "IKeyed-key"), "LionCore-M3"),
             new SerializedPropertyValue(
-                new MetaPointer("LionCore-builtins", "2023.1", "LionCore-builtins-INamed-name"),
+                MetaPointer.get("LionCore-builtins", "2023.1", "LionCore-builtins-INamed-name"),
                 "LionCore_M3")),
         LionCore_M3.getProperties());
     assertEquals(
         Arrays.asList(
             new SerializedContainmentValue(
-                new MetaPointer("LionCore-M3", "2023.1", "Language-entities"),
+                MetaPointer.get("LionCore-M3", "2023.1", "Language-entities"),
                 Arrays.asList(
                     "-id-Annotation",
                     "-id-Concept",
@@ -82,7 +82,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     assertEquals(
         Collections.singletonList(
             new SerializedReferenceValue(
-                new MetaPointer("LionCore-M3", "2023.1", "Language-dependsOn"),
+                MetaPointer.get("LionCore-M3", "2023.1", "Language-dependsOn"),
                 // This is wrong but see https://github.com/LionWeb-io/specification/issues/380
                 // to understand the reason
                 Collections.emptyList())),
@@ -114,21 +114,21 @@ public class SerializationOfLionCoreTest extends SerializationTest {
             .findFirst()
             .get();
     assertEquals("-id-LionCore-M3-2024-1", LionCore_M3.getID());
-    assertEquals(new MetaPointer("LionCore-M3", "2024.1", "Language"), LionCore_M3.getClassifier());
+    assertEquals(MetaPointer.get("LionCore-M3", "2024.1", "Language"), LionCore_M3.getClassifier());
     assertEquals(
         Arrays.asList(
             new SerializedPropertyValue(
-                new MetaPointer("LionCore-M3", "2024.1", "Language-version"), "2024.1"),
+                MetaPointer.get("LionCore-M3", "2024.1", "Language-version"), "2024.1"),
             new SerializedPropertyValue(
-                new MetaPointer("LionCore-M3", "2024.1", "IKeyed-key"), "LionCore-M3"),
+                MetaPointer.get("LionCore-M3", "2024.1", "IKeyed-key"), "LionCore-M3"),
             new SerializedPropertyValue(
-                new MetaPointer("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
+                MetaPointer.get("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
                 "LionCore_M3")),
         LionCore_M3.getProperties());
     assertEquals(
         Arrays.asList(
             new SerializedContainmentValue(
-                new MetaPointer("LionCore-M3", "2024.1", "Language-entities"),
+                MetaPointer.get("LionCore-M3", "2024.1", "Language-entities"),
                 Arrays.asList(
                     "-id-Annotation-2024-1",
                     "-id-Concept-2024-1",
@@ -157,7 +157,7 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     assertEquals(
         Collections.singletonList(
             new SerializedReferenceValue(
-                new MetaPointer("LionCore-M3", "2024.1", "Language-dependsOn"),
+                MetaPointer.get("LionCore-M3", "2024.1", "Language-dependsOn"),
                 Collections.emptyList())),
         LionCore_M3.getReferences());
 

--- a/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
@@ -79,14 +79,10 @@ public class SerializationOfLionCoreTest extends SerializationTest {
                     "-id-Property",
                     "-id-Reference"))),
         LionCore_M3.getContainments());
-    assertEquals(
-        Collections.singletonList(
-            new SerializedReferenceValue(
-                MetaPointer.get("LionCore-M3", "2023.1", "Language-dependsOn"),
-                // This is wrong but see https://github.com/LionWeb-io/specification/issues/380
-                // to understand the reason
-                Collections.emptyList())),
-        LionCore_M3.getReferences());
+    // Depends is empty and this is wrong but see
+    // https://github.com/LionWeb-io/specification/issues/380
+    // to understand the reason. And given it is empty it is not serialized
+    assertEquals(Collections.emptyList(), LionCore_M3.getReferences());
 
     SerializedClassifierInstance LionCore_M3_Interface_extends =
         serializedChunk.getClassifierInstances().stream()
@@ -150,16 +146,10 @@ public class SerializationOfLionCoreTest extends SerializationTest {
                     "-id-StructuredDataType-2024-1"))),
         LionCore_M3.getContainments());
     // This is the case because any Language depends (at least transitively and implicitly) on
-    // built-ins elements, a
-    // Language CAN declare a dependency on builtins but does not need to and for LionCore we
-    // decided NOT to
-    // list the dependency on LionCore-Builtins
-    assertEquals(
-        Collections.singletonList(
-            new SerializedReferenceValue(
-                MetaPointer.get("LionCore-M3", "2024.1", "Language-dependsOn"),
-                Collections.emptyList())),
-        LionCore_M3.getReferences());
+    // built-ins elements, a Language CAN declare a dependency on builtins but does not need to and
+    // for LionCore we decided NOT to list the dependency on LionCore-Builtins
+    // Then given the reference is empty, it is not serialized at all
+    assertEquals(Collections.emptyList(), LionCore_M3.getReferences());
 
     SerializedClassifierInstance LionCore_M3_Interface_extends =
         serializedChunk.getClassifierInstances().stream()

--- a/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
+++ b/core/src/test/java/io/lionweb/serialization/SerializationOfLionCoreTest.java
@@ -49,11 +49,11 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     assertEquals(MetaPointer.get("LionCore-M3", "2023.1", "Language"), LionCore_M3.getClassifier());
     assertEquals(
         Arrays.asList(
-            new SerializedPropertyValue(
+            SerializedPropertyValue.get(
                 MetaPointer.get("LionCore-M3", "2023.1", "Language-version"), "2023.1"),
-            new SerializedPropertyValue(
+            SerializedPropertyValue.get(
                 MetaPointer.get("LionCore-M3", "2023.1", "IKeyed-key"), "LionCore-M3"),
-            new SerializedPropertyValue(
+            SerializedPropertyValue.get(
                 MetaPointer.get("LionCore-builtins", "2023.1", "LionCore-builtins-INamed-name"),
                 "LionCore_M3")),
         LionCore_M3.getProperties());
@@ -117,11 +117,11 @@ public class SerializationOfLionCoreTest extends SerializationTest {
     assertEquals(MetaPointer.get("LionCore-M3", "2024.1", "Language"), LionCore_M3.getClassifier());
     assertEquals(
         Arrays.asList(
-            new SerializedPropertyValue(
+            SerializedPropertyValue.get(
                 MetaPointer.get("LionCore-M3", "2024.1", "Language-version"), "2024.1"),
-            new SerializedPropertyValue(
+            SerializedPropertyValue.get(
                 MetaPointer.get("LionCore-M3", "2024.1", "IKeyed-key"), "LionCore-M3"),
-            new SerializedPropertyValue(
+            SerializedPropertyValue.get(
                 MetaPointer.get("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name"),
                 "LionCore_M3")),
         LionCore_M3.getProperties());

--- a/extensions/src/test/java/io/lionweb/client/ExtraFlatbuffersSerializationTest.java
+++ b/extensions/src/test/java/io/lionweb/client/ExtraFlatbuffersSerializationTest.java
@@ -35,7 +35,7 @@ public class ExtraFlatbuffersSerializationTest {
     BulkImport bulkImport = new BulkImport();
     bulkImport.addNode(n1);
     bulkImport.addAttachPoint(
-        new BulkImport.AttachPoint("n2", new MetaPointer("Foo", "1", "c-key"), "n1"));
+        new BulkImport.AttachPoint("n2", MetaPointer.get("Foo", "1", "c-key"), "n1"));
 
     ExtraFlatBuffersSerialization flatBuffersSerialization =
         ExtraSerializationProvider.getExtraStandardFlatBuffersSerialization();
@@ -81,7 +81,7 @@ public class ExtraFlatbuffersSerializationTest {
     BulkImport bulkImport = new BulkImport();
     bulkImport.addNode(n1);
     bulkImport.addAttachPoint(
-        new BulkImport.AttachPoint("n2", new MetaPointer("Foo", "1", "c-key"), "n1"));
+        new BulkImport.AttachPoint("n2", MetaPointer.get("Foo", "1", "c-key"), "n1"));
 
     ExtraFlatBuffersSerialization flatBuffersSerialization =
         ExtraSerializationProvider.getExtraStandardFlatBuffersSerialization(LionWebVersion.v2023_1);

--- a/extensions/src/test/java/io/lionweb/client/ExtraProtoBufSerializationTest.java
+++ b/extensions/src/test/java/io/lionweb/client/ExtraProtoBufSerializationTest.java
@@ -38,7 +38,7 @@ public class ExtraProtoBufSerializationTest {
     BulkImport bulkImport = new BulkImport();
     bulkImport.addNode(n1);
     bulkImport.addAttachPoint(
-        new BulkImport.AttachPoint("n2", new MetaPointer("Foo", "1", "c-key"), "n1"));
+        new BulkImport.AttachPoint("n2", MetaPointer.get("Foo", "1", "c-key"), "n1"));
 
     ExtraProtoBufSerialization serialization =
         ExtraSerializationProvider.getExtraStandardProtoBufSerialization();
@@ -84,7 +84,7 @@ public class ExtraProtoBufSerializationTest {
     BulkImport bulkImport = new BulkImport();
     bulkImport.addNode(n1);
     bulkImport.addAttachPoint(
-        new BulkImport.AttachPoint("n2", new MetaPointer("Foo", "1", "c-key"), "n1"));
+        new BulkImport.AttachPoint("n2", MetaPointer.get("Foo", "1", "c-key"), "n1"));
 
     ExtraProtoBufSerialization serialization =
         ExtraSerializationProvider.getExtraStandardProtoBufSerialization(LionWebVersion.v2023_1);


### PR DESCRIPTION
These improvements were triggered by working on processing a 2M lines of code which leads to ~10M nodes, which leads to ~100M MetaPointers. In that particular system we are using the InMemoryServer so that we actually keep in memory a lot of SerializedClassifierInstance and so we persist a lot of MetaPointers. However even if we did not keep them, we would have to create them when serializing (so yes, they would eventually garbage collected, but still there would be work on allocation and garbage collection).

Based on this I propose preventing duplication of duplicate MetaPointers. We then do something similar for SerializedPropertyValue with a caveat: here we want to re-use common values but not all values. If someone store a huge content in a property then it is probably it will not be duplicate and so we are ok not caching it. However common values (null, false, true, 0, 1, etc.) may be reused a ton of times so we aim to reuse them.

Similarly for serialization we did not take advantage of the possibility of not serializing empty containments and references. We do so to save space during serialization but also to reduce the work during serialization and deserialization.

The first experiment seems encouraging as a particular application significantly reduced the memory used with this PR (by at least 1GB of memory). 

Also, running the SerializationExperiment present in this code base before the PR was getting:
```
= JSON serialization (without compression) =
  serialized in 3013ms
  size 490266650 bytes
```

With this PR we are getting:
```
= JSON serialization (without compression) =
  serialized in 686ms
  size 87614934 bytes
```
