### PR TITLE
Client propagation

### DIFF
--- a/client/src/main/java/io/lionweb/client/LionWebClient.java
+++ b/client/src/main/java/io/lionweb/client/LionWebClient.java
@@ -276,15 +276,15 @@ public class LionWebClient
   @Override
   public RepositoryVersionToken createPartitionsFromChunk(
       @NotNull List<SerializedClassifierInstance> data) throws IOException {
-    throw new UnsupportedOperationException();
+    return this.chunkLevelBulkAPIs.createPartitionsFromChunk(data);
   }
 
-  @Nullable
-  @Override
-  public RepositoryVersionToken storeChunk(@NotNull List<SerializedClassifierInstance> nodes)
-      throws IOException {
-    throw new UnsupportedOperationException();
-  }
+    @Nullable
+    @Override
+    public RepositoryVersionToken storeChunk(@NotNull List<SerializedClassifierInstance> nodes)
+            throws IOException {
+        return this.chunkLevelBulkAPIs.storeChunk(nodes);
+    }
 
   @NotNull
   @Override

--- a/client/src/main/java/io/lionweb/client/LionWebClient.java
+++ b/client/src/main/java/io/lionweb/client/LionWebClient.java
@@ -290,14 +290,14 @@ public class LionWebClient
   @Override
   public List<SerializedClassifierInstance> retrieveAsChunk(
       @Nullable List<String> nodeIds, int limit) throws IOException {
-    throw new UnsupportedOperationException();
+    return this.chunkLevelBulkAPIs.retrieveAsChunk(nodeIds, limit);
   }
 
   @NotNull
   @Override
   public List<SerializedClassifierInstance> retrieveAsChunk(@Nullable List<String> nodeIds)
       throws IOException {
-    throw new UnsupportedOperationException();
+    return this.chunkLevelBulkAPIs.retrieveAsChunk(nodeIds);
   }
 
   //

--- a/client/src/main/java/io/lionweb/client/LionWebClient.java
+++ b/client/src/main/java/io/lionweb/client/LionWebClient.java
@@ -279,12 +279,12 @@ public class LionWebClient
     return this.chunkLevelBulkAPIs.createPartitionsFromChunk(data);
   }
 
-    @Nullable
-    @Override
-    public RepositoryVersionToken storeChunk(@NotNull List<SerializedClassifierInstance> nodes)
-            throws IOException {
-        return this.chunkLevelBulkAPIs.storeChunk(nodes);
-    }
+  @Nullable
+  @Override
+  public RepositoryVersionToken storeChunk(@NotNull List<SerializedClassifierInstance> nodes)
+      throws IOException {
+    return this.chunkLevelBulkAPIs.storeChunk(nodes);
+  }
 
   @NotNull
   @Override

--- a/client/src/main/java/io/lionweb/client/api/ChunkLevelBulkAPIClient.java
+++ b/client/src/main/java/io/lionweb/client/api/ChunkLevelBulkAPIClient.java
@@ -1,6 +1,7 @@
 package io.lionweb.client.api;
 
 import io.lionweb.LionWebVersion;
+import io.lionweb.serialization.data.SerializedChunk;
 import io.lionweb.serialization.data.SerializedClassifierInstance;
 import java.io.IOException;
 import java.util.List;
@@ -37,6 +38,13 @@ public interface ChunkLevelBulkAPIClient {
   }
 
   @Nullable
+  default RepositoryVersionToken createPartitionsFromChunk(@NotNull SerializedChunk chunk)
+      throws IOException {
+    Objects.requireNonNull(chunk, "chunk should not be null");
+    return createPartitionsFromChunk(chunk.getClassifierInstances());
+  }
+
+  @Nullable
   RepositoryVersionToken deletePartitions(List<String> ids) throws IOException;
 
   @Nullable
@@ -48,6 +56,12 @@ public interface ChunkLevelBulkAPIClient {
       throws IOException {
     return storeChunk(
         StreamSupport.stream(nodes.spliterator(), false).collect(Collectors.toList()));
+  }
+
+  @Nullable
+  default RepositoryVersionToken storeChunk(@NotNull SerializedChunk chunk) throws IOException {
+    Objects.requireNonNull(chunk, "chunk should not be null");
+    return storeChunk(chunk.getClassifierInstances());
   }
 
   @NotNull

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedClassifierInstance.java
@@ -170,18 +170,18 @@ public class SerializedClassifierInstance {
   }
 
   /**
-   * Removes the specified child from the containments, if present.
+   * Removes the specified childId from the containments, if present.
    *
-   * @param child the identifier of the child to be removed; must not be null
-   * @return true if the child was successfully removed, false otherwise
+   * @param childId the identifier of the childId to be removed; must not be null
+   * @return true if the childId was successfully removed, false otherwise
    */
-  public boolean removeChild(@Nonnull String child) {
-    Objects.requireNonNull(child, "child should not be null");
+  public boolean removeChild(@Nonnull String childId) {
+    Objects.requireNonNull(childId, "childId should not be null");
     if (this.containments == null) {
       return false;
     }
     for (SerializedContainmentValue containment : this.containments) {
-      if (containment.removeChild(child)) {
+      if (containment.removeChild(childId)) {
         return true;
       }
     }

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedClassifierInstance.java
@@ -169,6 +169,18 @@ public class SerializedClassifierInstance {
     this.containments.add(new SerializedContainmentValue(containment, childrenIds));
   }
 
+  public boolean removeChild(String child) {
+    if (this.containments == null) {
+      return false;
+    }
+    for (SerializedContainmentValue containment : this.containments) {
+      if (containment.removeChild(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public void addReferenceValue(
       MetaPointer reference, List<SerializedReferenceValue.Entry> referenceValues) {
     if (this.references == null) {
@@ -242,6 +254,13 @@ public class SerializedClassifierInstance {
       this.annotations = new ArrayList<>(1);
     }
     this.annotations.add(annotationID);
+  }
+
+  public boolean removeAnnotation(String annotationID) {
+    if (this.annotations == null) {
+      return false;
+    }
+    return this.annotations.remove(annotationID);
   }
 
   @Override

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedClassifierInstance.java
@@ -169,7 +169,14 @@ public class SerializedClassifierInstance {
     this.containments.add(new SerializedContainmentValue(containment, childrenIds));
   }
 
-  public boolean removeChild(String child) {
+  /**
+   * Removes the specified child from the containments, if present.
+   *
+   * @param child the identifier of the child to be removed; must not be null
+   * @return true if the child was successfully removed, false otherwise
+   */
+  public boolean removeChild(@Nonnull String child) {
+    Objects.requireNonNull(child, "child should not be null");
     if (this.containments == null) {
       return false;
     }
@@ -256,7 +263,14 @@ public class SerializedClassifierInstance {
     this.annotations.add(annotationID);
   }
 
-  public boolean removeAnnotation(String annotationID) {
+  /**
+   * Removes the specified annotation identified by its ID from the list of annotations.
+   *
+   * @param annotationID the ID of the annotation to be removed; must not be null
+   * @return true if the annotation was successfully removed, otherwise false
+   */
+  public boolean removeAnnotation(@Nonnull String annotationID) {
+    Objects.requireNonNull(annotationID, "annotationID must not be null");
     if (this.annotations == null) {
       return false;
     }

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedContainmentValue.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedContainmentValue.java
@@ -30,6 +30,10 @@ public class SerializedContainmentValue {
     this.value.addAll(value);
   }
 
+  public boolean removeChild(String child) {
+    return value.remove(child);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedContainmentValue.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedContainmentValue.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 
 /** This represents the serialization of the values of a containment link in a Node. */
 public class SerializedContainmentValue {
@@ -30,7 +31,15 @@ public class SerializedContainmentValue {
     this.value.addAll(value);
   }
 
-  public boolean removeChild(String child) {
+  /**
+   * Removes a child from the list of Node-IDs contained.
+   *
+   * @param child the identifier of the child to be removed; must not be null
+   * @return true if the child was successfully removed, false otherwise
+   * @throws NullPointerException if the child is null
+   */
+  public boolean removeChild(@Nonnull String child) {
+    Objects.requireNonNull(child, "child must not be null");
     return value.remove(child);
   }
 

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedContainmentValue.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedContainmentValue.java
@@ -32,15 +32,15 @@ public class SerializedContainmentValue {
   }
 
   /**
-   * Removes a child from the list of Node-IDs contained.
+   * Removes a childId from the list of Node-IDs contained.
    *
-   * @param child the identifier of the child to be removed; must not be null
-   * @return true if the child was successfully removed, false otherwise
-   * @throws NullPointerException if the child is null
+   * @param childId the identifier of the childId to be removed; must not be null
+   * @return true if the childId was successfully removed, false otherwise
+   * @throws NullPointerException if the childId is null
    */
-  public boolean removeChild(@Nonnull String child) {
-    Objects.requireNonNull(child, "child must not be null");
-    return value.remove(child);
+  public boolean removeChild(@Nonnull String childId) {
+    Objects.requireNonNull(childId, "childId must not be null");
+    return value.remove(childId);
   }
 
   @Override

--- a/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
+++ b/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
@@ -27,6 +27,8 @@ public class SerializedClassifierInstanceTest {
     assertTrue(sci.getReferences().isEmpty());
     assertTrue(sci.getAnnotations().isEmpty());
 
+    // Adding a feature’s value is possible, just not through directly manipulating the immutable list.
+    // One should use the specific add methods instead
     assertThrows(
         UnsupportedOperationException.class,
         () -> sci.getProperties().add(SerializedPropertyValue.get(simpleMetaPointer("foo"), "a")));

--- a/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
+++ b/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
@@ -219,7 +219,8 @@ public class SerializedClassifierInstanceTest {
 
   @Test
   public void toStringContainsKeyInfo() {
-    SerializedClassifierInstance sci = new SerializedClassifierInstance("idX", simpleMetaPointer("C"));
+    SerializedClassifierInstance sci =
+        new SerializedClassifierInstance("idX", simpleMetaPointer("C"));
     sci.setParentNodeID("pY");
     String s = sci.toString();
     assertNotNull(s);

--- a/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
+++ b/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 public class SerializedClassifierInstanceTest {
 
-  private static MetaPointer mp(String key) {
+  private static MetaPointer simpleMetaPointer(String key) {
     return MetaPointer.get("L", "1", key);
   }
 
@@ -36,7 +36,7 @@ public class SerializedClassifierInstanceTest {
 
   @Test
   public void constructorSetsIdAndClassifier() {
-    MetaPointer classifier = mp("C");
+    MetaPointer classifier = simpleMetaPointer("C");
     SerializedClassifierInstance sci = new SerializedClassifierInstance("n1", classifier);
 
     assertEquals("n1", sci.getID());
@@ -46,7 +46,7 @@ public class SerializedClassifierInstanceTest {
   @Test
   public void idClassifierParentSettersGetters() {
     SerializedClassifierInstance sci = new SerializedClassifierInstance();
-    MetaPointer classifier = mp("C");
+    MetaPointer classifier = simpleMetaPointer("C");
 
     sci.setID("id-123");
     sci.setClassifier(classifier);
@@ -60,8 +60,8 @@ public class SerializedClassifierInstanceTest {
   @Test
   public void propertiesAddAndGetByKeyAndMeta() {
     SerializedClassifierInstance sci = new SerializedClassifierInstance();
-    MetaPointer pA = mp("propA");
-    MetaPointer pB = mp("propB");
+    MetaPointer pA = simpleMetaPointer("propA");
+    MetaPointer pB = simpleMetaPointer("propB");
 
     sci.addPropertyValue(SerializedPropertyValue.get(pA, "VA"));
     sci.setPropertyValue(pB, "VB"); // via convenience
@@ -73,14 +73,14 @@ public class SerializedClassifierInstanceTest {
 
     assertEquals("VA", sci.getPropertyValue(pA));
     assertEquals("VB", sci.getPropertyValue(pB));
-    assertNull(sci.getPropertyValue(mp("other")));
+    assertNull(sci.getPropertyValue(simpleMetaPointer("other")));
   }
 
   @Test
   public void containmentsAddChildrenGetChildrenAndClear() {
     SerializedClassifierInstance sci = new SerializedClassifierInstance();
-    MetaPointer contA = mp("contA");
-    MetaPointer contB = mp("contB");
+    MetaPointer contA = simpleMetaPointer("contA");
+    MetaPointer contB = simpleMetaPointer("contB");
 
     sci.addChildren(contA, Arrays.asList("c1", "c2"));
     sci.addChildren(contB, Collections.singletonList("c3"));
@@ -99,7 +99,7 @@ public class SerializedClassifierInstanceTest {
   @Test
   public void addChildAppendsOrCreatesEntry() {
     SerializedClassifierInstance sci = new SerializedClassifierInstance();
-    MetaPointer cont = mp("cont");
+    MetaPointer cont = simpleMetaPointer("cont");
 
     // When containment absent, addChild creates it
     sci.addChild(cont, "x1");
@@ -113,8 +113,8 @@ public class SerializedClassifierInstanceTest {
   @Test
   public void removeContainmentValueByMeta() {
     SerializedClassifierInstance sci = new SerializedClassifierInstance();
-    MetaPointer cont = mp("cont");
-    MetaPointer other = mp("other");
+    MetaPointer cont = simpleMetaPointer("cont");
+    MetaPointer other = simpleMetaPointer("other");
     sci.addChildren(cont, Arrays.asList("a", "b"));
 
     assertFalse(sci.removeContainmentValue(other));
@@ -125,8 +125,8 @@ public class SerializedClassifierInstanceTest {
   @Test
   public void removeChildRemovesFromAnyContainment() {
     SerializedClassifierInstance sci = new SerializedClassifierInstance();
-    MetaPointer c1 = mp("c1");
-    MetaPointer c2 = mp("c2");
+    MetaPointer c1 = simpleMetaPointer("c1");
+    MetaPointer c2 = simpleMetaPointer("c2");
     sci.addChildren(c1, Arrays.asList("a1", "a2"));
     sci.addChildren(c2, Arrays.asList("b1", "b2"));
 
@@ -140,8 +140,8 @@ public class SerializedClassifierInstanceTest {
   @Test
   public void referencesAddAndGet() {
     SerializedClassifierInstance sci = new SerializedClassifierInstance();
-    MetaPointer r1 = mp("ref1");
-    MetaPointer r2 = mp("ref2");
+    MetaPointer r1 = simpleMetaPointer("ref1");
+    MetaPointer r2 = simpleMetaPointer("ref2");
 
     SerializedReferenceValue.Entry e11 = new SerializedReferenceValue.Entry("RID-1", "RI-1");
     SerializedReferenceValue.Entry e12 = new SerializedReferenceValue.Entry("RID-2", "RI-2");
@@ -162,7 +162,7 @@ public class SerializedClassifierInstanceTest {
     assertEquals(Collections.singletonList(e21), r2ValsByMP);
 
     assertNull(sci.getReferenceValues("unknown"));
-    assertTrue(sci.getReferenceValues(mp("unknown")).isEmpty());
+    assertTrue(sci.getReferenceValues(simpleMetaPointer("unknown")).isEmpty());
 
     // Unmodifiable
     assertThrows(UnsupportedOperationException.class, () -> r1ValsByKey.add(e21));
@@ -189,10 +189,10 @@ public class SerializedClassifierInstanceTest {
 
   @Test
   public void equalsAndHashCodeConsiderAllFields() {
-    MetaPointer classifier = mp("C");
-    MetaPointer p = mp("prop");
-    MetaPointer cont = mp("cont");
-    MetaPointer ref = mp("ref");
+    MetaPointer classifier = simpleMetaPointer("C");
+    MetaPointer p = simpleMetaPointer("prop");
+    MetaPointer cont = simpleMetaPointer("cont");
+    MetaPointer ref = simpleMetaPointer("ref");
 
     SerializedClassifierInstance a = new SerializedClassifierInstance("id", classifier);
     a.setParentNodeID("parent");
@@ -219,7 +219,7 @@ public class SerializedClassifierInstanceTest {
 
   @Test
   public void toStringContainsKeyInfo() {
-    SerializedClassifierInstance sci = new SerializedClassifierInstance("idX", mp("C"));
+    SerializedClassifierInstance sci = new SerializedClassifierInstance("idX", simpleMetaPointer("C"));
     sci.setParentNodeID("pY");
     String s = sci.toString();
     assertNotNull(s);

--- a/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
+++ b/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
@@ -1,0 +1,230 @@
+package io.lionweb.serialization.data;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+public class SerializedClassifierInstanceTest {
+
+  private static MetaPointer mp(String key) {
+    return MetaPointer.get("L", "1", key);
+  }
+
+  @Test
+  public void defaultsAreEmptyAndUnmodifiable() {
+    SerializedClassifierInstance sci = new SerializedClassifierInstance();
+
+    assertNull(sci.getID());
+    assertNull(sci.getClassifier());
+    assertNull(sci.getParentNodeID());
+
+    assertTrue(sci.getProperties().isEmpty());
+    assertTrue(sci.getContainments().isEmpty());
+    assertTrue(sci.getChildren().isEmpty());
+    assertTrue(sci.getReferences().isEmpty());
+    assertTrue(sci.getAnnotations().isEmpty());
+
+    assertThrows(UnsupportedOperationException.class, () -> sci.getProperties().add(null));
+    assertThrows(UnsupportedOperationException.class, () -> sci.getContainments().add(null));
+    assertThrows(UnsupportedOperationException.class, () -> sci.getReferences().add(null));
+    assertThrows(UnsupportedOperationException.class, () -> sci.getAnnotations().add(null));
+    assertThrows(UnsupportedOperationException.class, () -> sci.getChildren().add("x"));
+  }
+
+  @Test
+  public void constructorSetsIdAndClassifier() {
+    MetaPointer classifier = mp("C");
+    SerializedClassifierInstance sci = new SerializedClassifierInstance("n1", classifier);
+
+    assertEquals("n1", sci.getID());
+    assertEquals(classifier, sci.getClassifier());
+  }
+
+  @Test
+  public void idClassifierParentSettersGetters() {
+    SerializedClassifierInstance sci = new SerializedClassifierInstance();
+    MetaPointer classifier = mp("C");
+
+    sci.setID("id-123");
+    sci.setClassifier(classifier);
+    sci.setParentNodeID("parent-1");
+
+    assertEquals("id-123", sci.getID());
+    assertEquals(classifier, sci.getClassifier());
+    assertEquals("parent-1", sci.getParentNodeID());
+  }
+
+  @Test
+  public void propertiesAddAndGetByKeyAndMeta() {
+    SerializedClassifierInstance sci = new SerializedClassifierInstance();
+    MetaPointer pA = mp("propA");
+    MetaPointer pB = mp("propB");
+
+    sci.addPropertyValue(SerializedPropertyValue.get(pA, "VA"));
+    sci.setPropertyValue(pB, "VB"); // via convenience
+
+    assertEquals(2, sci.getProperties().size());
+    assertEquals("VA", sci.getPropertyValue("propA"));
+    assertEquals("VB", sci.getPropertyValue("propB"));
+    assertNull(sci.getPropertyValue("nope"));
+
+    assertEquals("VA", sci.getPropertyValue(pA));
+    assertEquals("VB", sci.getPropertyValue(pB));
+    assertNull(sci.getPropertyValue(mp("other")));
+  }
+
+  @Test
+  public void containmentsAddChildrenGetChildrenAndClear() {
+    SerializedClassifierInstance sci = new SerializedClassifierInstance();
+    MetaPointer contA = mp("contA");
+    MetaPointer contB = mp("contB");
+
+    sci.addChildren(contA, Arrays.asList("c1", "c2"));
+    sci.addChildren(contB, Collections.singletonList("c3"));
+
+    assertEquals(2, sci.getContainments().size());
+    assertEquals(Arrays.asList("c1", "c2"), sci.getContainmentValues(contA));
+    assertEquals(Collections.singletonList("c3"), sci.getContainmentValues(contB));
+    assertEquals(Arrays.asList("c1", "c2", "c3"), sci.getChildren());
+
+    sci.clearContainments();
+    assertTrue(sci.getContainments().isEmpty());
+    assertTrue(sci.getChildren().isEmpty());
+    assertTrue(sci.getContainmentValues(contA).isEmpty());
+  }
+
+  @Test
+  public void addChildAppendsOrCreatesEntry() {
+    SerializedClassifierInstance sci = new SerializedClassifierInstance();
+    MetaPointer cont = mp("cont");
+
+    // When containment absent, addChild creates it
+    sci.addChild(cont, "x1");
+    assertEquals(Collections.singletonList("x1"), sci.getContainmentValues(cont));
+
+    // When containment present, addChild appends
+    sci.addChild(cont, "x2");
+    assertEquals(Arrays.asList("x1", "x2"), sci.getContainmentValues(cont));
+  }
+
+  @Test
+  public void removeContainmentValueByMeta() {
+    SerializedClassifierInstance sci = new SerializedClassifierInstance();
+    MetaPointer cont = mp("cont");
+    MetaPointer other = mp("other");
+    sci.addChildren(cont, Arrays.asList("a", "b"));
+
+    assertFalse(sci.removeContainmentValue(other));
+    assertTrue(sci.removeContainmentValue(cont));
+    assertTrue(sci.getContainments().isEmpty());
+  }
+
+  @Test
+  public void removeChildRemovesFromAnyContainment() {
+    SerializedClassifierInstance sci = new SerializedClassifierInstance();
+    MetaPointer c1 = mp("c1");
+    MetaPointer c2 = mp("c2");
+    sci.addChildren(c1, Arrays.asList("a1", "a2"));
+    sci.addChildren(c2, Arrays.asList("b1", "b2"));
+
+    assertTrue(sci.removeChild("a2"));
+    assertEquals(Collections.singletonList("a1"), sci.getContainmentValues(c1));
+    assertEquals(Arrays.asList("b1", "b2"), sci.getContainmentValues(c2));
+
+    assertFalse(sci.removeChild("nope"));
+  }
+
+  @Test
+  public void referencesAddAndGet() {
+    SerializedClassifierInstance sci = new SerializedClassifierInstance();
+    MetaPointer r1 = mp("ref1");
+    MetaPointer r2 = mp("ref2");
+
+    SerializedReferenceValue.Entry e11 = new SerializedReferenceValue.Entry("RID-1", "RI-1");
+    SerializedReferenceValue.Entry e12 = new SerializedReferenceValue.Entry("RID-2", "RI-2");
+    SerializedReferenceValue.Entry e21 = new SerializedReferenceValue.Entry("RID-3", "RI-3");
+
+    // Add via value list
+    sci.addReferenceValue(r1, Arrays.asList(e11));
+    // Add via entry (append)
+    sci.addReferenceValue(r1, e12);
+    // Add via object
+    sci.addReferenceValue(new SerializedReferenceValue(r2, Collections.singletonList(e21)));
+
+    List<SerializedReferenceValue.Entry> r1ValsByKey = sci.getReferenceValues("ref1");
+    assertNotNull(r1ValsByKey);
+    assertEquals(Arrays.asList(e11, e12), r1ValsByKey);
+
+    List<SerializedReferenceValue.Entry> r2ValsByMP = sci.getReferenceValues(r2);
+    assertEquals(Collections.singletonList(e21), r2ValsByMP);
+
+    assertNull(sci.getReferenceValues("unknown"));
+    assertTrue(sci.getReferenceValues(mp("unknown")).isEmpty());
+
+    // Unmodifiable
+    assertThrows(UnsupportedOperationException.class, () -> r1ValsByKey.add(e21));
+  }
+
+  @Test
+  public void annotationsSetAddRemoveGet() {
+    SerializedClassifierInstance sci = new SerializedClassifierInstance();
+
+    sci.setAnnotations(Arrays.asList("a1", "a2"));
+    assertEquals(Arrays.asList("a1", "a2"), sci.getAnnotations());
+
+    sci.addAnnotation("a3");
+    assertEquals(Arrays.asList("a1", "a2", "a3"), sci.getAnnotations());
+
+    assertTrue(sci.removeAnnotation("a2"));
+    assertEquals(Arrays.asList("a1", "a3"), sci.getAnnotations());
+
+    assertFalse(sci.removeAnnotation("nope"));
+
+    // Unmodifiable
+    assertThrows(UnsupportedOperationException.class, () -> sci.getAnnotations().add("x"));
+  }
+
+  @Test
+  public void equalsAndHashCodeConsiderAllFields() {
+    MetaPointer classifier = mp("C");
+    MetaPointer p = mp("prop");
+    MetaPointer cont = mp("cont");
+    MetaPointer ref = mp("ref");
+
+    SerializedClassifierInstance a = new SerializedClassifierInstance("id", classifier);
+    a.setParentNodeID("parent");
+    a.setPropertyValue(p, "V");
+    a.addChildren(cont, Arrays.asList("c1", "c2"));
+    a.addReferenceValue(
+        ref, Collections.singletonList(new SerializedReferenceValue.Entry("RID", "RI")));
+    a.setAnnotations(Arrays.asList("an1", "an2"));
+
+    SerializedClassifierInstance b = new SerializedClassifierInstance("id", classifier);
+    b.setParentNodeID("parent");
+    b.setPropertyValue(p, "V");
+    b.addChildren(cont, Arrays.asList("c1", "c2"));
+    b.addReferenceValue(
+        ref, Collections.singletonList(new SerializedReferenceValue.Entry("RID", "RI")));
+    b.setAnnotations(Arrays.asList("an1", "an2"));
+
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+
+    b.addAnnotation("diff");
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void toStringContainsKeyInfo() {
+    SerializedClassifierInstance sci = new SerializedClassifierInstance("idX", mp("C"));
+    sci.setParentNodeID("pY");
+    String s = sci.toString();
+    assertNotNull(s);
+    assertTrue(s.contains("id"));
+    assertTrue(s.contains("classifier"));
+    assertTrue(s.contains("parentNodeID"));
+  }
+}

--- a/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
+++ b/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
@@ -27,7 +27,8 @@ public class SerializedClassifierInstanceTest {
     assertTrue(sci.getReferences().isEmpty());
     assertTrue(sci.getAnnotations().isEmpty());
 
-    // Adding a feature’s value is possible, just not through directly manipulating the immutable list.
+    // Adding a feature’s value is possible, just not through directly manipulating the immutable
+    // list.
     // One should use the specific add methods instead
     assertThrows(
         UnsupportedOperationException.class,

--- a/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
+++ b/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
@@ -27,10 +27,25 @@ public class SerializedClassifierInstanceTest {
     assertTrue(sci.getReferences().isEmpty());
     assertTrue(sci.getAnnotations().isEmpty());
 
-    assertThrows(UnsupportedOperationException.class, () -> sci.getProperties().add(null));
-    assertThrows(UnsupportedOperationException.class, () -> sci.getContainments().add(null));
-    assertThrows(UnsupportedOperationException.class, () -> sci.getReferences().add(null));
-    assertThrows(UnsupportedOperationException.class, () -> sci.getAnnotations().add(null));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> sci.getProperties().add(SerializedPropertyValue.get(simpleMetaPointer("foo"), "a")));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            sci.getContainments()
+                .add(
+                    new SerializedContainmentValue(
+                        simpleMetaPointer("bar"), Collections.singletonList("child1"))));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            sci.getReferences()
+                .add(
+                    new SerializedReferenceValue(
+                        simpleMetaPointer("zum"),
+                        Arrays.asList(new SerializedReferenceValue.Entry("a", "b")))));
+    assertThrows(UnsupportedOperationException.class, () -> sci.getAnnotations().add("ann-1"));
     assertThrows(UnsupportedOperationException.class, () -> sci.getChildren().add("x"));
   }
 

--- a/core/src/test/java/io/lionweb/serialization/data/SerializedContainmentValueTest.java
+++ b/core/src/test/java/io/lionweb/serialization/data/SerializedContainmentValueTest.java
@@ -50,7 +50,8 @@ public class SerializedContainmentValueTest {
   @Test
   public void removeChildRemovesAndReturnsFlag() {
     SerializedContainmentValue scv =
-        new SerializedContainmentValue(simpleMetaPointer("cont"), new ArrayList<>(Arrays.asList("a", "b", "c")));
+        new SerializedContainmentValue(
+            simpleMetaPointer("cont"), new ArrayList<>(Arrays.asList("a", "b", "c")));
 
     assertTrue(scv.removeChild("b"));
     assertEquals(Arrays.asList("a", "c"), scv.getValue());
@@ -62,7 +63,8 @@ public class SerializedContainmentValueTest {
   @Test
   public void removeChildRemovesOnlyOneOccurrence() {
     SerializedContainmentValue scv =
-        new SerializedContainmentValue(simpleMetaPointer("cont"), new ArrayList<>(Arrays.asList("x", "y", "y")));
+        new SerializedContainmentValue(
+            simpleMetaPointer("cont"), new ArrayList<>(Arrays.asList("x", "y", "y")));
 
     assertTrue(scv.removeChild("y"));
     assertEquals(Arrays.asList("x", "y"), scv.getValue());

--- a/core/src/test/java/io/lionweb/serialization/data/SerializedContainmentValueTest.java
+++ b/core/src/test/java/io/lionweb/serialization/data/SerializedContainmentValueTest.java
@@ -1,0 +1,97 @@
+package io.lionweb.serialization.data;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+public class SerializedContainmentValueTest {
+
+  private static MetaPointer mp(String key) {
+    return MetaPointer.get("L", "1", key);
+  }
+
+  @Test
+  public void constructorCopiesInputListAndExposesUnmodifiableView() {
+    MetaPointer c = mp("cont");
+    ArrayList<String> input = new ArrayList<>(Arrays.asList("a", "b"));
+    SerializedContainmentValue scv = new SerializedContainmentValue(c, input);
+
+    // Defensive copy in constructor
+    input.add("c");
+    assertEquals(Arrays.asList("a", "b"), scv.getValue());
+
+    // Unmodifiable view
+    assertThrows(UnsupportedOperationException.class, () -> scv.getValue().add("x"));
+  }
+
+  @Test
+  public void gettersReturnExpectedValues() {
+    MetaPointer c = mp("contX");
+    SerializedContainmentValue scv = new SerializedContainmentValue(c, Arrays.asList("n1", "n2"));
+
+    assertSame(c, scv.getMetaPointer());
+    assertEquals(Arrays.asList("n1", "n2"), scv.getValue());
+  }
+
+  @Test
+  public void setValueReplacesContentAndIsExposedUnmodifiable() {
+    SerializedContainmentValue scv =
+        new SerializedContainmentValue(mp("cont"), Arrays.asList("a", "b"));
+
+    scv.setValue(Arrays.asList("x", "y", "z"));
+    assertEquals(Arrays.asList("x", "y", "z"), scv.getValue());
+
+    assertThrows(UnsupportedOperationException.class, () -> scv.getValue().remove("x"));
+  }
+
+  @Test
+  public void removeChildRemovesAndReturnsFlag() {
+    SerializedContainmentValue scv =
+        new SerializedContainmentValue(mp("cont"), new ArrayList<>(Arrays.asList("a", "b", "c")));
+
+    assertTrue(scv.removeChild("b"));
+    assertEquals(Arrays.asList("a", "c"), scv.getValue());
+
+    assertFalse(scv.removeChild("missing"));
+    assertEquals(Arrays.asList("a", "c"), scv.getValue());
+  }
+
+  @Test
+  public void removeChildRemovesOnlyOneOccurrence() {
+    SerializedContainmentValue scv =
+        new SerializedContainmentValue(mp("cont"), new ArrayList<>(Arrays.asList("x", "y", "y")));
+
+    assertTrue(scv.removeChild("y"));
+    assertEquals(Arrays.asList("x", "y"), scv.getValue());
+  }
+
+  @Test
+  public void equalsAndHashCodeDependOnMetaPointerAndValue() {
+    MetaPointer c1 = mp("cont");
+    MetaPointer c2 = mp("cont2");
+    SerializedContainmentValue a = new SerializedContainmentValue(c1, Arrays.asList("n1", "n2"));
+    SerializedContainmentValue b = new SerializedContainmentValue(c1, Arrays.asList("n1", "n2"));
+    SerializedContainmentValue c =
+        new SerializedContainmentValue(c1, Collections.singletonList("n1"));
+    SerializedContainmentValue d = new SerializedContainmentValue(c2, Arrays.asList("n1", "n2"));
+
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+
+    assertNotEquals(a, c);
+    assertNotEquals(a, d);
+  }
+
+  @Test
+  public void toStringContainsKeyInfo() {
+    SerializedContainmentValue scv =
+        new SerializedContainmentValue(mp("cont"), Arrays.asList("a", "b"));
+    String s = scv.toString();
+    assertNotNull(s);
+    assertTrue(s.contains("metaPointer"));
+    assertTrue(s.contains("value"));
+  }
+}

--- a/core/src/test/java/io/lionweb/serialization/data/SerializedContainmentValueTest.java
+++ b/core/src/test/java/io/lionweb/serialization/data/SerializedContainmentValueTest.java
@@ -9,13 +9,13 @@ import org.junit.Test;
 
 public class SerializedContainmentValueTest {
 
-  private static MetaPointer mp(String key) {
+  private static MetaPointer simpleMetaPointer(String key) {
     return MetaPointer.get("L", "1", key);
   }
 
   @Test
   public void constructorCopiesInputListAndExposesUnmodifiableView() {
-    MetaPointer c = mp("cont");
+    MetaPointer c = simpleMetaPointer("cont");
     ArrayList<String> input = new ArrayList<>(Arrays.asList("a", "b"));
     SerializedContainmentValue scv = new SerializedContainmentValue(c, input);
 
@@ -29,7 +29,7 @@ public class SerializedContainmentValueTest {
 
   @Test
   public void gettersReturnExpectedValues() {
-    MetaPointer c = mp("contX");
+    MetaPointer c = simpleMetaPointer("contX");
     SerializedContainmentValue scv = new SerializedContainmentValue(c, Arrays.asList("n1", "n2"));
 
     assertSame(c, scv.getMetaPointer());
@@ -39,7 +39,7 @@ public class SerializedContainmentValueTest {
   @Test
   public void setValueReplacesContentAndIsExposedUnmodifiable() {
     SerializedContainmentValue scv =
-        new SerializedContainmentValue(mp("cont"), Arrays.asList("a", "b"));
+        new SerializedContainmentValue(simpleMetaPointer("cont"), Arrays.asList("a", "b"));
 
     scv.setValue(Arrays.asList("x", "y", "z"));
     assertEquals(Arrays.asList("x", "y", "z"), scv.getValue());
@@ -50,7 +50,7 @@ public class SerializedContainmentValueTest {
   @Test
   public void removeChildRemovesAndReturnsFlag() {
     SerializedContainmentValue scv =
-        new SerializedContainmentValue(mp("cont"), new ArrayList<>(Arrays.asList("a", "b", "c")));
+        new SerializedContainmentValue(simpleMetaPointer("cont"), new ArrayList<>(Arrays.asList("a", "b", "c")));
 
     assertTrue(scv.removeChild("b"));
     assertEquals(Arrays.asList("a", "c"), scv.getValue());
@@ -62,7 +62,7 @@ public class SerializedContainmentValueTest {
   @Test
   public void removeChildRemovesOnlyOneOccurrence() {
     SerializedContainmentValue scv =
-        new SerializedContainmentValue(mp("cont"), new ArrayList<>(Arrays.asList("x", "y", "y")));
+        new SerializedContainmentValue(simpleMetaPointer("cont"), new ArrayList<>(Arrays.asList("x", "y", "y")));
 
     assertTrue(scv.removeChild("y"));
     assertEquals(Arrays.asList("x", "y"), scv.getValue());
@@ -70,8 +70,8 @@ public class SerializedContainmentValueTest {
 
   @Test
   public void equalsAndHashCodeDependOnMetaPointerAndValue() {
-    MetaPointer c1 = mp("cont");
-    MetaPointer c2 = mp("cont2");
+    MetaPointer c1 = simpleMetaPointer("cont");
+    MetaPointer c2 = simpleMetaPointer("cont2");
     SerializedContainmentValue a = new SerializedContainmentValue(c1, Arrays.asList("n1", "n2"));
     SerializedContainmentValue b = new SerializedContainmentValue(c1, Arrays.asList("n1", "n2"));
     SerializedContainmentValue c =
@@ -88,7 +88,7 @@ public class SerializedContainmentValueTest {
   @Test
   public void toStringContainsKeyInfo() {
     SerializedContainmentValue scv =
-        new SerializedContainmentValue(mp("cont"), Arrays.asList("a", "b"));
+        new SerializedContainmentValue(simpleMetaPointer("cont"), Arrays.asList("a", "b"));
     String s = scv.toString();
     assertNotNull(s);
     assertTrue(s.contains("metaPointer"));


### PR DESCRIPTION
In LionWebClient we were not forwarding a couple of calls to the underlying `chunkLevelBulkAPIs` element.

Also, added a few methods in `SerializedClassifierInstance` and `SerializedContainmentValue`, with some tests.