### PR TITLE
Fix equality for SerializedChunk

### DIFF
--- a/core/src/main/java/io/lionweb/serialization/data/SerializedChunk.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedChunk.java
@@ -106,9 +106,9 @@ public class SerializedChunk {
     if (this == o) return true;
     if (!(o instanceof SerializedChunk)) return false;
     SerializedChunk that = (SerializedChunk) o;
-    return serializationFormatVersion.equals(that.serializationFormatVersion)
-        && languages.equals(that.languages)
-        && classifierInstances.equals(that.classifierInstances);
+    return Objects.equals(serializationFormatVersion, that.serializationFormatVersion)
+        && Objects.equals(languages, that.languages)
+        && Objects.equals(classifierInstances, that.classifierInstances);
   }
 
   @Override

--- a/core/src/test/java/io/lionweb/serialization/data/SerializedChunkTest.java
+++ b/core/src/test/java/io/lionweb/serialization/data/SerializedChunkTest.java
@@ -1,0 +1,20 @@
+package io.lionweb.serialization.data;
+
+import static org.junit.Assert.*;
+
+import io.lionweb.LionWebVersion;
+import org.junit.Test;
+
+public class SerializedChunkTest {
+
+  @Test
+  public void serializedChunkEquality() {
+    SerializedChunk c1 = new SerializedChunk();
+    SerializedChunk c2 = new SerializedChunk();
+    assertEquals(c1, c2);
+    c1.setSerializationFormatVersion(LionWebVersion.v2023_1.getVersionString());
+    assertNotEquals(c1, c2);
+    c2.setSerializationFormatVersion(LionWebVersion.v2023_1.getVersionString());
+    assertEquals(c1, c2);
+  }
+}


### PR DESCRIPTION
Currently the equals method could cause NPE