### PR TITLE
SerializationChunk and duplicate features

### DIFF
--- a/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
@@ -334,7 +334,7 @@ public abstract class AbstractSerialization {
                           property, ((LanguageEntity<?>) property.getContainer()).getLanguage()),
                       serializePropertyValue(
                           property.getType(), classifierInstance.getPropertyValue(property)));
-              serializedClassifierInstance.addPropertyValue(propertyValue);
+              serializedClassifierInstance.unsafeAddPropertyValue(propertyValue);
             });
   }
 

--- a/core/src/main/java/io/lionweb/serialization/LowLevelJsonSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/LowLevelJsonSerialization.java
@@ -269,7 +269,7 @@ public class LowLevelJsonSerialization {
       properties.forEach(
           property -> {
             JsonObject propertyJO = property.getAsJsonObject();
-            serializedClassifierInstance.addPropertyValue(
+            serializedClassifierInstance.unsafeAddPropertyValue(
                 SerializedPropertyValue.get(
                     SerializationUtils.tryToGetMetaPointerProperty(propertyJO, "property"),
                     SerializationUtils.tryToGetStringProperty(propertyJO, "value")));

--- a/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
@@ -110,7 +110,7 @@ public class ProtoBufSerialization extends AbstractSerialization {
                             SerializedPropertyValue.get(
                                 metapointersArray[p.getMpiMetaPointer()],
                                 stringsArray[p.getSiValue()]);
-                        sci.addPropertyValue(spv);
+                        sci.unsafeAddPropertyValue(spv);
                       });
               n.getContainmentsList()
                   .forEach(

--- a/core/src/main/java/io/lionweb/serialization/data/SerializedClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/serialization/data/SerializedClassifierInstance.java
@@ -86,7 +86,25 @@ public class SerializedClassifierInstance {
     return Collections.unmodifiableList(properties);
   }
 
-  public void addPropertyValue(SerializedPropertyValue propertyValue) {
+  /**
+   * WARNING: this will always add the property, even if one entry with the same metapointer already
+   * exists.
+   *
+   * <p>It is however slightly faster than the (safer) setPropertyValue.
+   */
+  public void unsafeAddPropertyValue(SerializedPropertyValue propertyValue) {
+    this.properties.add(propertyValue);
+  }
+
+  public void setPropertyValue(SerializedPropertyValue propertyValue) {
+    for (int i = 0; i < this.properties.size(); i++) {
+      SerializedPropertyValue property = this.properties.get(i);
+      if (property.getMetaPointer() != null
+          && property.getMetaPointer().equals(propertyValue.getValue())) {
+        this.properties.set(i, propertyValue);
+        return;
+      }
+    }
     this.properties.add(propertyValue);
   }
 

--- a/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
+++ b/core/src/test/java/io/lionweb/serialization/data/SerializedClassifierInstanceTest.java
@@ -81,7 +81,7 @@ public class SerializedClassifierInstanceTest {
     MetaPointer pA = simpleMetaPointer("propA");
     MetaPointer pB = simpleMetaPointer("propB");
 
-    sci.addPropertyValue(SerializedPropertyValue.get(pA, "VA"));
+    sci.unsafeAddPropertyValue(SerializedPropertyValue.get(pA, "VA"));
     sci.setPropertyValue(pB, "VB"); // via convenience
 
     assertEquals(2, sci.getProperties().size());

--- a/core/src/test/java/io/lionweb/utils/ChunkValidatorTest.java
+++ b/core/src/test/java/io/lionweb/utils/ChunkValidatorTest.java
@@ -225,7 +225,7 @@ public class ChunkValidatorTest {
     // Add property with different language
     SerializedPropertyValue property =
         SerializedPropertyValue.get(MetaPointer.get("prop-lang", "1.0", "TestProp"), "test value");
-    node.addPropertyValue(property);
+    node.unsafeAddPropertyValue(property);
 
     // Add reference with different language
     SerializedReferenceValue reference =


### PR DESCRIPTION
We make a safe method to add a property value to a SerializedClassifierInstance avoid duplication (fix #263 )

We add a chunk for validating chunks against duplicated features (fix #262 )