### PR TITLE
Bugfix in id assignation for InMemoryServer

### DIFF
--- a/client/src/main/java/io/lionweb/client/inmemory/RepositoryData.java
+++ b/client/src/main/java/io/lionweb/client/inmemory/RepositoryData.java
@@ -82,8 +82,11 @@ class RepositoryData {
 
   List<String> ids(int count) {
     List<String> res = new ArrayList<>(count);
-    for (int i = 0; i < count; i++) {
-      res.add("id-" + (nextId++));
+    while (res.size() < count) {
+      String candidate = "id-" + (nextId++);
+      if (!nodesByID.containsKey(candidate)) {
+        res.add(candidate);
+      }
     }
     return res;
   }

--- a/client/src/main/java/io/lionweb/client/inmemory/RepositoryData.java
+++ b/client/src/main/java/io/lionweb/client/inmemory/RepositoryData.java
@@ -80,17 +80,14 @@ class RepositoryData {
     return new RepositoryVersionToken("v-" + ++currentVersion);
   }
 
-  private Set<String> assignedIDs = new HashSet<>();
-
   List<String> ids(int count) {
     List<String> res = new ArrayList<>(count);
     while (res.size() < count) {
       String candidate = "id-" + (nextId++);
-      if (!nodesByID.containsKey(candidate) && !assignedIDs.contains(candidate)) {
+      if (!nodesByID.containsKey(candidate)) {
         res.add(candidate);
       }
     }
-    assignedIDs.addAll(res);
     return res;
   }
 

--- a/client/src/main/java/io/lionweb/client/inmemory/RepositoryData.java
+++ b/client/src/main/java/io/lionweb/client/inmemory/RepositoryData.java
@@ -80,14 +80,17 @@ class RepositoryData {
     return new RepositoryVersionToken("v-" + ++currentVersion);
   }
 
+  private Set<String> assignedIDs = new HashSet<>();
+
   List<String> ids(int count) {
     List<String> res = new ArrayList<>(count);
     while (res.size() < count) {
       String candidate = "id-" + (nextId++);
-      if (!nodesByID.containsKey(candidate)) {
+      if (!nodesByID.containsKey(candidate) && !assignedIDs.contains(candidate)) {
         res.add(candidate);
       }
     }
+    assignedIDs.addAll(res);
     return res;
   }
 

--- a/client/src/test/java/io/lionweb/client/inmemory/RepositoryDataTest.java
+++ b/client/src/test/java/io/lionweb/client/inmemory/RepositoryDataTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.lionweb.LionWebVersion;
 import io.lionweb.client.api.HistorySupport;
 import io.lionweb.client.api.RepositoryConfiguration;
+import io.lionweb.language.LionCoreBuiltins;
 import io.lionweb.serialization.data.MetaPointer;
 import io.lionweb.serialization.data.SerializedClassifierInstance;
 import java.util.Arrays;
@@ -93,5 +94,15 @@ public class RepositoryDataTest {
     // n2 has two children: n3 and n4. n3 has been replaced under n1
     // however n4 should disappear
     assertEquals(new HashSet<>(Arrays.asList("n1", "n3", "n5")), repositoryData.nodesByID.keySet());
+  }
+
+  @Test
+  public void idsAssignation() {
+    RepositoryData repoData = new RepositoryData(new RepositoryConfiguration("repo1", LionWebVersion.v2023_1, HistorySupport.DISABLED));
+    assertEquals(Collections.singletonList("id-1"), repoData.ids(1));
+    // If I store a node with id-2, the system should not assign me such id later on
+    repoData.partitionIDs.add("id-2");
+    repoData.store(Collections.singletonList(new SerializedClassifierInstance("id-2", MetaPointer.from(LionCoreBuiltins.getNode(LionWebVersion.v2023_1)))));
+    assertEquals(Collections.singletonList("id-3"), repoData.ids(1));
   }
 }

--- a/client/src/test/java/io/lionweb/client/inmemory/RepositoryDataTest.java
+++ b/client/src/test/java/io/lionweb/client/inmemory/RepositoryDataTest.java
@@ -104,5 +104,8 @@ public class RepositoryDataTest {
     repoData.partitionIDs.add("id-2");
     repoData.store(Collections.singletonList(new SerializedClassifierInstance("id-2", MetaPointer.from(LionCoreBuiltins.getNode(LionWebVersion.v2023_1)))));
     assertEquals(Collections.singletonList("id-3"), repoData.ids(1));
+
+    // If I ask again for IDs to be assigned to me I should get different IDs
+    assertEquals(Collections.singletonList("id-4"), repoData.ids(1));
   }
 }

--- a/client/src/test/java/io/lionweb/client/inmemory/RepositoryDataTest.java
+++ b/client/src/test/java/io/lionweb/client/inmemory/RepositoryDataTest.java
@@ -98,11 +98,16 @@ public class RepositoryDataTest {
 
   @Test
   public void idsAssignation() {
-    RepositoryData repoData = new RepositoryData(new RepositoryConfiguration("repo1", LionWebVersion.v2023_1, HistorySupport.DISABLED));
+    RepositoryData repoData =
+        new RepositoryData(
+            new RepositoryConfiguration("repo1", LionWebVersion.v2023_1, HistorySupport.DISABLED));
     assertEquals(Collections.singletonList("id-1"), repoData.ids(1));
     // If I store a node with id-2, the system should not assign me such id later on
     repoData.partitionIDs.add("id-2");
-    repoData.store(Collections.singletonList(new SerializedClassifierInstance("id-2", MetaPointer.from(LionCoreBuiltins.getNode(LionWebVersion.v2023_1)))));
+    repoData.store(
+        Collections.singletonList(
+            new SerializedClassifierInstance(
+                "id-2", MetaPointer.from(LionCoreBuiltins.getNode(LionWebVersion.v2023_1)))));
     assertEquals(Collections.singletonList("id-3"), repoData.ids(1));
 
     // If I ask again for IDs to be assigned to me I should get different IDs


### PR DESCRIPTION
In an InMemoryServer we could load some nodes and then let the user create new nodes. Now, if we load nodes which happens to have IDs using the same format as the ids we generate there is the risk of a conflict.

So when assigning IDs to users we check they have not been already used.