### PR TITLE
Fix issue with adding children to annotations

### DIFF
--- a/core/src/main/java/io/lionweb/language/Annotation.java
+++ b/core/src/main/java/io/lionweb/language/Annotation.java
@@ -91,12 +91,22 @@ public class Annotation extends Classifier<Annotation> {
     }
   }
 
-  public void setAnnotates(@Nullable Classifier<?> target) {
+  /**
+   * Sets the "annotates" reference of this Annotation to the specified target Classifier. If the
+   * target is null, the reference will also be set to null. Otherwise, it will be set to a new
+   * {@link ReferenceValue} containing the target and its name.
+   *
+   * @param target the Classifier to set as the target of the "annotates" reference, or null to
+   *     clear it
+   * @return this Annotation instance, allowing for method chaining
+   */
+  public Annotation setAnnotates(@Nullable Classifier<?> target) {
     if (target == null) {
       this.setReferenceSingleValue("annotates", null);
     } else {
       this.setReferenceSingleValue("annotates", new ReferenceValue(target, target.getName()));
     }
+    return this;
   }
 
   @Nonnull

--- a/core/src/main/java/io/lionweb/language/Classifier.java
+++ b/core/src/main/java/io/lionweb/language/Classifier.java
@@ -129,6 +129,32 @@ public abstract class Classifier<T extends M3Node> extends LanguageEntity<T>
     return (T) this;
   }
 
+  /**
+   * Adds a containment feature to the classifier with the specified name, type, and multiplicity.
+   *
+   * @param name the name of the containment feature to add; must not be null
+   * @param type the type of the containment feature to add; must not be null
+   * @param multiplicity the multiplicity of the containment feature to add, determining whether it
+   *     is optional and/or allows multiple values; must not be null
+   * @return the current instance of the classifier, allowing method chaining
+   */
+  public T addContainment(
+      @Nonnull String name, @Nonnull Classifier<?> type, @Nonnull Multiplicity multiplicity) {
+    Objects.requireNonNull(name, "name should not be null");
+    Objects.requireNonNull(type, "type should not be null");
+    Objects.requireNonNull(multiplicity, "multiplicity should not be null");
+    Containment containment = new Containment(this.getLionWebVersion(), name);
+    containment.setType(type);
+    containment.setOptional(multiplicity.isOptional());
+    containment.setMultiple(multiplicity.isMultiple());
+    addFeature(containment);
+    return (T) this;
+  }
+
+  public T addContainment(@Nonnull String name, @Nonnull Classifier<?> type) {
+    return addContainment(name, type, Multiplicity.REQUIRED);
+  }
+
   public void removeFeature(@Nonnull Feature<?> feature) {
     Objects.requireNonNull(feature, "feature should not be null");
     if (!getFeatures().contains(feature)) {

--- a/core/src/main/java/io/lionweb/language/Multiplicity.java
+++ b/core/src/main/java/io/lionweb/language/Multiplicity.java
@@ -1,0 +1,43 @@
+package io.lionweb.language;
+
+/**
+ * Represents the multiplicity of a feature.
+ *
+ * <p>The {@code Multiplicity} enum includes the following constants: - {@code OPTIONAL}: Indicates
+ * an optional relationship or property that is not required and does not allow multiple instances
+ * (i.e., values accepted 0..1). - {@code REQUIRED}: Represents a required, non-optional property or
+ * relationship that does not allow multiple instances (i.e., values accepted 1..1). - {@code
+ * ZERO_OR_MORE}: Allows zero or more instances, making it optional and allowing multiple instances
+ * (i.e., values accepted 0..*). This is not a valid value for properties. - {@code ONE_OR_MORE}:
+ * Specifies that at least one instance is required, but multiple instances are also allowed (i.e.,
+ * values accepted 1..*). This is not a valid value for properties.
+ *
+ * <p>Each {@code Multiplicity} constant is defined by two attributes: - {@code optional}: Boolean
+ * indicating whether the relationship or property is optional. - {@code multiple}: Boolean
+ * indicating whether multiple instances are allowed.
+ *
+ * <p>This enumeration provides methods to access these attributes: - {@link #isOptional()} to check
+ * if the multiplicity is optional. - {@link #isMultiple()} to check if the multiplicity allows
+ * multiple instances.
+ */
+public enum Multiplicity {
+  OPTIONAL(true, false),
+  REQUIRED(false, false),
+  ZERO_OR_MORE(true, true),
+  ONE_OR_MORE(false, true);
+  private boolean optional;
+  private boolean multiple;
+
+  Multiplicity(boolean optional, boolean multiple) {
+    this.optional = optional;
+    this.multiple = multiple;
+  }
+
+  public boolean isOptional() {
+    return optional;
+  }
+
+  public boolean isMultiple() {
+    return multiple;
+  }
+}

--- a/core/src/main/java/io/lionweb/model/ClassifierInstanceUtils.java
+++ b/core/src/main/java/io/lionweb/model/ClassifierInstanceUtils.java
@@ -246,12 +246,32 @@ public class ClassifierInstanceUtils {
     }
   }
 
+  /**
+   * Adds a child node to the specified {@link ClassifierInstance} under a containment defined by
+   * the given containment name.
+   *
+   * @param _this the {@link ClassifierInstance} to which the child node will be added. Must not be
+   *     null.
+   * @param containmentName the name of the containment under which the child will be added. Must
+   *     not be null.
+   * @param child the {@link Node} instance to be added as a child. Must not be null.
+   * @throws NullPointerException if any of the parameters is null.
+   * @throws IllegalArgumentException if the specified containment name is not found in the
+   *     classifier.
+   */
   public static void addChild(
       @Nonnull ClassifierInstance<?> _this, @Nonnull String containmentName, @Nonnull Node child) {
     Objects.requireNonNull(_this, "_this should not be null");
     Objects.requireNonNull(containmentName, "containmentName should not be null");
     Objects.requireNonNull(child, "child should not be null");
     Containment containment = _this.getClassifier().getContainmentByName(containmentName);
+    if (containment == null) {
+      throw new IllegalArgumentException(
+          "Concept "
+              + _this.getClassifier().qualifiedName()
+              + " does not contained a containment named "
+              + containmentName);
+    }
     _this.addChild(containment, child);
   }
 

--- a/core/src/main/java/io/lionweb/model/impl/DynamicClassifierInstance.java
+++ b/core/src/main/java/io/lionweb/model/impl/DynamicClassifierInstance.java
@@ -360,7 +360,7 @@ public abstract class DynamicClassifierInstance<T extends Classifier<T>>
       }
     } else {
       if (value instanceof HasSettableParent) {
-        ((HasSettableParent) value).setParent((Node) this);
+        ((HasSettableParent) value).setParent(this);
       }
       containmentValues.put(link.getKey(), new ArrayList(Arrays.asList(value)));
       if (partitionObserverCache != null) {

--- a/core/src/test/java/io/lionweb/model/impl/DynamicAnnotationTest.java
+++ b/core/src/test/java/io/lionweb/model/impl/DynamicAnnotationTest.java
@@ -2,6 +2,9 @@ package io.lionweb.model.impl;
 
 import static org.junit.Assert.*;
 
+import io.lionweb.language.*;
+import io.lionweb.language.assigners.CommonIDAssigners;
+import io.lionweb.language.assigners.CommonKeyAssigners;
 import io.lionweb.model.ClassifierInstanceUtils;
 import io.lionweb.model.Node;
 import io.lionweb.serialization.*;
@@ -20,5 +23,51 @@ public class DynamicAnnotationTest {
     Node retrievedValue1 =
         ClassifierInstanceUtils.getChildrenByContainmentName(myAnnotation, "values").get(0);
     assertEquals(123, ClassifierInstanceUtils.getPropertyValueByName(retrievedValue1, "amount"));
+  }
+
+  @Test
+  public void annotationDescendants() {
+    Language language = new Language("ALanguage");
+    Concept c1 = new Concept(language, "C1");
+    Concept c2 = new Concept(language, "C2");
+    Concept c3 = new Concept(language, "C3");
+    c2.addContainment("mySubC2", c2, Multiplicity.OPTIONAL);
+    Annotation a1 =
+        new Annotation(language, "A1")
+            .setAnnotates(c1)
+            .addContainment("myC2", c2, Multiplicity.ZERO_OR_MORE)
+            .addContainment("myC3", c3, Multiplicity.OPTIONAL);
+    CommonKeyAssigners.qualifiedKeyAssigner.assignKeys(language);
+    CommonIDAssigners.qualifiedIDAssigner.assignIDs(language);
+
+    DynamicNode n1 = new DynamicNode("n1", c1);
+    DynamicAnnotationInstance a1_1 = new DynamicAnnotationInstance("a1_1", a1);
+    a1_1.setAnnotated(n1);
+    DynamicNode n2 = new DynamicNode("n2", c2);
+    DynamicNode n3 = new DynamicNode("n3", c2);
+    ClassifierInstanceUtils.addChild(a1_1, "myC2", n2);
+    ClassifierInstanceUtils.addChild(a1_1, "myC2", n3);
+    DynamicNode n4 = new DynamicNode("n4", c2);
+    ClassifierInstanceUtils.addChild(n3, "mySubC2", n4);
+
+    DynamicNode n5 = new DynamicNode("n5", c3);
+    ClassifierInstanceUtils.addChild(a1_1, "myC3", n5);
+
+    assertEquals(n3, n4.getParent());
+    assertEquals(a1_1, n4.getParent().getParent());
+    assertEquals(n1, n4.getParent().getParent().getParent());
+
+    assertEquals(a1_1, n3.getParent());
+    assertEquals(n1, n3.getParent().getParent());
+
+    assertEquals(a1_1, n2.getParent());
+    assertEquals(n1, n2.getParent().getParent());
+
+    assertEquals(a1_1, n5.getParent());
+    assertEquals(n1, n5.getParent().getParent());
+
+    assertEquals(n1, a1_1.getParent());
+
+    assertNull(n1.getParent());
   }
 }


### PR DESCRIPTION
Previously there was an unnecessary cast to `Node` when setting the parent of a `Node`. This prevented from adding children to annotations.

Relevant for @gabriele-tomassetti